### PR TITLE
Fix decorative tile placement logic

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -88,6 +88,23 @@ namespace TimelessEchoes.MapGeneration
         public Tilemap GrassMap => grassMap;
         public Tilemap DecorationMap => decorationMap;
 
+        private static readonly Vector3Int[] NeighbourOffsets =
+        {
+            new(1, 0, 0), new(-1, 0, 0), new(0, 1, 0), new(0, -1, 0),
+            new(1, 1, 0), new(1, -1, 0), new(-1, 1, 0), new(-1, -1, 0)
+        };
+
+        private bool IsInnerTile(Tilemap map, Vector3Int position)
+        {
+            foreach (var offset in NeighbourOffsets)
+            {
+                if (!map.HasTile(position + offset))
+                    return false;
+            }
+
+            return true;
+        }
+
         private void Awake()
         {
             rng = randomizeSeed ? new Random() : new Random(seed);
@@ -173,7 +190,11 @@ namespace TimelessEchoes.MapGeneration
 
                     if (waterDecorativeTiles != null && waterDecorativeTiles.Length > 0 &&
                         rng.NextDouble() < waterDecorationDensity)
-                        PlaceDecorativeTile(new Vector3Int(offset.x + x, offset.y + y, 0), waterDecorativeTiles);
+                    {
+                        var pos = new Vector3Int(offset.x + x, offset.y + y, 0);
+                        if (IsInnerTile(waterMap, pos))
+                            PlaceDecorativeTile(pos, waterDecorativeTiles);
+                    }
                 }
 
                 for (var y = waterDepth + 1; y < waterDepth + sandDepth; y++)
@@ -209,7 +230,10 @@ namespace TimelessEchoes.MapGeneration
 
                     if (sandDecorativeTiles != null && sandDecorativeTiles.Length > 0 &&
                         rng.NextDouble() < sandDecorationDensity)
-                        PlaceDecorativeTile(pos, sandDecorativeTiles);
+                    {
+                        if (IsInnerTile(sandMap, pos))
+                            PlaceDecorativeTile(pos, sandDecorativeTiles);
+                    }
                 }
 
                 for (var y = waterDepth + sandDepth; y < waterDepth + sandDepth + grassDepth; y++)
@@ -232,7 +256,11 @@ namespace TimelessEchoes.MapGeneration
 
                     if (grassDecorativeTiles != null && grassDecorativeTiles.Length > 0 &&
                         rng.NextDouble() < grassDecorationDensity)
-                        PlaceDecorativeTile(new Vector3Int(offset.x + x, offset.y + y, 0), grassDecorativeTiles);
+                    {
+                        var pos = new Vector3Int(offset.x + x, offset.y + y, 0);
+                        if (IsInnerTile(grassMap, pos))
+                            PlaceDecorativeTile(pos, grassDecorativeTiles);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- ensure decorative tiles do not spawn on map edges or corners

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861d07b8fe8832e89c2f68399634622