### PR TITLE
Fix task list ordering when adding runtime tasks

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -106,6 +106,7 @@ namespace TimelessEchoes.Tasks
                 kill.target = enemy.transform;
                 tasks.Add(kill);
                 taskMap[kill] = obj;
+                SortTaskListsByX();
                 return;
             }
 
@@ -113,6 +114,7 @@ namespace TimelessEchoes.Tasks
             {
                 tasks.Add(existing);
                 taskMap[existing] = obj;
+                SortTaskListsByX();
                 return;
             }
 


### PR DESCRIPTION
## Summary
- ensure runtime task additions resort the TaskController

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860e0ebbab0832eb38946bee79f6753