### PR TITLE
Revise chunk generation flow

### DIFF
--- a/Assets/Scripts/MapGeneration/Chunks/ProceduralChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/Chunks/ProceduralChunkGenerator.cs
@@ -134,6 +134,7 @@ namespace TimelessEchoes.MapGeneration.Chunks
         private int grassTopBuffer = 2;
 
         private readonly List<GameObject> generatedObjects = new();
+        private readonly List<ITask> runtimeTasks = new();
         private TaskController controller;
         private System.Random rng;
 
@@ -146,25 +147,38 @@ namespace TimelessEchoes.MapGeneration.Chunks
             rng = randomizeSeed ? new System.Random() : new System.Random(seed);
         }
 
-        public void Generate(TaskController taskController, int startSandDepth, int startGrassDepth)
+        public void SetTaskController(TaskController taskController)
         {
             controller = taskController;
-            rng = randomizeSeed ? new System.Random() : new System.Random(seed);
+        }
 
-            ClearSpawnedObjects();
-            GenerateTerrain(startSandDepth, startGrassDepth);
-            // The call to GenerateTasks is now immediate. The manager will wait
-            // for the physics to update AFTER this whole method is complete.
+        public void GenerateTiles(int startSandDepth, int startGrassDepth)
+        {
+            rng = randomizeSeed ? new System.Random() : new System.Random(seed);
+            BuildTerrain(startSandDepth, startGrassDepth);
+        }
+
+        public void SpawnTasks()
+        {
             GenerateTasks();
+        }
+
+        public void RemoveTasksFromController(TaskController taskController)
+        {
+            if (taskController == null) return;
+            foreach (var task in runtimeTasks)
+                taskController.RemoveTask(task);
+            runtimeTasks.Clear();
         }
 
         public void Clear()
         {
             ClearMaps();
+            RemoveTasksFromController(controller);
             ClearSpawnedObjects();
         }
 
-        private void GenerateTerrain(int startSandDepth, int startGrassDepth)
+        private void BuildTerrain(int startSandDepth, int startGrassDepth)
         {
             var sandDepths = new int[size.x];
             var grassDepths = new int[size.x];
@@ -320,7 +334,27 @@ namespace TimelessEchoes.MapGeneration.Chunks
 
             spawnedTasks.Sort((a, b) => a.x.CompareTo(b.x));
             foreach (var pair in spawnedTasks)
+            {
                 controller.AddRuntimeTaskObject(pair.obj);
+                var enemy = pair.obj.GetComponent<Enemy>();
+                if (enemy != null)
+                {
+                    var kill = pair.obj.GetComponent<KillEnemyTask>();
+                    if (kill != null)
+                        runtimeTasks.Add(kill);
+                    continue;
+                }
+
+                if (pair.obj is ITask direct)
+                {
+                    runtimeTasks.Add(direct);
+                    continue;
+                }
+
+                var compTask = pair.obj.GetComponent<ITask>();
+                if (compTask != null)
+                    runtimeTasks.Add(compTask);
+            }
         }
 
         private Vector3 RandomPositionAtX(float localX)
@@ -533,6 +567,7 @@ namespace TimelessEchoes.MapGeneration.Chunks
             }
 
             generatedObjects.Clear();
+            runtimeTasks.Clear();
         }
 
         [Serializable]


### PR DESCRIPTION
## Summary
- update `ChunkManager` logic to spawn new chunks when the hero reaches the middle of the middle chunk
- adjust chunk generation order so tiles are generated, then pathfinding rescanned before tasks are spawned
- remove tasks from the task controller when chunks are destroyed
- refactor `ProceduralChunkGenerator` to separate terrain generation from task spawning

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6860ca51c338832ea40e026c8eecaed5