### PR TITLE
Improve woodcutting task sprite handling

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -257,6 +257,8 @@ namespace TimelessEchoes.Tasks
                 {
                     if (task is OpenChestTask)
                         Destroy(obj.GetComponent<OpenChestTask>());
+                    else if (task is WoodcuttingTask)
+                        Destroy(obj.GetComponent<WoodcuttingTask>());
                     else
                         Destroy(obj.gameObject);
                 }
@@ -264,6 +266,8 @@ namespace TimelessEchoes.Tasks
             else if (task is MonoBehaviour mb)
             {
                 if (task is OpenChestTask)
+                    Destroy(mb);
+                else if (task is WoodcuttingTask)
                     Destroy(mb);
                 else
                     Destroy(mb.gameObject);

--- a/Assets/Scripts/Tasks/WoodcuttingTask.cs
+++ b/Assets/Scripts/Tasks/WoodcuttingTask.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+
+namespace TimelessEchoes.Tasks
+{
+    /// <summary>
+    ///     Task for chopping down a tree. Spawns a stump when completed and
+    ///     does not destroy the original tree GameObject.
+    /// </summary>
+    public class WoodcuttingTask : ContinuousTask
+    {
+        [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private Sprite stumpSprite;
+
+        private Sprite originalSprite;
+
+        private bool spawnedStump;
+
+        protected override string AnimationName => "Chopping";
+        protected override string InterruptTriggerName => "StopChopping";
+
+        public override Transform Target => transform;
+
+        public override void StartTask()
+        {
+            base.StartTask();
+            spawnedStump = false;
+            if (spriteRenderer == null)
+                spriteRenderer = GetComponent<SpriteRenderer>();
+            if (spriteRenderer != null)
+            {
+                if (originalSprite == null)
+                    originalSprite = spriteRenderer.sprite;
+                spriteRenderer.sprite = originalSprite;
+            }
+        }
+
+        public override void Tick(TimelessEchoes.Hero.HeroController hero)
+        {
+            base.Tick(hero);
+            if (!spawnedStump && IsComplete())
+            {
+                spawnedStump = true;
+                if (spriteRenderer == null)
+                    spriteRenderer = GetComponent<SpriteRenderer>();
+                if (spriteRenderer != null && stumpSprite != null)
+                    spriteRenderer.sprite = stumpSprite;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- modify `WoodcuttingTask` to swap the sprite when chopping completes rather than spawning a prefab
- preserve tree GameObject by removing only the component in `TaskController`

## Testing
- `npm test` *(fails: could not find package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f60408050832e965707e8cd3ec63f