### PR TITLE
Add prefab variants for missing slimes

### DIFF
--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Blue.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Blue.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Blue
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: f499e6cb621d21f4d9542f7a2ab91b08, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f6905179186c264a82ad2c4dbec39bd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+        value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+        value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 43810669774899895, guid: f3a27f43c7070b1458586ed35bab3dfb, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Blue.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Blue.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Blue
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: f499e6cb621d21f4d9542f7a2ab91b08, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f6905179186c264a82ad2c4dbec39bd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+        value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+        value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 7086287932117018057, guid: 40797916ff6958444a0f54dc5f1c5d2c, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Green.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Green.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Green
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: f499e6cb621d21f4d9542f7a2ab91b08, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f6905179186c264a82ad2c4dbec39bd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+        value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+        value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 5974850342220603758, guid: ed517c4b34720b145ae9a8a233b9963e, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Pink.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Pink.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Pink
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: f499e6cb621d21f4d9542f7a2ab91b08, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f6905179186c264a82ad2c4dbec39bd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+        value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+        value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -4439855420470161935, guid: 160408a71ac3a6d42a642c19996e590f, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Red.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Red.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Red
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: f499e6cb621d21f4d9542f7a2ab91b08, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f6905179186c264a82ad2c4dbec39bd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+        value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+        value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -4816725795396207319, guid: 4a0032986a96f1848b7dfd28332e79f7, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Yellow.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Yellow.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Yellow
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: f499e6cb621d21f4d9542f7a2ab91b08, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f6905179186c264a82ad2c4dbec39bd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+        value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+        value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 8771735074934591030, guid: 378509acf7c2f1f4185edd533b7b3d47, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Pink.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Pink.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Pink
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: f499e6cb621d21f4d9542f7a2ab91b08, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f6905179186c264a82ad2c4dbec39bd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+        value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+        value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -3554783601331016760, guid: cc23d3f964a1e5440aac3fe6a4ab92d1, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Red.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Red.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Red
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: f499e6cb621d21f4d9542f7a2ab91b08, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4f6905179186c264a82ad2c4dbec39bd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+        value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+        value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 3889767076933404985, guid: f67999f43e6e3304d8c33d27330fe20e, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}


### PR DESCRIPTION
## Summary
- add new small slime prefabs for blue, pink and red
- add medium slime prefabs for all colours

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68608a2f56d0832e846b0623f2b3ef4f