### PR TITLE
Allow water tasks on blocking layer

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -151,7 +151,7 @@ namespace TimelessEchoes.Tasks
                 var pos = isWaterTask ? waterPos : RandomPositionAtX(localX);
 
                 var attempts = 0;
-                while (attempts < 5 && (HasBlockingCollider(pos) || IsBlockedAhead(pos)))
+                while (!isWaterTask && attempts < 5 && (HasBlockingCollider(pos) || IsBlockedAhead(pos)))
                 {
                     if (isWaterTask)
                     {
@@ -167,7 +167,7 @@ namespace TimelessEchoes.Tasks
                     attempts++;
                 }
 
-                if (HasBlockingCollider(pos) || IsBlockedAhead(pos))
+                if (!isWaterTask && (HasBlockingCollider(pos) || IsBlockedAhead(pos)))
                     continue;
 
                 var obj = Instantiate(entry.prefab, pos, Quaternion.identity, transform);

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ from the entry point to keep your hero on an efficient route.
 Mining and fishing tasks award resources when completed. Use these resources to
 upgrade your hero.
 
+Water-based tasks ignore blocking colliders, allowing them to spawn even when a
+tile on the `Blocking` layer is present.
+
 ## Building
 Use **File > Build Settings...** to create standalone builds.
 


### PR DESCRIPTION
## Summary
- let ProceduralTaskGenerator skip blocking checks for water tasks
- document this behaviour in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ca23cb888832eae531912c5722333