### PR TITLE
Maintain hero target during combat

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -28,6 +28,8 @@ namespace TimelessEchoes.Hero
         [SerializeField] private MonoBehaviour currentTaskObject;
         private readonly bool allowAttacks = true;
 
+        private Transform currentEnemy;
+
         private AIPath ai;
         private float attackSpeedBonus;
         private float baseAttackSpeed;
@@ -205,9 +207,18 @@ namespace TimelessEchoes.Hero
         {
             if (stats == null) return;
 
-            var nearest = FindNearestEnemy();
+            if (currentEnemy != null)
+            {
+                var hp = currentEnemy.GetComponent<Health>();
+                var dist = Vector2.Distance(transform.position, currentEnemy.position);
+                if (hp == null || hp.CurrentHealth <= 0f || dist > stats.visionRange)
+                    currentEnemy = null;
+            }
+
+            var nearest = currentEnemy != null ? currentEnemy : FindNearestEnemy();
             if (nearest != null)
             {
+                currentEnemy = nearest;
                 if (state == State.PerformingTask && CurrentTask != null) CurrentTask.OnInterrupt(this);
                 HandleCombat(nearest);
                 return;


### PR DESCRIPTION
## Summary
- stop hero from automatically switching to a closer enemy while in combat

## Testing
- `dotnet test` *(fails: command not found)*
- `nunit3-console` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e57cf6bc832e8ef663d9e82530ca