### PR TITLE
Fix EnemyKillTracker tests reference

### DIFF
--- a/Assets/Tests/Editor/TimelessEchoes.Tests.asmdef
+++ b/Assets/Tests/Editor/TimelessEchoes.Tests.asmdef
@@ -1,7 +1,8 @@
 {
   "name": "TimelessEchoes.Tests",
   "references": [
-    "UnityEngine.TestRunner"
+    "UnityEngine.TestRunner",
+    "Assembly-CSharp"
   ],
   "optionalUnityReferences": [],
   "includePlatforms": [],


### PR DESCRIPTION
## Summary
- update test asmdef to reference `Assembly-CSharp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fa9b8765c832ea38ee81b5676c0be