### PR TITLE
Fix skill and stat level display after loading data

### DIFF
--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -73,6 +73,7 @@ namespace TimelessEchoes.Skills
             }
             ShowLevelTextChanged += OnShowLevelTextChanged;
             OnLoadData += OnShowLevelTextChanged;
+            OnShowLevelTextChanged();
             if (selectedIndex < 0)
             {
                 DeselectSkill();

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -70,6 +70,7 @@ namespace TimelessEchoes.Upgrades
 
             ShowLevelTextChanged += OnShowLevelTextChanged;
             OnLoadData += OnShowLevelTextChanged;
+            OnShowLevelTextChanged();
         }
 
         private void OnDisable()


### PR DESCRIPTION
## Summary
- refresh skill level UI whenever menus open
- refresh stat upgrade UI whenever menus open

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685df8f9f68c832eb29b24290fabe5f5