### PR TITLE
Fix decor and task placement edges

### DIFF
--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -160,20 +160,18 @@ namespace TimelessEchoes.MapGeneration
                         : waterDepth;
 
                     var isCurrentTileSideEdge = y < leftWaterBottom || y < rightWaterBottom;
-                    var isWaterGroundLevel = y == 0;
                     var isTopEdge = y == waterDepth - 1;
-                    var isTileBelowGroundLevel = y - 1 == 0;
                     var isTileBelowSideEdge = y - 1 < leftWaterBottom || y - 1 < rightWaterBottom;
-                    var isTileBelowEdge = isTileBelowGroundLevel || isTileBelowSideEdge;
+                    var isTileBelowEdge = isTileBelowSideEdge;
 
-                    if (isCurrentTileSideEdge || isTileBelowEdge || isWaterGroundLevel || isTopEdge) continue;
+                    if (isCurrentTileSideEdge || isTileBelowEdge || isTopEdge) continue;
 
                     if (waterDecorativeTiles != null && waterDecorativeTiles.Length > 0 &&
                         rng.NextDouble() < waterDecorationDensity)
                         PlaceDecorativeTile(new Vector3Int(offset.x + x, offset.y + y, 0), waterDecorativeTiles);
                 }
 
-                for (var y = waterDepth + 1; y < waterDepth + sandDepth; y++)
+                for (var y = waterDepth; y < waterDepth + sandDepth; y++)
                 {
                     var leftWaterBottom = x > 0
                         ? segmentSize.y - sandDepths[x - 1] - grassDepths[x - 1]
@@ -191,14 +189,12 @@ namespace TimelessEchoes.MapGeneration
 
                     var isCurrentTileWaterEdge = y < leftWaterBottom || y < rightWaterBottom;
                     var isCurrentTileGrassEdge = y >= leftGrassBottom || y >= rightGrassBottom;
-                    var isSandGroundLevel = y == waterDepth;
                     var isTopEdge = y == waterDepth + sandDepth - 1;
-                    var isTileBelowGroundLevel = y - 1 == waterDepth;
                     var isTileBelowWaterEdge = y - 1 < leftWaterBottom || y - 1 < rightWaterBottom;
                     var isTileBelowGrassEdge = y - 1 >= leftGrassBottom || y - 1 >= rightGrassBottom;
-                    var isTileBelowEdge = isTileBelowGroundLevel || isTileBelowWaterEdge || isTileBelowGrassEdge;
+                    var isTileBelowEdge = isTileBelowWaterEdge || isTileBelowGrassEdge;
 
-                    if (isCurrentTileWaterEdge || isCurrentTileGrassEdge || isTileBelowEdge || isSandGroundLevel || isTopEdge)
+                    if (isCurrentTileWaterEdge || isCurrentTileGrassEdge || isTileBelowEdge || isTopEdge)
                         continue;
 
                     var pos = new Vector3Int(offset.x + x, offset.y + y, 0);
@@ -219,13 +215,11 @@ namespace TimelessEchoes.MapGeneration
                         : waterDepth + sandDepth;
 
                     var isCurrentTileSideEdge = y < leftGrassBottom || y < rightGrassBottom;
-                    var isGrassGroundLevel = y == waterDepth + sandDepth;
                     var isTopEdge = y == waterDepth + sandDepth + grassDepth - 1;
-                    var isTileBelowGroundLevel = y - 1 == waterDepth + sandDepth;
                     var isTileBelowSideEdge = y - 1 < leftGrassBottom || y - 1 < rightGrassBottom;
-                    var isTileBelowEdge = isTileBelowGroundLevel || isTileBelowSideEdge;
+                    var isTileBelowEdge = isTileBelowSideEdge;
 
-                    if (isCurrentTileSideEdge || isTileBelowEdge || isGrassGroundLevel || isTopEdge) continue;
+                    if (isCurrentTileSideEdge || isTileBelowEdge || isTopEdge) continue;
 
                     if (grassDecorativeTiles != null && grassDecorativeTiles.Length > 0 &&
                         rng.NextDouble() < grassDecorationDensity)

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -299,7 +299,11 @@ namespace TimelessEchoes.Tasks
                 var sand = terrainMap.GetTile(new Vector3Int(cell.x, y + 1, 0)) == sandTile;
                 if (water && sand)
                 {
-                    position = terrainMap.GetCellCenterWorld(new Vector3Int(cell.x, y, 0));
+                    var below = new Vector3Int(cell.x, y - 1, 0);
+                    if (y - 1 >= minY && terrainMap.GetTile(below) == waterTile)
+                        position = terrainMap.GetCellCenterWorld(below);
+                    else
+                        position = terrainMap.GetCellCenterWorld(new Vector3Int(cell.x, y, 0));
                     return true;
                 }
             }
@@ -344,13 +348,11 @@ namespace TimelessEchoes.Tasks
                 var above = terrainMap.GetTile(new Vector3Int(cell.x, y + 1, 0)) == grassTile;
 
                 var isCurrentTileSideEdge = !left || !right;
-                var isGrassGroundLevel = !below;
                 var isTopEdge = !above;
-                var isTileBelowGroundLevel = !below;
                 var isTileBelowSideEdge = !belowLeft || !belowRight;
-                var isTileBelowEdge = isTileBelowGroundLevel || isTileBelowSideEdge;
+                var isTileBelowEdge = isTileBelowSideEdge;
 
-                var isEdge = isCurrentTileSideEdge || isTileBelowEdge || isGrassGroundLevel || isTopEdge;
+                var isEdge = isCurrentTileSideEdge || isTileBelowEdge || isTopEdge;
                 if (!includeEdge && isEdge)
                     continue;
 


### PR DESCRIPTION
## Summary
- adjust decoration placement to allow bottom tiles and skip top tiles
- make water tasks spawn one tile below the surface
- update grass task edge detection to skip top tiles only

## Testing
- `mono --version`

------
https://chatgpt.com/codex/tasks/task_e_686244d7b588832e9a6c5e42ae104ff9