### PR TITLE
Display level text on UI with toggle

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -69,6 +69,7 @@ namespace Blindsided.SaveData
             public bool TransparentUi;
             public bool Tutorial;
             public bool UseScaledTimeForValues;
+            public bool ShowLevelText = true;
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -89,6 +89,12 @@ namespace Blindsided.SaveData
             set => oracle.saveData.SavedPreferences.UseScaledTimeForValues = value;
         }
 
+        public static bool ShowLevelText
+        {
+            get => oracle.saveData.SavedPreferences.ShowLevelText;
+            set => oracle.saveData.SavedPreferences.ShowLevelText = value;
+        }
+
         public static bool DevSpeed
         {
             get => oracle.saveData.DevOptions.DevSpeed;

--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using Blindsided.Utilities;
 using UnityEngine.EventSystems;
+using static Blindsided.SaveData.StaticReferences;
 
 namespace TimelessEchoes.Skills
 {
@@ -59,6 +60,7 @@ namespace TimelessEchoes.Skills
             if (popupPanel != null)
                 popupPanel.SetActive(false);
             DeselectSkill();
+            UpdateSkillSelectorLevels();
         }
 
         private void OnEnable()
@@ -78,6 +80,7 @@ namespace TimelessEchoes.Skills
             {
                 UpdateSelectedSkillUI();
             }
+            UpdateSkillSelectorLevels();
         }
 
         private void OnDisable()
@@ -102,11 +105,12 @@ namespace TimelessEchoes.Skills
                 return;
             var selector = skillSelectors[index];
             if (selector != null && selector.levelText != null)
-                selector.levelText.text = $"Lvl {level}";
+                selector.levelText.text = ShowLevelText ? $"Lvl {level}" : string.Empty;
 
             bool popupShowing = popupPanel != null && popupPanel.activeSelf && selectedIndex == index;
             if (!popupShowing && selector != null && selector.highlightImage != null)
                 selector.highlightImage.enabled = true;
+            UpdateSkillSelectorLevels();
         }
 
         private void SelectSkill(int index)
@@ -159,6 +163,32 @@ namespace TimelessEchoes.Skills
                 experienceText.text = $"{current:0.#} / {needed:0.#}";
             if (experienceBar != null)
                 experienceBar.fillAmount = needed > 0 ? Mathf.Clamp01(current / needed) : 0f;
+        }
+
+        private void UpdateSkillSelectorLevels()
+        {
+            for (int i = 0; i < skillSelectors.Count && i < skills.Count; i++)
+            {
+                var selector = skillSelectors[i];
+                var skill = skills[i];
+                if (selector == null || selector.levelText == null) continue;
+
+                if (ShowLevelText)
+                {
+                    int lvl = 1;
+                    if (controller != null)
+                    {
+                        var prog = controller.GetProgress(skill);
+                        if (prog != null)
+                            lvl = prog.Level;
+                    }
+                    selector.levelText.text = $"Lvl {lvl}";
+                }
+                else
+                {
+                    selector.levelText.text = string.Empty;
+                }
+            }
         }
 
         private void Update()

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using References.UI;
 using UnityEngine;
+using static Blindsided.SaveData.StaticReferences;
 
 namespace TimelessEchoes.Upgrades
 {
@@ -49,6 +50,7 @@ namespace TimelessEchoes.Upgrades
             DeselectStat();
             if (references != null)
                 references.gameObject.SetActive(false);
+            UpdateStatSelectorLevels();
         }
 
         private void OnEnable()
@@ -63,6 +65,7 @@ namespace TimelessEchoes.Upgrades
             {
                 UpdateUI();
             }
+            UpdateStatSelectorLevels();
         }
 
         private void Update()
@@ -137,6 +140,7 @@ namespace TimelessEchoes.Upgrades
             UpdateInfoText();
             if (references.upgradeButton)
                 references.upgradeButton.interactable = controller && controller.CanUpgrade(CurrentUpgrade);
+            UpdateStatSelectorLevels();
         }
 
         private void UpdateCostSlotValues()
@@ -181,6 +185,7 @@ namespace TimelessEchoes.Upgrades
             {
                 BuildCostSlots();
                 UpdateUI();
+                UpdateStatSelectorLevels();
             }
         }
 
@@ -193,6 +198,26 @@ namespace TimelessEchoes.Upgrades
                 if (lvl >= t.minLevel && lvl < t.maxLevel)
                     return t;
             return null;
+        }
+
+        private void UpdateStatSelectorLevels()
+        {
+            for (var i = 0; i < statSelectors.Count && i < upgrades.Count; i++)
+            {
+                var selector = statSelectors[i];
+                var upgrade = upgrades[i];
+                if (selector == null || selector.countText == null) continue;
+
+                if (ShowLevelText)
+                {
+                    int lvl = controller ? controller.GetLevel(upgrade) : 0;
+                    selector.countText.text = $"Lvl {lvl}";
+                }
+                else
+                {
+                    selector.countText.text = string.Empty;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `ShowLevelText` preference
- expose the preference in `StaticReferences`
- display skill levels all the time when enabled
- add level labels to stat upgrade UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ddbb277e0832e931ab7756d4e9267