### PR TITLE
Implement enemy kill tracking and stats panel

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -206,6 +206,7 @@ namespace Blindsided
             saveData.HeroStates ??= new Dictionary<string, GameData.HeroState>();
             saveData.Resources ??= new Dictionary<string, GameData.ResourceEntry>();
             saveData.SkillData ??= new Dictionary<string, GameData.SkillProgress>();
+            saveData.EnemyKills ??= new Dictionary<string, double>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -36,6 +36,9 @@ namespace Blindsided.SaveData
         public Dictionary<string, int> UpgradeLevels = new();
 
         [HideReferenceObjectPicker]
+        public Dictionary<string, double> EnemyKills = new();
+
+        [HideReferenceObjectPicker]
         public class ResourceEntry
         {
             public double Amount;

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -9,6 +9,7 @@ namespace Blindsided.SaveData
     {
         public static Dictionary<string, int> UpgradeLevels => oracle.saveData.UpgradeLevels;
         public static Dictionary<string, ResourceEntry> Resources => oracle.saveData.Resources;
+        public static Dictionary<string, double> EnemyKills => oracle.saveData.EnemyKills;
 
         public static int ItemShards
         {

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -2,6 +2,7 @@ using Pathfinding;
 using Pathfinding.RVO;
 using UnityEngine;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.Stats;
 using System.Collections.Generic;
 
 namespace TimelessEchoes.Enemies
@@ -34,6 +35,7 @@ namespace TimelessEchoes.Enemies
         private LayerMask blockingMask;
 
         public bool IsEngaged => setter != null && setter.target == hero;
+        public EnemyStats Stats => stats;
 
         public static event System.Action<Enemy> OnEngage;
 
@@ -209,6 +211,9 @@ namespace TimelessEchoes.Enemies
                     resourceManager.Add(drop.resource, count);
                 }
             }
+
+            var tracker = FindFirstObjectByType<EnemyKillTracker>();
+            tracker?.RegisterKill(stats);
         }
 
         private void OnDestroy()

--- a/Assets/Scripts/Enemies/EnemyKillTracker.cs
+++ b/Assets/Scripts/Enemies/EnemyKillTracker.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using UnityEngine;
+using TimelessEchoes.Enemies;
+using Blindsided.Utilities;
+using static Blindsided.EventHandler;
+using static Blindsided.Oracle;
+
+namespace TimelessEchoes.Stats
+{
+    public class EnemyKillTracker : MonoBehaviour
+    {
+        public static readonly int[] Thresholds = { 10, 100, 1000, 10000 };
+
+        private readonly Dictionary<EnemyStats, double> kills = new();
+
+        private void Awake()
+        {
+            LoadState();
+            OnSaveData += SaveState;
+            OnLoadData += LoadState;
+        }
+
+        private void OnDestroy()
+        {
+            OnSaveData -= SaveState;
+            OnLoadData -= LoadState;
+        }
+
+        public void RegisterKill(EnemyStats stats)
+        {
+            if (stats == null) return;
+            if (kills.ContainsKey(stats))
+                kills[stats] += 1;
+            else
+                kills[stats] = 1;
+        }
+
+        public double GetKills(EnemyStats stats)
+        {
+            return stats != null && kills.TryGetValue(stats, out var c) ? c : 0;
+        }
+
+        public int GetRevealLevel(EnemyStats stats)
+        {
+            double count = GetKills(stats);
+            int level = 0;
+            foreach (var t in Thresholds)
+            {
+                if (count >= t) level++;
+            }
+            return level;
+        }
+
+        public float GetDamageMultiplier(EnemyStats stats)
+        {
+            return 1f + GetRevealLevel(stats) * 0.25f;
+        }
+
+        private void SaveState()
+        {
+            if (oracle == null) return;
+            var dict = new Dictionary<string, double>();
+            foreach (var pair in kills)
+            {
+                if (pair.Key != null)
+                    dict[pair.Key.name] = pair.Value;
+            }
+            oracle.saveData.EnemyKills = dict;
+        }
+
+        private void LoadState()
+        {
+            if (oracle == null) return;
+            oracle.saveData.EnemyKills ??= new Dictionary<string, double>();
+            kills.Clear();
+            foreach (var enemy in Resources.LoadAll<EnemyStats>(""))
+            {
+                oracle.saveData.EnemyKills.TryGetValue(enemy.name, out var count);
+                kills[enemy] = count;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Enemies/EnemyStats.cs
+++ b/Assets/Scripts/Enemies/EnemyStats.cs
@@ -7,6 +7,8 @@ namespace TimelessEchoes.Enemies
     [CreateAssetMenu(fileName = "EnemyStats", menuName = "SO/Enemy Stats")]
     public class EnemyStats : ScriptableObject
     {
+        public string enemyName;
+        public Sprite icon;
         public int maxHealth = 10;
         public int experience = 10;
         public int defense = 0;

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -5,6 +5,7 @@ using Sirenix.OdinInspector;
 using TimelessEchoes.Enemies;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.Stats;
 using UnityEngine;
 using static TimelessEchoes.TELogger;
 
@@ -341,7 +342,12 @@ namespace TimelessEchoes.Hero
             var projObj = Instantiate(stats.projectilePrefab, origin.position, Quaternion.identity);
             var proj = projObj.GetComponent<Projectile>();
             if (proj != null)
-                proj.Init(target, (baseDamage + damageBonus) * combatDamageMultiplier);
+            {
+                var killTracker = FindFirstObjectByType<EnemyKillTracker>();
+                var enemyStats = target.GetComponent<Enemy>()?.Stats;
+                float bonus = killTracker != null ? killTracker.GetDamageMultiplier(enemyStats) : 1f;
+                proj.Init(target, (baseDamage + damageBonus) * combatDamageMultiplier * bonus);
+            }
         }
 
         private enum State

--- a/Assets/Scripts/UI/EnemyStatsPanelUI.cs
+++ b/Assets/Scripts/UI/EnemyStatsPanelUI.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using UnityEngine;
+using TimelessEchoes.References.StatPanel;
+using TimelessEchoes.Enemies;
+using TimelessEchoes.Stats;
+using Blindsided.Utilities;
+
+namespace TimelessEchoes.UI
+{
+    public class EnemyStatsPanelUI : MonoBehaviour
+    {
+        [SerializeField] private StatPanelReferences references;
+        [SerializeField] private EnemyKillTracker killTracker;
+
+        private readonly Dictionary<EnemyStats, EnemyStatEntryUIReferences> entries = new();
+
+        private void Awake()
+        {
+            if (references == null)
+                references = GetComponent<StatPanelReferences>();
+            if (killTracker == null)
+                killTracker = FindFirstObjectByType<EnemyKillTracker>();
+            BuildEntries();
+        }
+
+        private void OnEnable()
+        {
+            UpdateEntries();
+        }
+
+        private void Update()
+        {
+            UpdateEntries();
+        }
+
+        private void BuildEntries()
+        {
+            if (references == null || references.enemyEntryParent == null || references.enemyEntryPrefab == null)
+                return;
+
+            foreach (Transform child in references.enemyEntryParent)
+                Destroy(child.gameObject);
+
+            foreach (var stats in Resources.LoadAll<EnemyStats>(""))
+            {
+                var obj = Instantiate(references.enemyEntryPrefab.gameObject, references.enemyEntryParent);
+                var ui = obj.GetComponent<EnemyStatEntryUIReferences>();
+                if (ui == null) continue;
+                entries[stats] = ui;
+            }
+        }
+
+        private void UpdateEntries()
+        {
+            foreach (var pair in entries)
+                UpdateEntry(pair.Key, pair.Value);
+        }
+
+        private void UpdateEntry(EnemyStats stats, EnemyStatEntryUIReferences ui)
+        {
+            if (stats == null || ui == null) return;
+            double kills = killTracker ? killTracker.GetKills(stats) : 0;
+            int reveal = killTracker ? killTracker.GetRevealLevel(stats) : 0;
+            float bonus = (killTracker ? killTracker.GetDamageMultiplier(stats) : 1f) - 1f;
+
+            if (ui.enemyIconImage != null)
+            {
+                ui.enemyIconImage.sprite = stats.icon;
+                ui.enemyIconImage.enabled = stats.icon != null;
+            }
+
+            if (ui.enemyNameText != null)
+                ui.enemyNameText.text = stats.enemyName;
+
+            string hp = reveal >= 2 ? CalcUtils.FormatNumber(stats.maxHealth, true, 400f, false) : "???";
+            string dmg = reveal >= 1 ? CalcUtils.FormatNumber(stats.damage, true, 400f, false) : "???";
+            ui.hitpointsAndDamageText.text = $"Hitpoints: {hp}\nDamage: {dmg}";
+
+            string move = reveal >= 3 ? CalcUtils.FormatNumber(stats.moveSpeed, true, 400f, false) : "???";
+            string atk = reveal >= 4 ? CalcUtils.FormatNumber(stats.attackSpeed, true, 400f, false) : "???";
+            ui.movementAndAttackRateText.text = $"Move Speed: {move}\nAttack Rate: {atk}";
+
+            string killsText = CalcUtils.FormatNumber(kills, true, 400f, false);
+            if (reveal < EnemyKillTracker.Thresholds.Length)
+            {
+                int next = EnemyKillTracker.Thresholds[reveal];
+                string nextStr = CalcUtils.FormatNumber(next, true, 400f, false);
+                killsText += $" / {nextStr}";
+                if (ui.progressBar != null)
+                {
+                    ui.progressBar.SetActive(true);
+                    ui.nextRevealProgressBar.fillAmount = Mathf.Clamp01((float)(kills / next));
+                }
+            }
+            else
+            {
+                if (ui.progressBar != null)
+                    ui.progressBar.SetActive(false);
+            }
+
+            if (ui.killsAndNextAndBonusText != null)
+                ui.killsAndNextAndBonusText.text = $"Kills: {killsText}\nBonus Damage: {(bonus * 100f):0}%";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track enemy kills in `GameData` via new `EnemyKillTracker`
- expose enemy stats name and icon on `EnemyStats`
- register enemy kills when an enemy dies
- apply kill-based damage bonus when the hero attacks
- auto-generate UI entries in `EnemyStatsPanelUI`
- keep save data dictionaries up to date

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f89b49f24832e8d28cc5aea337312