### PR TITLE
Add hero-driven distance UI update

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -6,6 +6,7 @@ using TimelessEchoes.Enemies;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.Upgrades;
 using TimelessEchoes.Stats;
+using TimelessEchoes.UI;
 using UnityEngine;
 using static TimelessEchoes.TELogger;
 
@@ -53,6 +54,7 @@ namespace TimelessEchoes.Hero
         private Vector2 lastMoveDir = Vector2.down;
         private float moveSpeedBonus;
         private AIDestinationSetter setter;
+        private MapUI mapUI;
 
         private State state;
 
@@ -71,6 +73,9 @@ namespace TimelessEchoes.Hero
             if (taskController == null)
                 taskController = GetComponentInParent<TaskController>();
 
+            if (mapUI == null)
+                mapUI = FindFirstObjectByType<MapUI>();
+
             state = State.Idle;
 
             ApplyStatUpgrades();
@@ -88,12 +93,17 @@ namespace TimelessEchoes.Hero
         {
             UpdateAnimation();
             UpdateBehavior();
+            if (mapUI != null)
+                mapUI.UpdateDistance(transform.position.x);
         }
 
         private void OnEnable()
         {
             if (taskController == null)
                 taskController = GetComponent<TaskController>();
+
+            if (mapUI == null)
+                mapUI = FindFirstObjectByType<MapUI>();
 
             ApplyStatUpgrades();
             if (stats != null)

--- a/Assets/Scripts/UI/MapUI.cs
+++ b/Assets/Scripts/UI/MapUI.cs
@@ -1,0 +1,24 @@
+using TMPro;
+using UnityEngine;
+
+namespace TimelessEchoes.UI
+{
+    /// <summary>
+    ///     Updates the map UI with the hero's distance travelled.
+    /// </summary>
+    public class MapUI : MonoBehaviour
+    {
+        [SerializeField] private TMP_Text distanceText;
+
+        /// <summary>
+        ///     Updates the UI with the distance the hero has travelled.
+        /// </summary>
+        /// <param name="distance">The hero's X position.</param>
+        public void UpdateDistance(float distance)
+        {
+            if (distanceText == null) return;
+            int x = Mathf.FloorToInt(distance);
+            distanceText.text = $"Distance travelled: {x}";
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -147,6 +147,9 @@ namespace TimelessEchoes.Upgrades
                 else
                     FloatingText.Spawn($"+{Mathf.FloorToInt((float)amount)}", slot.transform.position + Vector3.up, Color.white, 8f, transform);
             }
+
+            if (tooltip != null && tooltip.gameObject.activeSelf)
+                StartCoroutine(DelayedTooltipUpdate());
         }
 
         private void UpdateSlot(int index)
@@ -208,6 +211,13 @@ namespace TimelessEchoes.Upgrades
             yield return null; // wait one frame for layout groups to update
             if (slot != null)
                 FloatingText.Spawn($"+{Mathf.FloorToInt((float)amount)}", slot.transform.position + Vector3.up, Color.white, 8f, transform);
+        }
+
+        private IEnumerator DelayedTooltipUpdate()
+        {
+            yield return null;
+            if (selectedIndex >= 0 && tooltip != null && tooltip.gameObject.activeSelf)
+                ShowTooltip(selectedIndex);
         }
     }
 }


### PR DESCRIPTION
## Summary
- simplify `MapUI` to expose an `UpdateDistance` method
- have `HeroController` locate `MapUI` and update it each frame
- keep tooltip position correct after resources shift

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6860ea06a358832ea048849914325d2c