### PR TITLE
Update task spawner to avoid water tiles

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -207,7 +207,8 @@ namespace TimelessEchoes.Tasks
                         break;
                     }
 
-                    var isObstructed = HasBlockingCollider(pos) || IsBlockedAhead(pos);
+                    var isWaterTile = !isWaterTask && IsWaterTile(pos);
+                    var isObstructed = HasBlockingCollider(pos) || IsBlockedAhead(pos) || isWaterTile;
                     var onWaterEdge = !isEnemy && allowWater &&
                                       Mathf.Abs(pos.y - waterPos.y) < otherTaskEdgeOffset;
 
@@ -339,6 +340,16 @@ namespace TimelessEchoes.Tasks
             var idx = Random.Range(0, validYs.Count);
             position = grassMap.GetCellCenterWorld(new Vector3Int(cell.x, validYs[idx], 0));
             return true;
+        }
+
+        private bool IsWaterTile(Vector3 worldPos)
+        {
+            EnsureTilemaps();
+            if (waterMap == null)
+                return false;
+
+            var cell = waterMap.WorldToCell(worldPos);
+            return waterMap.HasTile(cell);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- check the water tilemap directly when generating positions
- added helper `IsWaterTile` for tile queries
- prevent non-water tasks from spawning on water

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860e362420c832ead5a015b8cafb167