### PR TITLE
Remove entry and exit points from task controller

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -101,9 +101,7 @@ namespace TimelessEchoes.Hero
                 health.Init(hp);
             }
 
-            var start = taskController != null ? taskController.EntryPoint : null;
-            if (start != null)
-                transform.position = start.position;
+            // Hero no longer relocates to a task controller entry point
             if (animator != null)
             {
                 var stateInfo = animator.GetCurrentAnimatorStateInfo(0);

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -14,8 +14,6 @@ namespace TimelessEchoes.Tasks
     {
         [SerializeField] private List<MonoBehaviour> taskObjects = new();
 
-        [SerializeField] private Transform entryPoint;
-        [SerializeField] private Transform exitPoint;
 
         [SerializeField] private LayerMask enemyMask = ~0;
 
@@ -35,8 +33,6 @@ namespace TimelessEchoes.Tasks
         /// </summary>
         public IReadOnlyList<MonoBehaviour> TaskObjects => taskObjects;
 
-        public Transform EntryPoint => entryPoint;
-        public Transform ExitPoint => exitPoint;
         public AstarPath Pathfinder => astarPath;
         public CinemachineCamera MapCamera => mapCamera;
         public MonoBehaviour CurrentTaskObject => currentTaskObject;
@@ -175,7 +171,6 @@ namespace TimelessEchoes.Tasks
             }
 
             hero?.SetTask(null);
-            hero?.SetDestination(entryPoint);
             SelectEarliestTask();
         }
 
@@ -270,7 +265,6 @@ namespace TimelessEchoes.Tasks
             currentIndex = tasks.Count;
             Log("All tasks complete", this);
             currentTaskObject = null;
-            hero?.SetDestination(exitPoint);
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Timeless Echoes is an incremental hero management game built with Unity **6000.1
 
 ## Overview
 In this game you choose a hero who automatically runs through maps. Each run spawns a `Map` prefab which procedurally generates terrain and tasks.
-Your hero spawns at the entry point and the `TaskController` assigns the earliest unfinished task. The hero uses A* pathfinding to reach each task in order and moves to the exit once all are complete.
+Your hero spawns in the map and the `TaskController` assigns the earliest unfinished task. The hero uses A* pathfinding to reach each task in order.
 Map generation combines `TilemapChunkGenerator` and `ProceduralTaskGenerator`
 components so every run has a fresh layout and set of objectives.
 


### PR DESCRIPTION
## Summary
- clean up references to entry and exit points
- spawn hero without relocating to controller entry point
- update documentation

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860b41dd7b0832ea7f332c2912c5142