### PR TITLE
Fix mining resume after combat

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -325,9 +325,19 @@ namespace TimelessEchoes.Hero
 
         private void HandleCombat(Transform enemy)
         {
+            if (state == State.Mining)
+            {
+                ai.canMove = true;
+                animator?.SetTrigger("StopMining");
+                if (miningTask?.ProgressBar != null)
+                    miningTask.ProgressBar.gameObject.SetActive(false);
+                miningTask = null;
+            }
+
             if (state != State.Combat)
                 Log($"Hero entering combat with {enemy.name}", this);
             state = State.Combat;
+            ai.canMove = true;
             setter.target = enemy;
             if (!inCombat && diceRoller != null && !isRolling)
             {


### PR DESCRIPTION
## Summary
- ensure hero movement is re-enabled if mining is interrupted by combat
- cancel mining visuals and reset before engaging enemies

## Testing
- `git status --short`
- `git --no-pager log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685bd6b85624832eb42d7a029f7f4e95