### PR TITLE
Use shared tilemaps for procedural chunks

### DIFF
--- a/Assets/Scripts/MapGeneration/Chunks/ChunkManager.cs
+++ b/Assets/Scripts/MapGeneration/Chunks/ChunkManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using TimelessEchoes.Tasks;
+using UnityEngine.Tilemaps;
 using Unity.Cinemachine;
 using UnityEngine;
 
@@ -11,6 +12,11 @@ namespace TimelessEchoes.MapGeneration.Chunks
     public class ChunkManager : MonoBehaviour
     {
         [SerializeField] private ProceduralChunkGenerator chunkPrefab;
+        [Header("Tilemaps")]
+        [SerializeField] private Tilemap waterMap;
+        [SerializeField] private Tilemap sandMap;
+        [SerializeField] private Tilemap grassMap;
+        [SerializeField] private Tilemap decorationMap;
         [SerializeField] private TaskController taskController;
         [SerializeField] private CinemachineCamera camera;
         [SerializeField] private int chunkWidth = 64;
@@ -60,12 +66,22 @@ namespace TimelessEchoes.MapGeneration.Chunks
         private void SpawnChunk()
         {
             var chunk = Instantiate(chunkPrefab, new Vector3(nextX, 0f, 0f), Quaternion.identity, transform);
+            chunk.SetTilemaps(waterMap, sandMap, grassMap, decorationMap);
+            RemoveLocalTilemaps(chunk);
             chunk.Generate(taskController, lastSandDepth, lastGrassDepth);
             lastSandDepth = chunk.EndSandDepth;
             lastGrassDepth = chunk.EndGrassDepth;
             nextX += chunkWidth;
             chunks.Add(chunk);
             RelocateAndScan();
+        }
+
+        private void RemoveLocalTilemaps(ProceduralChunkGenerator chunk)
+        {
+            var maps = chunk.GetComponentsInChildren<Tilemap>();
+            foreach (var m in maps)
+                if (m != waterMap && m != sandMap && m != grassMap && m != decorationMap)
+                    Destroy(m.gameObject);
         }
 
         private void RelocateAndScan()

--- a/Assets/Scripts/MapGeneration/Chunks/ProceduralChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/Chunks/ProceduralChunkGenerator.cs
@@ -28,6 +28,14 @@ namespace TimelessEchoes.MapGeneration.Chunks
         [TabGroup("References"), SerializeField] private Tilemap grassMap;
         [TabGroup("References"), SerializeField] private Tilemap decorationMap;
 
+        public void SetTilemaps(Tilemap water, Tilemap sand, Tilemap grass, Tilemap decor)
+        {
+            waterMap = water;
+            sandMap = sand;
+            grassMap = grass;
+            decorationMap = decor;
+        }
+
         [Header("Tiles"), TabGroup("References")]
         [SerializeField] private TileBase waterTile;
         [TabGroup("References"), SerializeField] private TileBase sandRuleTile;
@@ -93,7 +101,7 @@ namespace TimelessEchoes.MapGeneration.Chunks
             controller = taskController;
             rng = randomizeSeed ? new System.Random() : new System.Random(seed);
 
-            Clear();
+            ClearSpawnedObjects();
             GenerateTerrain(startSandDepth, startGrassDepth);
             GenerateTasks();
         }


### PR DESCRIPTION
## Summary
- reference shared tilemaps from `ChunkManager`
- inject those tilemaps into `ProceduralChunkGenerator`
- remove temporary tilemaps from spawned chunks
- avoid clearing maps when generating chunks

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6860b3fc6910832ea938178910636d54