### PR TITLE
Add slime variants

### DIFF
--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Blue.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Blue.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Blue
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: ad0a5d46c7a7d0e4b8026508c7984132, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 26835af928284989a60fa2e8c53227e2, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 43810669774899895, guid: f3a27f43c7070b1458586ed35bab3dfb, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Blue.prefab.meta
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Blue.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 370ef629523d47c58f7df122efe1b298
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Blue.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Blue.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Blue
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 07d2fdafe9223f44c90868cb1cc0b9bc, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4e511179ff6f4d75be9f5579a5025d04, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 7086287932117018057, guid: 40797916ff6958444a0f54dc5f1c5d2c, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Blue.prefab.meta
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Blue.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f816f5c00882400090acde66d6b0d356
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Green.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Green.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Green
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 4f948946fa3ac95439a3ea5e01cdc1fc, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 0c2cca794cc4431b951962c60f9dda6c, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 5974850342220603758, guid: ed517c4b34720b145ae9a8a233b9963e, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Green.prefab.meta
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Green.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 61d915512172447da09c5d5876e7a097
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Pink.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Pink.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Pink
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: b7c5e2a0946f7fe4d8d28eadd63e513d, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 72ad984febee4da2a79ebcf25a3376dd, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -4439855420470161935, guid: 160408a71ac3a6d42a642c19996e590f, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Pink.prefab.meta
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Pink.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 518fcc48b92f4b88a369f9442b8dbae8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Red.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Red.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Red
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 90ca1163044afff49af2dfff29b56838, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 72a49fcb907c458db5471c9efdaf14cb, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -4816725795396207319, guid: 4a0032986a96f1848b7dfd28332e79f7, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Red.prefab.meta
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Red.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 01718d22969a4be7b58fd5e9185de033
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Yellow.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Yellow.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Medium_Yellow
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 7fdb8369247978541af436a6ffaec50e, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 8da44056ea4144cf91d93f9e92f2aca2, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 8771735074934591030, guid: 378509acf7c2f1f4185edd533b7b3d47, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Yellow.prefab.meta
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Medium_Yellow.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9f3c73382fc94fee81c78d04471ff46e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Pink.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Pink.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Pink
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 52f034323a2a0ee4bb8a81a364e23c8a, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: a7130bd560e84148ba65da5d24f96e18, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: -3554783601331016760, guid: cc23d3f964a1e5440aac3fe6a4ab92d1, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Pink.prefab.meta
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Pink.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cb00f76c73fd4dd2822d97947dcc97e1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Red.prefab
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Red.prefab
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5857144657511018994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1929803122595014453, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2377590028762114089, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Name
+      value: Slime_Red
+      objectReference: {fileID: 0}
+    - target: {fileID: 3857100333722271928, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 27c39e7f8732b61428e4aea8beb28063, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: stats
+      value: 
+      objectReference: {fileID: 11400000, guid: a7d9f5713f684e9088bab870f52f27c2, type: 2}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263738220208231591, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: resourceDrops.Array.data[0].dropRange.y
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 9165481713511291873, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 3889767076933404985, guid: f67999f43e6e3304d8c33d27330fe20e, type: 3}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecfc6fa2867da674c82b2413b109a473, type: 3}

--- a/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Red.prefab.meta
+++ b/Assets/Prefabs/Tasks/Enemies/Slime/Slime_Red.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 35a938056f7440f7b42b9b6f98ec5ce1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/MediumSlime_Blue.asset
+++ b/Assets/Resources/MediumSlime_Blue.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07b3f1b0013cbb546a76110fae216a33, type: 3}
+  m_Name: MediumSlime_Blue
+  m_EditorClassIdentifier: 
+  enemyName: Blue Slime
+  icon: {fileID: 7086287932117018057, guid: 40797916ff6958444a0f54dc5f1c5d2c, type: 3}
+  maxHealth: 15
+  experience: 10
+  defense: 0
+  damage: 2
+  moveSpeed: 5
+  attackSpeed: 1.1
+  attackRange: 1
+  visionRange: 6
+  assistRange: 10
+  wanderDistance: 3
+  projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Resources/MediumSlime_Blue.asset.meta
+++ b/Assets/Resources/MediumSlime_Blue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e511179ff6f4d75be9f5579a5025d04
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/MediumSlime_Green.asset
+++ b/Assets/Resources/MediumSlime_Green.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07b3f1b0013cbb546a76110fae216a33, type: 3}
+  m_Name: MediumSlime_Green
+  m_EditorClassIdentifier: 
+  enemyName: Green Slime
+  icon: {fileID: 5974850342220603758, guid: ed517c4b34720b145ae9a8a233b9963e, type: 3}
+  maxHealth: 15
+  experience: 10
+  defense: 0
+  damage: 2
+  moveSpeed: 5
+  attackSpeed: 1.1
+  attackRange: 1
+  visionRange: 6
+  assistRange: 10
+  wanderDistance: 3
+  projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Resources/MediumSlime_Green.asset.meta
+++ b/Assets/Resources/MediumSlime_Green.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c2cca794cc4431b951962c60f9dda6c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/MediumSlime_Pink.asset
+++ b/Assets/Resources/MediumSlime_Pink.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07b3f1b0013cbb546a76110fae216a33, type: 3}
+  m_Name: MediumSlime_Pink
+  m_EditorClassIdentifier: 
+  enemyName: Pink Slime
+  icon: {fileID: -4439855420470161935, guid: 160408a71ac3a6d42a642c19996e590f, type: 3}
+  maxHealth: 15
+  experience: 10
+  defense: 0
+  damage: 2
+  moveSpeed: 5
+  attackSpeed: 1.1
+  attackRange: 1
+  visionRange: 6
+  assistRange: 10
+  wanderDistance: 3
+  projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Resources/MediumSlime_Pink.asset.meta
+++ b/Assets/Resources/MediumSlime_Pink.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72ad984febee4da2a79ebcf25a3376dd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/MediumSlime_Red.asset
+++ b/Assets/Resources/MediumSlime_Red.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07b3f1b0013cbb546a76110fae216a33, type: 3}
+  m_Name: MediumSlime_Red
+  m_EditorClassIdentifier: 
+  enemyName: Red Slime
+  icon: {fileID: -4816725795396207319, guid: 4a0032986a96f1848b7dfd28332e79f7, type: 3}
+  maxHealth: 15
+  experience: 10
+  defense: 0
+  damage: 2
+  moveSpeed: 5
+  attackSpeed: 1.1
+  attackRange: 1
+  visionRange: 6
+  assistRange: 10
+  wanderDistance: 3
+  projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Resources/MediumSlime_Red.asset.meta
+++ b/Assets/Resources/MediumSlime_Red.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72a49fcb907c458db5471c9efdaf14cb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/MediumSlime_Yellow.asset
+++ b/Assets/Resources/MediumSlime_Yellow.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07b3f1b0013cbb546a76110fae216a33, type: 3}
+  m_Name: MediumSlime_Yellow
+  m_EditorClassIdentifier: 
+  enemyName: Yellow Slime
+  icon: {fileID: 8771735074934591030, guid: 378509acf7c2f1f4185edd533b7b3d47, type: 3}
+  maxHealth: 15
+  experience: 10
+  defense: 0
+  damage: 2
+  moveSpeed: 5
+  attackSpeed: 1.1
+  attackRange: 1
+  visionRange: 6
+  assistRange: 10
+  wanderDistance: 3
+  projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Resources/MediumSlime_Yellow.asset.meta
+++ b/Assets/Resources/MediumSlime_Yellow.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8da44056ea4144cf91d93f9e92f2aca2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/SmallSlime_Blue.asset
+++ b/Assets/Resources/SmallSlime_Blue.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07b3f1b0013cbb546a76110fae216a33, type: 3}
+  m_Name: SmallSlime_Blue
+  m_EditorClassIdentifier: 
+  enemyName: Blue Minislime
+  icon: {fileID: 43810669774899895, guid: f3a27f43c7070b1458586ed35bab3dfb, type: 3}
+  maxHealth: 10
+  experience: 10
+  defense: 0
+  damage: 1
+  moveSpeed: 3
+  attackSpeed: 1
+  attackRange: 1
+  visionRange: 5
+  assistRange: 8
+  wanderDistance: 2
+  projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Resources/SmallSlime_Blue.asset.meta
+++ b/Assets/Resources/SmallSlime_Blue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26835af928284989a60fa2e8c53227e2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/SmallSlime_Pink.asset
+++ b/Assets/Resources/SmallSlime_Pink.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07b3f1b0013cbb546a76110fae216a33, type: 3}
+  m_Name: SmallSlime_Pink
+  m_EditorClassIdentifier: 
+  enemyName: Pink Minislime
+  icon: {fileID: -3554783601331016760, guid: cc23d3f964a1e5440aac3fe6a4ab92d1, type: 3}
+  maxHealth: 10
+  experience: 10
+  defense: 0
+  damage: 1
+  moveSpeed: 3
+  attackSpeed: 1
+  attackRange: 1
+  visionRange: 5
+  assistRange: 8
+  wanderDistance: 2
+  projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Resources/SmallSlime_Pink.asset.meta
+++ b/Assets/Resources/SmallSlime_Pink.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7130bd560e84148ba65da5d24f96e18
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/SmallSlime_Red.asset
+++ b/Assets/Resources/SmallSlime_Red.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 07b3f1b0013cbb546a76110fae216a33, type: 3}
+  m_Name: SmallSlime_Red
+  m_EditorClassIdentifier: 
+  enemyName: Red Minislime
+  icon: {fileID: 3889767076933404985, guid: f67999f43e6e3304d8c33d27330fe20e, type: 3}
+  maxHealth: 10
+  experience: 10
+  defense: 0
+  damage: 1
+  moveSpeed: 3
+  attackSpeed: 1
+  attackRange: 1
+  visionRange: 5
+  assistRange: 8
+  wanderDistance: 2
+  projectilePrefab: {fileID: 5086888241769898753, guid: 16c7aba8affac87478feae7df4c5e22e, type: 3}

--- a/Assets/Resources/SmallSlime_Red.asset.meta
+++ b/Assets/Resources/SmallSlime_Red.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a7d9f5713f684e9088bab870f52f27c2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- create small slime prefabs for blue, pink, and red
- add medium slime prefabs for all colors
- add associated EnemyStats assets for every new slime

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68608ff1abe4832eaa89efbff3f0d677