### PR TITLE
Refine chunk spawn flow

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -124,6 +124,27 @@ namespace TimelessEchoes.Tasks
             }
         }
 
+        /// <summary>
+        /// Remove a task object and any tasks associated with it.
+        /// </summary>
+        public void RemoveTaskObject(MonoBehaviour obj)
+        {
+            if (obj == null)
+                return;
+
+            var toRemove = new List<ITask>();
+            foreach (var pair in taskMap)
+            {
+                if (pair.Value == obj)
+                    toRemove.Add(pair.Key);
+            }
+
+            foreach (var task in toRemove)
+                RemoveTask(task);
+
+            taskObjects.Remove(obj);
+        }
+
         public void ResetTasks()
         {
             AcquireHero();


### PR DESCRIPTION
## Summary
- add runtime task tracking and separate terrain/task generation
- detect hero reaching mid chunk to load a new chunk
- reposition grid before scanning
- clean up old chunk tasks when destroying
- expose method to remove a task object

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860ca51c338832ea40e026c8eecaed5