### PR TITLE
Implement enemy order sorting on stats panel

### DIFF
--- a/Assets/Scripts/Enemies/EnemyStats.cs
+++ b/Assets/Scripts/Enemies/EnemyStats.cs
@@ -8,6 +8,7 @@ namespace TimelessEchoes.Enemies
     public class EnemyStats : ScriptableObject
     {
         public string enemyName;
+        [Tooltip("Lower numbers appear first in the stats panel")] public int displayOrder = 0;
         public Sprite icon;
         public int maxHealth = 10;
         public int experience = 10;

--- a/Assets/Scripts/UI/EnemyStatsPanelUI.cs
+++ b/Assets/Scripts/UI/EnemyStatsPanelUI.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
 using TimelessEchoes.References.StatPanel;
 using TimelessEchoes.Enemies;
 using TimelessEchoes.Stats;
@@ -41,7 +42,12 @@ namespace TimelessEchoes.UI
             foreach (Transform child in references.enemyEntryParent)
                 Destroy(child.gameObject);
 
-            foreach (var stats in Resources.LoadAll<EnemyStats>(""))
+            var allStats = Resources.LoadAll<EnemyStats>("");
+            var sorted = allStats
+                .OrderBy(s => s.displayOrder)
+                .ThenBy(s => s.enemyName);
+
+            foreach (var stats in sorted)
             {
                 var obj = Instantiate(references.enemyEntryPrefab.gameObject, references.enemyEntryParent);
                 var ui = obj.GetComponent<EnemyStatEntryUIReferences>();


### PR DESCRIPTION
## Summary
- add a `displayOrder` field to `EnemyStats` to allow ordering
- build stats panel UI using `displayOrder` then by `enemyName` so enemies appear in a consistent order

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860946de380832e9d07b33d18148989