### PR TITLE
Fix level text not updating on load

### DIFF
--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using References.UI;
 using TMPro;
@@ -72,7 +73,7 @@ namespace TimelessEchoes.Skills
                 controller.OnLevelUp += OnLevelUp;
             }
             ShowLevelTextChanged += OnShowLevelTextChanged;
-            OnLoadData += OnShowLevelTextChanged;
+            OnLoadData += OnLoadDataHandler;
             OnShowLevelTextChanged();
             if (selectedIndex < 0)
             {
@@ -95,7 +96,7 @@ namespace TimelessEchoes.Skills
                 controller.OnLevelUp -= OnLevelUp;
             }
             ShowLevelTextChanged -= OnShowLevelTextChanged;
-            OnLoadData -= OnShowLevelTextChanged;
+            OnLoadData -= OnLoadDataHandler;
         }
 
         private void OnExperienceGained(Skill skill, float current, float required)
@@ -212,6 +213,17 @@ namespace TimelessEchoes.Skills
             UpdateSkillSelectorLevels();
             if (selectedIndex >= 0)
                 UpdateSelectedSkillUI();
+        }
+
+        private void OnLoadDataHandler()
+        {
+            StartCoroutine(DelayedUpdate());
+        }
+
+        private IEnumerator DelayedUpdate()
+        {
+            yield return null;
+            OnShowLevelTextChanged();
         }
 
         private void DeselectSkill()

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using References.UI;
 using UnityEngine;
@@ -69,14 +70,14 @@ namespace TimelessEchoes.Upgrades
             UpdateStatSelectorLevels();
 
             ShowLevelTextChanged += OnShowLevelTextChanged;
-            OnLoadData += OnShowLevelTextChanged;
+            OnLoadData += OnLoadDataHandler;
             OnShowLevelTextChanged();
         }
 
         private void OnDisable()
         {
             ShowLevelTextChanged -= OnShowLevelTextChanged;
-            OnLoadData -= OnShowLevelTextChanged;
+            OnLoadData -= OnLoadDataHandler;
         }
 
         private void Update()
@@ -94,6 +95,17 @@ namespace TimelessEchoes.Upgrades
             UpdateStatSelectorLevels();
             if (selectedIndex >= 0)
                 UpdateUI();
+        }
+
+        private void OnLoadDataHandler()
+        {
+            StartCoroutine(DelayedUpdate());
+        }
+
+        private IEnumerator DelayedUpdate()
+        {
+            yield return null;
+            OnShowLevelTextChanged();
         }
 
         private void DeselectStat()


### PR DESCRIPTION
## Summary
- update SkillUIManager and StatUpgradeUIManager to refresh after load events
- delay UI refresh until next frame so controllers finish loading

## Testing
- `mcs Assets/Scripts/Skills/SkillUIManager.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa814ec8832e8fb0c533386f13da