### PR TITLE
Add water task list to ProceduralTaskGenerator

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -15,8 +15,10 @@ namespace TimelessEchoes.MapGeneration
         [Header("Tilemaps")]
         [TabGroup("References")]
         [SerializeField] private Tilemap waterMap;
+        public Tilemap WaterMap => waterMap;
         [TabGroup("References")]
         [SerializeField] private Tilemap sandMap;
+        public Tilemap SandMap => sandMap;
         [TabGroup("References")]
         [SerializeField] private Tilemap grassMap;
 


### PR DESCRIPTION
## Summary
- add public tilemap accessors in `TilemapChunkGenerator`
- support `waterTasks` list in `ProceduralTaskGenerator`
- spawn water tasks only on the topmost water tiles at the sand edge

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c9c4da9cc832eb85a628fbf1d82ea