### PR TITLE
Bugfix for dice roll when re-entering combat

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -271,6 +271,10 @@ namespace TimelessEchoes.Hero
             {
                 Log("Hero exiting combat", this);
                 combatDamageMultiplier = 1f;
+                // Stop any ongoing dice roll so a fresh roll occurs when
+                // combat is re-entered. The coroutine may be interrupted
+                // before it resets this flag, so clear it here.
+                isRolling = false;
                 diceRoller?.ResetRoll();
                 inCombat = false;
                 state = State.Idle;


### PR DESCRIPTION
## Summary
- clear isRolling state when leaving combat
- ensure new dice rolls occur after re-entering combat

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c7e357068832e824fe69150d40b83