### PR TITLE
Fix missing level text display

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using static Blindsided.Oracle;
 using static Blindsided.SaveData.GameData;
@@ -89,10 +90,19 @@ namespace Blindsided.SaveData
             set => oracle.saveData.SavedPreferences.UseScaledTimeForValues = value;
         }
 
+        public static event Action ShowLevelTextChanged;
+
         public static bool ShowLevelText
         {
             get => oracle.saveData.SavedPreferences.ShowLevelText;
-            set => oracle.saveData.SavedPreferences.ShowLevelText = value;
+            set
+            {
+                if (oracle.saveData.SavedPreferences.ShowLevelText != value)
+                {
+                    oracle.saveData.SavedPreferences.ShowLevelText = value;
+                    ShowLevelTextChanged?.Invoke();
+                }
+            }
         }
 
         public static bool DevSpeed

--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 using Blindsided.Utilities;
 using UnityEngine.EventSystems;
 using static Blindsided.SaveData.StaticReferences;
+using static Blindsided.EventHandler;
 
 namespace TimelessEchoes.Skills
 {
@@ -70,6 +71,8 @@ namespace TimelessEchoes.Skills
                 controller.OnExperienceGained += OnExperienceGained;
                 controller.OnLevelUp += OnLevelUp;
             }
+            ShowLevelTextChanged += OnShowLevelTextChanged;
+            OnLoadData += OnShowLevelTextChanged;
             if (selectedIndex < 0)
             {
                 DeselectSkill();
@@ -90,6 +93,8 @@ namespace TimelessEchoes.Skills
                 controller.OnExperienceGained -= OnExperienceGained;
                 controller.OnLevelUp -= OnLevelUp;
             }
+            ShowLevelTextChanged -= OnShowLevelTextChanged;
+            OnLoadData -= OnShowLevelTextChanged;
         }
 
         private void OnExperienceGained(Skill skill, float current, float required)
@@ -199,6 +204,13 @@ namespace TimelessEchoes.Skills
                     popupPanel.SetActive(false);
                 DeselectSkill();
             }
+        }
+
+        private void OnShowLevelTextChanged()
+        {
+            UpdateSkillSelectorLevels();
+            if (selectedIndex >= 0)
+                UpdateSelectedSkillUI();
         }
 
         private void DeselectSkill()

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using References.UI;
 using UnityEngine;
 using static Blindsided.SaveData.StaticReferences;
+using static Blindsided.EventHandler;
 
 namespace TimelessEchoes.Upgrades
 {
@@ -66,6 +67,15 @@ namespace TimelessEchoes.Upgrades
                 UpdateUI();
             }
             UpdateStatSelectorLevels();
+
+            ShowLevelTextChanged += OnShowLevelTextChanged;
+            OnLoadData += OnShowLevelTextChanged;
+        }
+
+        private void OnDisable()
+        {
+            ShowLevelTextChanged -= OnShowLevelTextChanged;
+            OnLoadData -= OnShowLevelTextChanged;
         }
 
         private void Update()
@@ -76,6 +86,13 @@ namespace TimelessEchoes.Upgrades
                     references.gameObject.SetActive(false);
                 DeselectStat();
             }
+        }
+
+        private void OnShowLevelTextChanged()
+        {
+            UpdateStatSelectorLevels();
+            if (selectedIndex >= 0)
+                UpdateUI();
         }
 
         private void DeselectStat()


### PR DESCRIPTION
## Summary
- add ShowLevelTextChanged event to preferences
- refresh level text when ShowLevelText is toggled or data loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685df4b21f80832eaf2aec5ba2a6b31f