### PR TITLE
Toggle progress bars during mining and fishing

### DIFF
--- a/Assets/Prefabs/Tasks/Fishing/Fish.prefab
+++ b/Assets/Prefabs/Tasks/Fishing/Fish.prefab
@@ -543,6 +543,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   fishTime: 2
   progressBar: {fileID: 567852907585319674}
+  progressBarObject: {fileID: 7311250231813555340}
   fishingPoint: {fileID: 1391531017378201527}
 --- !u!1 &7311250231813555340
 GameObject:

--- a/Assets/Prefabs/Tasks/Mining/Rock_Small.prefab
+++ b/Assets/Prefabs/Tasks/Mining/Rock_Small.prefab
@@ -396,10 +396,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3f088ecfefd815e43b86f9bedb99e254, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   mineTime: 2
   progressBar: {fileID: 2992031436270654903}
+  progressBarObject: {fileID: 6903395814371763851}
   leftPoint: {fileID: 5457777148452022193}
   rightPoint: {fileID: 5457777148452022193}
   upPoint: {fileID: 5457777148452022193}

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -352,7 +352,9 @@ namespace TimelessEchoes.Hero
             {
                 ai.canMove = true;
                 animator?.SetTrigger("StopMining");
-                if (miningTask?.ProgressBar != null)
+                if (miningTask?.ProgressBarObject != null)
+                    miningTask.ProgressBarObject.SetActive(false);
+                else if (miningTask?.ProgressBar != null)
                     miningTask.ProgressBar.gameObject.SetActive(false);
                 miningTask = null;
             }
@@ -360,7 +362,9 @@ namespace TimelessEchoes.Hero
             {
                 ai.canMove = true;
                 animator?.SetTrigger("CatchFish");
-                if (fishingTask?.ProgressBar != null)
+                if (fishingTask?.ProgressBarObject != null)
+                    fishingTask.ProgressBarObject.SetActive(false);
+                else if (fishingTask?.ProgressBar != null)
                     fishingTask.ProgressBar.gameObject.SetActive(false);
                 fishingTask = null;
             }
@@ -407,7 +411,10 @@ namespace TimelessEchoes.Hero
             setter.target = task.transform;
             if (task.ProgressBar != null)
             {
-                task.ProgressBar.gameObject.SetActive(true);
+                if (task.ProgressBarObject != null)
+                    task.ProgressBarObject.SetActive(true);
+                else
+                    task.ProgressBar.gameObject.SetActive(true);
                 task.ProgressBar.fillAmount = 1f;
             }
 
@@ -449,7 +456,10 @@ namespace TimelessEchoes.Hero
             setter.target = task.transform;
             if (task.ProgressBar != null)
             {
-                task.ProgressBar.gameObject.SetActive(true);
+                if (task.ProgressBarObject != null)
+                    task.ProgressBarObject.SetActive(true);
+                else
+                    task.ProgressBar.gameObject.SetActive(true);
                 task.ProgressBar.fillAmount = 1f;
             }
 

--- a/Assets/Scripts/Tasks/FishingTask.cs
+++ b/Assets/Scripts/Tasks/FishingTask.cs
@@ -13,6 +13,7 @@ namespace TimelessEchoes.Tasks
     public class FishingTask : BaseTask
     {
         [SerializeField] private float fishTime = 2f;
+        [SerializeField] private GameObject progressBarObject;
         [SerializeField] private SlicedFilledImage progressBar;
         [SerializeField] private Transform fishingPoint;
         [SerializeField] private List<ResourceDrop> resourceDrops = new();
@@ -22,6 +23,7 @@ namespace TimelessEchoes.Tasks
 
         public float FishTime => fishTime;
         public SlicedFilledImage ProgressBar => progressBar;
+        public GameObject ProgressBarObject => progressBarObject != null ? progressBarObject : progressBar?.gameObject;
         public IList<ResourceDrop> Drops => resourceDrops;
 
         public override Transform Target => fishingPoint != null ? fishingPoint : transform;
@@ -30,7 +32,13 @@ namespace TimelessEchoes.Tasks
         {
             complete = false;
             if (progressBar != null)
+            {
                 progressBar.fillAmount = 1f;
+                if (progressBarObject != null)
+                    progressBarObject.SetActive(false);
+                else
+                    progressBar.gameObject.SetActive(false);
+            }
             if (resourceManager == null)
                 resourceManager = FindFirstObjectByType<ResourceManager>();
         }
@@ -45,7 +53,12 @@ namespace TimelessEchoes.Tasks
             if (complete) return;
             complete = true;
             if (progressBar != null)
-                progressBar.gameObject.SetActive(false);
+            {
+                if (progressBarObject != null)
+                    progressBarObject.SetActive(false);
+                else
+                    progressBar.gameObject.SetActive(false);
+            }
             if (resourceManager == null)
                 resourceManager = FindFirstObjectByType<ResourceManager>();
             if (resourceManager != null)

--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -13,6 +13,7 @@ namespace TimelessEchoes.Tasks
     public class MiningTask : BaseTask
     {
         [SerializeField] private float mineTime = 2f;
+        [SerializeField] private GameObject progressBarObject;
         [SerializeField] private SlicedFilledImage progressBar;
         [SerializeField] private Transform leftPoint;
         [SerializeField] private Transform rightPoint;
@@ -28,6 +29,7 @@ namespace TimelessEchoes.Tasks
         public float MineTime => mineTime;
         public IList<ResourceDrop> Drops => resourceDrops;
         public SlicedFilledImage ProgressBar => progressBar;
+        public GameObject ProgressBarObject => progressBarObject != null ? progressBarObject : progressBar?.gameObject;
 
         public override Transform Target
         {
@@ -49,7 +51,14 @@ namespace TimelessEchoes.Tasks
             complete = false;
             if (cachedTarget == null)
                 _ = Target;
-            if (progressBar != null) progressBar.fillAmount = 1f;
+            if (progressBar != null)
+            {
+                progressBar.fillAmount = 1f;
+                if (progressBarObject != null)
+                    progressBarObject.SetActive(false);
+                else
+                    progressBar.gameObject.SetActive(false);
+            }
             if (resourceManager == null)
                 resourceManager = FindFirstObjectByType<ResourceManager>();
         }
@@ -83,7 +92,12 @@ namespace TimelessEchoes.Tasks
             if (complete) return;
             complete = true;
             if (progressBar != null)
-                progressBar.gameObject.SetActive(false);
+            {
+                if (progressBarObject != null)
+                    progressBarObject.SetActive(false);
+                else
+                    progressBar.gameObject.SetActive(false);
+            }
             if (resourceManager == null)
                 resourceManager = FindFirstObjectByType<ResourceManager>();
             if (resourceManager != null)


### PR DESCRIPTION
## Summary
- hide progress bar objects until needed
- expose progressBarObject references on mining and fishing tasks
- toggle progress bars via hero script
- update prefabs with new progressBarObject links

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca765e8ac832ebb81e766eeaffd75