### PR TITLE
Add inventory auto-open and window toggle utility

### DIFF
--- a/Assets/Scripts/UI/WindowToggle.cs
+++ b/Assets/Scripts/UI/WindowToggle.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TimelessEchoes.UI
+{
+    /// <summary>
+    ///     Toggles a window's active state when the assigned button is pressed.
+    /// </summary>
+    public class WindowToggle : MonoBehaviour
+    {
+        [SerializeField] private Button toggleButton;
+        [SerializeField] private GameObject window;
+
+        private void Awake()
+        {
+            if (toggleButton == null)
+                toggleButton = GetComponent<Button>();
+
+            if (toggleButton != null)
+                toggleButton.onClick.AddListener(ToggleWindow);
+        }
+
+        private void OnDestroy()
+        {
+            if (toggleButton != null)
+                toggleButton.onClick.RemoveListener(ToggleWindow);
+        }
+
+        private void ToggleWindow()
+        {
+            if (window != null)
+                window.SetActive(!window.activeSelf);
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -15,6 +15,7 @@ namespace TimelessEchoes.Upgrades
         [SerializeField] private ResourceManager resourceManager;
         [SerializeField] private List<Resource> resources = new();
         [SerializeField] private List<ResourceUIReferences> slots = new();
+        [SerializeField] private GameObject inventoryWindow;
         [SerializeField] private TooltipUIReferences tooltip;
         [SerializeField] private bool showTooltipOnHover;
         [SerializeField] private Vector2 tooltipOffset = Vector2.zero;
@@ -158,7 +159,11 @@ namespace TimelessEchoes.Upgrades
         {
             var index = resources.IndexOf(resource);
             if (index >= 0)
+            {
+                if (inventoryWindow != null && !inventoryWindow.activeSelf)
+                    inventoryWindow.SetActive(true);
                 SelectSlot(index);
+            }
         }
 
         private void ShowTooltip(int index)


### PR DESCRIPTION
## Summary
- open inventory window when highlighting a resource
- implement `WindowToggle` script for toggling UI windows

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686074e1bc10832e947022f640bb4e85