### PR TITLE
Fix WeightedRuleTile editor method

### DIFF
--- a/Assets/Scripts/Tilemaps/WeightedRuleTile.cs
+++ b/Assets/Scripts/Tilemaps/WeightedRuleTile.cs
@@ -128,7 +128,7 @@ namespace TimelessEchoes.Tilemaps
         [CustomEditor(typeof(WeightedRuleTile))]
         public class WeightedRuleTileEditor : RuleTileEditor
         {
-            public override void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRuleOutput tilingRule)
+            public new void RuleInspectorOnGUI(Rect rect, RuleTile.TilingRuleOutput tilingRule)
             {
                 base.RuleInspectorOnGUI(rect, tilingRule);
 


### PR DESCRIPTION
## Summary
- fix invalid override in `WeightedRuleTileEditor`

## Testing
- `find . -name '*Test*' -type f | head`

------
https://chatgpt.com/codex/tasks/task_e_685cba49fc00832e8d3aaf9438f9b1a1