### PR TITLE
Implement skill and milestone system

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -206,6 +206,7 @@ namespace Blindsided
             saveData.HeroStates ??= new Dictionary<string, SaveData.GameData.HeroState>();
             saveData.GlobalKillCounts ??= new Dictionary<string, int>();
             saveData.Resources ??= new Dictionary<string, SaveData.GameData.ResourceEntry>();
+            saveData.SkillData ??= new Dictionary<string, SaveData.GameData.SkillProgress>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -37,6 +37,9 @@ namespace Blindsided.SaveData
         [HideReferenceObjectPicker] [TabGroup("UpgradeSystem")]
         public Dictionary<string, int> UpgradeLevels = new();
 
+        [HideReferenceObjectPicker] [TabGroup("Skills")]
+        public Dictionary<string, SkillProgress> SkillData = new();
+
         [HideReferenceObjectPicker]
         public class ResourceEntry
         {
@@ -97,6 +100,13 @@ namespace Blindsided.SaveData
         {
             public int CurrentXP;
             public int Level;
+        }
+
+        [HideReferenceObjectPicker]
+        public class SkillProgress
+        {
+            public int Level;
+            public float CurrentXP;
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/References/UI/SkillUIReferences.cs
+++ b/Assets/Scripts/References/UI/SkillUIReferences.cs
@@ -1,0 +1,14 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace References.UI
+{
+    public class SkillUIReferences : MonoBehaviour
+    {
+        public Image iconImage;
+        public TMP_Text levelText;
+        public Image selectionImage;
+        public Button selectButton;
+    }
+}

--- a/Assets/Scripts/Skills/MilestoneBonus.cs
+++ b/Assets/Scripts/Skills/MilestoneBonus.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace TimelessEchoes.Skills
+{
+    [Serializable]
+    public class MilestoneBonus
+    {
+        public int levelRequirement;
+        public string bonusDescription;
+        public string bonusID;
+    }
+}

--- a/Assets/Scripts/Skills/MilestoneBonusUI.cs
+++ b/Assets/Scripts/Skills/MilestoneBonusUI.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+namespace TimelessEchoes.Skills
+{
+    public class MilestoneBonusUI : MonoBehaviour
+    {
+        [SerializeField] private Transform entryParent;
+        [SerializeField] private GameObject entryPrefab;
+        [SerializeField] private SkillController controller;
+
+        private void Awake()
+        {
+            if (controller == null)
+                controller = FindFirstObjectByType<SkillController>();
+        }
+
+        public void PopulateMilestones(Skill skill)
+        {
+            if (skill == null || entryParent == null || entryPrefab == null)
+                return;
+
+            foreach (Transform child in entryParent)
+                Destroy(child.gameObject);
+
+            var prog = controller ? controller.GetProgress(skill) : null;
+            int level = prog != null ? prog.Level : 1;
+
+            foreach (var milestone in skill.milestones)
+            {
+                var entry = Instantiate(entryPrefab, entryParent);
+                var texts = entry.GetComponentsInChildren<TMP_Text>();
+                foreach (var t in texts)
+                    t.text = $"Lv {milestone.levelRequirement}: {milestone.bonusDescription}";
+
+                var img = entry.GetComponentInChildren<UnityEngine.UI.Image>();
+                if (img != null)
+                    img.color = level >= milestone.levelRequirement ? Color.white : new Color(1f, 1f, 1f, 0.3f);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Skills/Skill.cs
+++ b/Assets/Scripts/Skills/Skill.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TimelessEchoes.Skills
+{
+    [CreateAssetMenu(fileName = "Skill", menuName = "SO/Skill")]
+    public class Skill : ScriptableObject
+    {
+        public string skillName;
+        public Sprite skillIcon;
+        public float xpForFirstLevel = 10f;
+        public float xpLevelMultiplier = 1.5f;
+        public List<MilestoneBonus> milestones = new();
+    }
+}

--- a/Assets/Scripts/Skills/SkillController.cs
+++ b/Assets/Scripts/Skills/SkillController.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using static Blindsided.EventHandler;
+using static Blindsided.Oracle;
+
+namespace TimelessEchoes.Skills
+{
+    /// <summary>
+    /// Handles skill experience and levels.
+    /// </summary>
+    public class SkillController : MonoBehaviour
+    {
+        [Serializable]
+        public class SkillProgress
+        {
+            public int Level;
+            public float CurrentXP;
+        }
+
+        [SerializeField] private List<Skill> skills = new();
+
+        private readonly Dictionary<Skill, SkillProgress> progress = new();
+
+        public event Action<Skill, float, float> OnExperienceGained;
+
+        private void Awake()
+        {
+            LoadState();
+            OnSaveData += SaveState;
+            OnLoadData += LoadState;
+        }
+
+        private void OnDestroy()
+        {
+            OnSaveData -= SaveState;
+            OnLoadData -= LoadState;
+        }
+
+        public SkillProgress GetProgress(Skill skill)
+        {
+            if (skill == null) return null;
+            progress.TryGetValue(skill, out var prog);
+            return prog;
+        }
+
+        public void AddExperience(Skill skill, float xpAmount)
+        {
+            if (skill == null || xpAmount <= 0f) return;
+            if (!progress.TryGetValue(skill, out var prog))
+            {
+                prog = new SkillProgress { Level = 1, CurrentXP = 0f };
+                progress[skill] = prog;
+            }
+
+            prog.CurrentXP += xpAmount;
+
+            var currentLevel = prog.Level;
+            float xpNeeded = skill.xpForFirstLevel * Mathf.Pow(currentLevel, skill.xpLevelMultiplier);
+            while (prog.CurrentXP >= xpNeeded)
+            {
+                prog.CurrentXP -= xpNeeded;
+                prog.Level++;
+                currentLevel = prog.Level;
+                xpNeeded = skill.xpForFirstLevel * Mathf.Pow(currentLevel, skill.xpLevelMultiplier);
+            }
+
+            OnExperienceGained?.Invoke(skill, prog.CurrentXP, xpNeeded);
+        }
+
+        private void SaveState()
+        {
+            if (oracle == null) return;
+            var dict = new Dictionary<string, Blindsided.SaveData.GameData.SkillProgress>();
+            foreach (var pair in progress)
+            {
+                if (pair.Key != null)
+                    dict[pair.Key.name] = new Blindsided.SaveData.GameData.SkillProgress
+                    {
+                        Level = pair.Value.Level,
+                        CurrentXP = pair.Value.CurrentXP
+                    };
+            }
+            oracle.saveData.SkillData = dict;
+        }
+
+        private void LoadState()
+        {
+            if (oracle == null) return;
+            oracle.saveData.SkillData ??= new Dictionary<string, Blindsided.SaveData.GameData.SkillProgress>();
+            progress.Clear();
+            foreach (var skill in skills)
+            {
+                if (skill == null) continue;
+                if (oracle.saveData.SkillData.TryGetValue(skill.name, out var data))
+                {
+                    progress[skill] = new SkillProgress { Level = data.Level, CurrentXP = data.CurrentXP };
+                }
+                else
+                {
+                    progress[skill] = new SkillProgress { Level = 1, CurrentXP = 0f };
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -9,6 +9,9 @@ namespace TimelessEchoes.Tasks
     /// </summary>
     public abstract class BaseTask : MonoBehaviour, ITask
     {
+        [SerializeField] private TimelessEchoes.Skills.Skill associatedSkill;
+        [SerializeField] private float xpGrantedOnCompletion;
+
         /// <summary>
         ///     A property to indicate if this task should prevent the hero from moving.
         /// </summary>
@@ -50,6 +53,13 @@ namespace TimelessEchoes.Tasks
         /// </summary>
         public virtual void OnInterrupt(HeroController hero)
         {
+        }
+
+        protected void GrantCompletionXP()
+        {
+            if (associatedSkill == null || xpGrantedOnCompletion <= 0f) return;
+            var controller = FindFirstObjectByType<TimelessEchoes.Skills.SkillController>();
+            controller?.AddExperience(associatedSkill, xpGrantedOnCompletion);
         }
     }
 }

--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -51,6 +51,7 @@ namespace TimelessEchoes.Tasks
                 isComplete = true;
                 HideProgressBar();
                 GenerateDrops();
+                GrantCompletionXP();
                 // The hero will get a new task automatically now
             }
         }

--- a/Assets/Scripts/Tasks/OpenChestTask.cs
+++ b/Assets/Scripts/Tasks/OpenChestTask.cs
@@ -47,6 +47,7 @@ namespace TimelessEchoes.Tasks
             yield return new WaitForSeconds(openDuration);
 
             GenerateDrops();
+            GrantCompletionXP();
             opened = true;
             isWaiting = false;
         }


### PR DESCRIPTION
## Summary
- add skill data ScriptableObject and milestone definitions
- implement SkillController for XP management with save integration
- create UI classes for displaying skills and milestones
- allow tasks to grant skill XP on completion
- hook skill data into existing save system

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dc90d1710832ea0894c835ce1aaf0