### PR TITLE
Fix HealthTests failing in edit mode

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -34,7 +34,10 @@ namespace TimelessEchoes.Enemies
             var isHero = GetComponent<HeroController>() != null;
             var colour = isHero ? red : orange;
             var fontSize = isHero ? 6f : 8f;
-            FloatingText.Spawn(CalcUtils.FormatNumber(amount), transform.position + Vector3.up, colour, fontSize);
+            if (Application.isPlaying)
+            {
+                FloatingText.Spawn(CalcUtils.FormatNumber(amount), transform.position + Vector3.up, colour, fontSize);
+            }
             if (CurrentHealth <= 0f)
             {
                 OnDeath?.Invoke();


### PR DESCRIPTION
## Summary
- guard FloatingText.Spawn with Application.isPlaying so edit mode unit tests don't spawn UI objects

## Testing
- `apt-get update -y`
- `apt-get install -y mono-devel nunit-console`
  - _Mono and NUnit installed but Unity tests couldn't run without Unity engine_

------
https://chatgpt.com/codex/tasks/task_e_685fadfe8a00832eaddade51abb42586