### PR TITLE
Add map generation config window

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using Pathfinding;
+using Sirenix.OdinInspector;
+using TimelessEchoes.Tasks;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+using VinTools.BetterRuleTiles;
+
+namespace TimelessEchoes.MapGeneration
+{
+    [CreateAssetMenu(menuName = "SO/Map Generation Config")]
+    public class MapGenerationConfig : ScriptableObject
+    {
+        public TilemapChunkSettings tilemapChunkSettings = new();
+        public ProceduralTaskSettings taskGeneratorSettings = new();
+        public SegmentedMapSettings segmentedMapSettings = new();
+
+        [Serializable]
+        public class TilemapChunkSettings
+        {
+            public Tilemap terrainMap;
+            public BetterRuleTile waterTile;
+            public BetterRuleTile sandRuleTile;
+            public BetterRuleTile grassRuleTile;
+
+            [Min(2)] public int minAreaWidth = 2;
+            [Min(0)] public int edgeWaviness = 1;
+
+            public Vector2Int sandDepthRange = new(2, 6);
+            public Vector2Int grassDepthRange = new(2, 6);
+
+            public int seed;
+            public bool randomizeSeed = true;
+        }
+
+        [Serializable]
+        public class ProceduralTaskSettings
+        {
+            public float minX;
+            public float maxX = 990f;
+            public float height = 18f;
+            public float density = 0.1f;
+
+            public LayerMask blockingMask;
+            [MinValue(0f)] public float otherTaskEdgeOffset = 1f;
+
+            public List<ProceduralTaskGenerator.WeightedSpawn> enemies = new();
+            public List<ProceduralTaskGenerator.WeightedSpawn> otherTasks = new();
+            public List<ProceduralTaskGenerator.WeightedSpawn> waterTasks = new();
+            public List<ProceduralTaskGenerator.WeightedSpawn> sandTasks = new();
+            public List<ProceduralTaskGenerator.WeightedSpawn> grassTasks = new();
+
+            [MinValue(0f)] public float minTaskDistance = 1.5f;
+
+            public Tilemap terrainMap;
+            public BetterRuleTile waterTile;
+            public BetterRuleTile sandTile;
+            public BetterRuleTile grassTile;
+        }
+
+        [Serializable]
+        public class SegmentedMapSettings
+        {
+            public Vector2Int segmentSize = new(64, 18);
+            public Transform segmentParent;
+            public AstarPath pathfinder;
+        }
+    }
+}

--- a/Assets/Scripts/MapGeneration/MapGenerationWindow.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationWindow.cs
@@ -1,0 +1,31 @@
+#if UNITY_EDITOR
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace TimelessEchoes.MapGeneration
+{
+    public class MapGenerationWindow : OdinMenuEditorWindow
+    {
+        [MenuItem("Tools/Map Generation Config")]
+        private static void Open()
+        {
+            GetWindow<MapGenerationWindow>().Show();
+        }
+
+        protected override OdinMenuTree BuildMenuTree()
+        {
+            var tree = new OdinMenuTree();
+            var guids = AssetDatabase.FindAssets("t:MapGenerationConfig");
+            foreach (var guid in guids)
+            {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                var asset = AssetDatabase.LoadAssetAtPath<MapGenerationConfig>(path);
+                if (asset != null)
+                    tree.Add(System.IO.Path.GetFileNameWithoutExtension(path), asset);
+            }
+            return tree;
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
+++ b/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
@@ -14,9 +14,12 @@ namespace TimelessEchoes.MapGeneration
     [RequireComponent(typeof(TaskController))]
     public class SegmentedMapGenerator : MonoBehaviour
     {
-        [SerializeField] private Vector2Int segmentSize = new(64, 18);
-        [SerializeField] private Transform segmentParent;
-        [SerializeField] private AstarPath pathfinder;
+        [SerializeField]
+        private MapGenerationConfig config;
+
+        [SerializeField] [HideInInspector] private Vector2Int segmentSize = new(64, 18);
+        [SerializeField] [HideInInspector] private Transform segmentParent;
+        [SerializeField] [HideInInspector] private AstarPath pathfinder;
 
         private TilemapChunkGenerator chunkGenerator;
         private ProceduralTaskGenerator taskGenerator;
@@ -37,8 +40,18 @@ namespace TimelessEchoes.MapGeneration
             chunkGenerator = GetComponent<TilemapChunkGenerator>();
             taskGenerator = GetComponent<ProceduralTaskGenerator>();
             controller = GetComponent<TaskController>();
+            ApplyConfig();
             if (segmentParent == null)
                 segmentParent = transform;
+        }
+
+        private void ApplyConfig()
+        {
+            if (config == null) return;
+
+            segmentSize = config.segmentedMapSettings.segmentSize;
+            segmentParent = config.segmentedMapSettings.segmentParent;
+            pathfinder = config.segmentedMapSettings.pathfinder;
         }
 
         private IEnumerator Start()

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -9,37 +9,50 @@ namespace TimelessEchoes.MapGeneration
 {
     public class TilemapChunkGenerator : MonoBehaviour
     {
+        [SerializeField]
+        private MapGenerationConfig config;
+
         [Header("Tilemaps")] [TabGroup("References")] [SerializeField]
+        [HideInInspector]
         private Tilemap terrainMap;
 
 
         [Header("Tiles")] [TabGroup("References")] [SerializeField]
+        [HideInInspector]
         private BetterRuleTile waterTile;
 
         [TabGroup("References")] [SerializeField]
+        [HideInInspector]
         private BetterRuleTile sandRuleTile;
 
         [TabGroup("References")] [SerializeField]
+        [HideInInspector]
         private BetterRuleTile grassRuleTile;
 
 
         [Header("Generation Settings")] [TabGroup("Settings")] [SerializeField] [Min(2)]
+        [HideInInspector]
         private int minAreaWidth = 2;
 
         [TabGroup("Settings")] [SerializeField] [Min(0)]
+        [HideInInspector]
         private int edgeWaviness = 1;
 
 
         [Header("Depth Ranges (Min, Max)")] [TabGroup("Settings")] [SerializeField]
+        [HideInInspector]
         private Vector2Int sandDepthRange = new(2, 6);
 
         [TabGroup("Settings")] [SerializeField]
+        [HideInInspector]
         private Vector2Int grassDepthRange = new(2, 6);
 
         [Header("Random Seed")] [TabGroup("Settings")] [SerializeField]
+        [HideInInspector]
         private int seed;
 
         [TabGroup("Settings")] [SerializeField]
+        [HideInInspector]
         private bool randomizeSeed = true;
 
         private Random rng;
@@ -52,9 +65,26 @@ namespace TimelessEchoes.MapGeneration
 
         private void Awake()
         {
+            ApplyConfig();
             rng = randomizeSeed ? new Random() : new Random(seed);
             prevSandDepth = -1;
             prevGrassDepth = -1;
+        }
+
+        private void ApplyConfig()
+        {
+            if (config == null) return;
+
+            terrainMap = config.tilemapChunkSettings.terrainMap;
+            waterTile = config.tilemapChunkSettings.waterTile;
+            sandRuleTile = config.tilemapChunkSettings.sandRuleTile;
+            grassRuleTile = config.tilemapChunkSettings.grassRuleTile;
+            minAreaWidth = config.tilemapChunkSettings.minAreaWidth;
+            edgeWaviness = config.tilemapChunkSettings.edgeWaviness;
+            sandDepthRange = config.tilemapChunkSettings.sandDepthRange;
+            grassDepthRange = config.tilemapChunkSettings.grassDepthRange;
+            seed = config.tilemapChunkSettings.seed;
+            randomizeSeed = config.tilemapChunkSettings.randomizeSeed;
         }
 
         public void GenerateSegment(Vector2Int offset, Vector2Int segmentSize)

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -17,52 +17,70 @@ namespace TimelessEchoes.Tasks
     [RequireComponent(typeof(TaskController))]
     public class ProceduralTaskGenerator : MonoBehaviour
     {
+        [SerializeField]
+        private MapGenerationConfig config;
         [TabGroup("Settings", "Area")] [SerializeField]
+        [HideInInspector]
         private float minX;
 
         [TabGroup("Settings", "Area")] [SerializeField]
+        [HideInInspector]
         private float maxX = 990f;
 
         [TabGroup("Settings", "Area")] [SerializeField]
+        [HideInInspector]
         private float height = 18f;
 
         [TabGroup("Settings", "Area")] [SerializeField]
+        [HideInInspector]
         private float density = 0.1f;
 
         [TabGroup("Settings", "Generation")] [SerializeField]
+        [HideInInspector]
         private LayerMask blockingMask;
 
         [TabGroup("Settings", "Generation")] [SerializeField] [MinValue(0)]
+        [HideInInspector]
         private float otherTaskEdgeOffset = 1f;
 
         [TabGroup("Settings", "Generation")] [SerializeField]
+        [HideInInspector]
         private List<WeightedSpawn> enemies = new();
 
         [TabGroup("Settings", "Generation")] [SerializeField]
+        [HideInInspector]
         private List<WeightedSpawn> otherTasks = new();
 
         [TabGroup("Settings", "Generation")] [SerializeField]
+        [HideInInspector]
         private List<WeightedSpawn> waterTasks = new();
 
         [TabGroup("Settings", "Generation")] [SerializeField]
+        [HideInInspector]
         private List<WeightedSpawn> sandTasks = new();
 
         [TabGroup("Settings", "Generation")] [SerializeField]
+        [HideInInspector]
         private List<WeightedSpawn> grassTasks = new();
 
         [TabGroup("Settings", "Generation")] [SerializeField] [MinValue(0f)]
+        [HideInInspector]
         private float minTaskDistance = 1.5f;
 
         [TabGroup("Settings", "References")] [SerializeField]
+        [HideInInspector]
         private Tilemap terrainMap;
 
         [TabGroup("Settings", "References")] [SerializeField]
+        [HideInInspector]
         private BetterRuleTile waterTile;
 
         [TabGroup("Settings", "References")] [SerializeField]
+        [HideInInspector]
         private BetterRuleTile sandTile;
 
         [TabGroup("Settings", "References")] [SerializeField]
+        [HideInInspector]
         private BetterRuleTile grassTile;
 
         private readonly List<GameObject> generatedObjects = new();
@@ -88,7 +106,30 @@ namespace TimelessEchoes.Tasks
         {
             if (controller == null)
                 controller = GetComponent<TaskController>();
+            ApplyConfig();
             EnsureTilemaps();
+        }
+
+        private void ApplyConfig()
+        {
+            if (config == null) return;
+
+            minX = config.taskGeneratorSettings.minX;
+            maxX = config.taskGeneratorSettings.maxX;
+            height = config.taskGeneratorSettings.height;
+            density = config.taskGeneratorSettings.density;
+            blockingMask = config.taskGeneratorSettings.blockingMask;
+            otherTaskEdgeOffset = config.taskGeneratorSettings.otherTaskEdgeOffset;
+            enemies = config.taskGeneratorSettings.enemies;
+            otherTasks = config.taskGeneratorSettings.otherTasks;
+            waterTasks = config.taskGeneratorSettings.waterTasks;
+            sandTasks = config.taskGeneratorSettings.sandTasks;
+            grassTasks = config.taskGeneratorSettings.grassTasks;
+            minTaskDistance = config.taskGeneratorSettings.minTaskDistance;
+            terrainMap = config.taskGeneratorSettings.terrainMap;
+            waterTile = config.taskGeneratorSettings.waterTile;
+            sandTile = config.taskGeneratorSettings.sandTile;
+            grassTile = config.taskGeneratorSettings.grassTile;
         }
 
         private void OnDrawGizmos()


### PR DESCRIPTION
## Summary
- hide generator fields with `HideInInspector`
- add `MapGenerationConfig` ScriptableObject for map settings
- create `MapGenerationWindow` for Odin-based editing
- load settings from config in generators

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686318c92fcc832ea73b9c4bff1a45be