### PR TITLE
Add encounter gating for enemy info

### DIFF
--- a/Assets/Scripts/References/StatPanel/EnemyStatEntryUIReferences.cs
+++ b/Assets/Scripts/References/StatPanel/EnemyStatEntryUIReferences.cs
@@ -8,6 +8,7 @@ namespace TimelessEchoes.References.StatPanel
     public class EnemyStatEntryUIReferences : MonoBehaviour
     {
         public Image enemyIconImage;
+        public TMP_Text enemyIDText;
         public TMP_Text enemyNameText;
         public TMP_Text hitpointsAndDamageText;
         public TMP_Text movementAndAttackRateText;

--- a/Assets/Scripts/UI/EnemyStatsPanelUI.cs
+++ b/Assets/Scripts/UI/EnemyStatsPanelUI.cs
@@ -95,12 +95,24 @@ namespace TimelessEchoes.UI
 
             if (ui.enemyIconImage != null)
             {
-                ui.enemyIconImage.sprite = stats.icon;
-                ui.enemyIconImage.enabled = stats.icon != null;
+                bool encountered = kills > 0;
+                Sprite sprite = encountered ? stats.icon : null;
+                ui.enemyIconImage.sprite = sprite;
+                if (sprite != null)
+                    ui.enemyIconImage.SetNativeSize();
+                ui.enemyIconImage.enabled = encountered && sprite != null;
             }
 
             if (ui.enemyNameText != null)
-                ui.enemyNameText.text = stats.enemyName;
+            {
+                if (kills > 0)
+                    ui.enemyNameText.text = stats.enemyName;
+                else
+                    ui.enemyNameText.text = "???";
+            }
+
+            if (ui.enemyIDText != null)
+                ui.enemyIDText.text = $"#{stats.displayOrder}";
 
             string hp = reveal >= 2 ? CalcUtils.FormatNumber(stats.maxHealth, true, 400f, false) : "???";
             string dmg = reveal >= 1 ? CalcUtils.FormatNumber(stats.damage, true, 400f, false) : "???";


### PR DESCRIPTION
## Summary
- add enemy ID text reference
- hide enemy name/icon until first kill
- display id number based on `displayOrder`
- set enemy icons to native size when displayed

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860a9795598832ebd43d20097ac2c04