### PR TITLE
Add resource drops for fishing tasks

### DIFF
--- a/Assets/Scripts/Tasks/FishingTask.cs
+++ b/Assets/Scripts/Tasks/FishingTask.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Blindsided.Utilities;
+using TimelessEchoes.Upgrades;
 using UnityEngine;
 
 namespace TimelessEchoes.Tasks
@@ -13,11 +15,14 @@ namespace TimelessEchoes.Tasks
         [SerializeField] private float fishTime = 2f;
         [SerializeField] private SlicedFilledImage progressBar;
         [SerializeField] private Transform fishingPoint;
+        [SerializeField] private List<ResourceDrop> resourceDrops = new();
 
         private bool complete;
+        private ResourceManager resourceManager;
 
         public float FishTime => fishTime;
         public SlicedFilledImage ProgressBar => progressBar;
+        public IList<ResourceDrop> Drops => resourceDrops;
 
         public override Transform Target => fishingPoint != null ? fishingPoint : transform;
 
@@ -26,6 +31,8 @@ namespace TimelessEchoes.Tasks
             complete = false;
             if (progressBar != null)
                 progressBar.fillAmount = 1f;
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
         }
 
         public override bool IsComplete()
@@ -39,6 +46,28 @@ namespace TimelessEchoes.Tasks
             complete = true;
             if (progressBar != null)
                 progressBar.gameObject.SetActive(false);
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
+            if (resourceManager != null)
+                foreach (var drop in resourceDrops)
+                {
+                    if (drop.resource == null) continue;
+                    if (Random.value > drop.dropChance) continue;
+
+                    var min = drop.dropRange.x;
+                    var max = drop.dropRange.y;
+                    if (max < min) max = min;
+                    var t = Random.value;
+                    t *= t;
+                    var count = Mathf.Clamp(Mathf.FloorToInt(Mathf.Lerp(min, max + 1, t)), min, max);
+                    if (count > 0)
+                    {
+                        resourceManager.Add(drop.resource, count);
+                        FloatingText.Spawn($"{drop.resource.name} x{count}",
+                            transform.position + Vector3.up,
+                            Color.blue);
+                    }
+                }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ objects for enemies and creates a `KillEnemyTask` for each one. Each task
 stores a direct reference to that enemy, and tasks are ordered by distance
 from the entry point to keep your hero on an efficient route.
 
+Mining and fishing tasks award resources when completed. Use these resources to
+upgrade your hero.
+
 ## Building
 Use **File > Build Settings...** to create standalone builds.
 


### PR DESCRIPTION
## Summary
- extend `FishingTask` with resource drops
- document that mining and fishing reward resources

## Testing
- `npm test` *(fails: package.json not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c807418832ebe6c3508a404d6cf