### PR TITLE
Fix hero task completion behavior

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -388,9 +388,7 @@ namespace TimelessEchoes.Hero
                 TELogger.Log($"Finished mining {miningTask.name}", this);
                 ai.canMove = true;
                 animator?.SetTrigger("StopMining");
-                taskController?.RemoveTask(miningTask);
                 miningTask.CompleteTask();
-                SetTask(null);
                 taskController?.SelectEarliestTask();
                 miningTask = null;
                 state = State.Idle;

--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -106,7 +106,6 @@ namespace TimelessEchoes.Tasks
                     }
                 }
 
-            Destroy(gameObject);
         }
     }
 }

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -244,7 +244,14 @@ namespace TimelessEchoes.Tasks
             {
                 taskObjects.Remove(obj);
                 taskMap.Remove(task);
+                if (obj != null)
+                    Destroy(obj.gameObject);
             }
+            else if (task is MonoBehaviour mb)
+            {
+                Destroy(mb.gameObject);
+            }
+
             if (index <= currentIndex)
                 currentIndex--;
         }


### PR DESCRIPTION
## Summary
- prevent `MiningTask` from destroying itself
- have `TaskController` destroy task gameobjects when removed
- simplify hero mining completion to just finish the task and request a new one

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bc8d7ed08832e80ccb00595750363