### PR TITLE
Remove drop text when enemies die

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -207,7 +207,6 @@ namespace TimelessEchoes.Enemies
                 if (count > 0)
                 {
                     resourceManager.Add(drop.resource, count);
-                    TimelessEchoes.FloatingText.Spawn($"{drop.resource.name} x{count}", transform.position + Vector3.up, Color.yellow);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- stop showing FloatingText when enemies drop resources

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ddabd2ed4832e9ce2716944cf1f6a