### PR TITLE
Fix hero mining start after combat

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -208,7 +208,16 @@ namespace TimelessEchoes.Hero
             if (setter != null)
             {
                 setter.target = task != null ? task.Target : null;
-                ai?.SearchPath();
+                // Reset the AI path so reachedDestination isn't true
+                // before the new destination has been processed.
+                if (ai != null)
+                {
+                    ai.Teleport(transform.position); // Clears path and searches again
+                }
+                else
+                {
+                    ai?.SearchPath();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- reset AI path when assigning new tasks

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bd97bfa64832ea21e234026fa0cd8