### PR TITLE
Trigger death animation before destroying enemy

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -189,6 +189,10 @@ namespace TimelessEchoes.Enemies
 
         private void OnDeath()
         {
+            SetActiveState(false);
+            if (animator != null)
+                animator.SetTrigger("Die");
+
             if (resourceManager == null)
                 resourceManager = FindFirstObjectByType<ResourceManager>();
             if (resourceManager == null) return;
@@ -209,6 +213,12 @@ namespace TimelessEchoes.Enemies
                     resourceManager.Add(drop.resource, count);
                 }
             }
+        }
+
+        // Called via animation event at the end of the Die animation
+        public void DestroySelf()
+        {
+            Destroy(gameObject);
         }
 
         private void OnDestroy()

--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -38,10 +38,7 @@ namespace TimelessEchoes.Enemies
             if (CurrentHealth <= 0f)
             {
                 OnDeath?.Invoke();
-
-                // Automatically remove enemies when their health reaches zero
-                if (GetComponent<Enemy>() != null)
-                    Destroy(gameObject);
+                // Enemy objects now handle destruction after playing a death animation
             }
         }
 


### PR DESCRIPTION
## Summary
- play death animation on enemy and disable AI when health hits zero
- remove automatic enemy destruction from `Health`
- add helper to destroy an enemy after the death animation ends

## Testing
- `ls -R | grep Tests`

------
https://chatgpt.com/codex/tasks/task_e_685f583db5b4832e90ede1cc9313623a