### PR TITLE
Adjust pathfinding updates and task order

### DIFF
--- a/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
+++ b/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
@@ -45,6 +45,8 @@ namespace TimelessEchoes.MapGeneration
         {
             for (var i = 0; i < 3; i++)
                 yield return StartCoroutine(CreateSegment());
+
+            MoveGraph();
         }
 
         private void Update()
@@ -109,7 +111,7 @@ namespace TimelessEchoes.MapGeneration
 
             var arr = segments.ToArray();
             var start = arr[1].startX;
-            gg.SetDimensions(segmentSize.x * 2, segmentSize.y, gg.nodeSize);
+            gg.SetDimensions(segmentSize.x * 4, segmentSize.y, gg.nodeSize);
             gg.center = new Vector3(start + segmentSize.x, 9f, 0f);
             pathfinder.Scan();
         }

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -122,6 +122,8 @@ namespace TimelessEchoes.Tasks
                 tasks.Add(compTask);
                 taskMap[compTask] = obj;
             }
+
+            SortTaskListsByX();
         }
 
         /// <summary>
@@ -190,6 +192,7 @@ namespace TimelessEchoes.Tasks
                     taskMap[compTask] = obj;
                 }
             }
+            SortTaskListsByX();
 
             hero?.SetTask(null);
             SelectEarliestTask();
@@ -330,6 +333,37 @@ namespace TimelessEchoes.Tasks
 
             if (index <= currentIndex)
                 currentIndex--;
+        }
+
+        private void SortTaskListsByX()
+        {
+            var pairs = new List<(float x, MonoBehaviour obj, ITask task)>();
+            foreach (var task in tasks)
+            {
+                MonoBehaviour obj = null;
+                taskMap.TryGetValue(task, out obj);
+                float x = 0f;
+                if (obj != null)
+                    x = obj.transform.position.x;
+                else if (task != null && task.Target != null)
+                    x = task.Target.position.x;
+                pairs.Add((x, obj, task));
+            }
+
+            pairs.Sort((a, b) => a.x.CompareTo(b.x));
+
+            tasks.Clear();
+            taskObjects.Clear();
+            taskMap.Clear();
+            foreach (var p in pairs)
+            {
+                tasks.Add(p.task);
+                if (p.obj != null)
+                {
+                    taskObjects.Add(p.obj);
+                    taskMap[p.task] = p.obj;
+                }
+            }
         }
 
         public void RemoveCompletedTasks()


### PR DESCRIPTION
## Summary
- initialize pathfinding grid after the first segments are created
- extend the pathfinding grid to cover the previous segment
- keep tasks sorted by their world X position

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860df20cf5c832e907b217df60965fa