### PR TITLE
Expose decor map on generator

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -16,6 +16,7 @@ namespace TimelessEchoes.MapGeneration
         public TilemapChunkSettings tilemapChunkSettings = new();
         public ProceduralTaskSettings taskGeneratorSettings = new();
         public SegmentedMapSettings segmentedMapSettings = new();
+        public DecorSettings decorSettings = new();
 
         [Serializable]
         public class TilemapChunkSettings
@@ -60,6 +61,13 @@ namespace TimelessEchoes.MapGeneration
         public class SegmentedMapSettings
         {
             public Vector2Int segmentSize = new(64, 18);
+        }
+
+        [Serializable]
+        public class DecorSettings
+        {
+            [HideInInspector] [TabGroup("Decor", "References")] public Tilemap decorMap;
+            [TabGroup("Decor", "Items")] public List<TilemapChunkGenerator.DecorEntry> decor = new();
         }
     }
 }

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -455,7 +455,11 @@ namespace TimelessEchoes.Tasks
             var right = terrainMap.GetTile(cell + Vector3Int.right) == tile;
             var up = terrainMap.GetTile(cell + Vector3Int.up) == tile;
             var down = terrainMap.GetTile(cell + Vector3Int.down) == tile;
-            return !(left && right && up && down);
+            var upLeft = terrainMap.GetTile(cell + Vector3Int.up + Vector3Int.left) == tile;
+            var upRight = terrainMap.GetTile(cell + Vector3Int.up + Vector3Int.right) == tile;
+            var downLeft = terrainMap.GetTile(cell + Vector3Int.down + Vector3Int.left) == tile;
+            var downRight = terrainMap.GetTile(cell + Vector3Int.down + Vector3Int.right) == tile;
+            return !(left && right && up && down && upLeft && upRight && downLeft && downRight);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- show `decorMap` field in TilemapChunkGenerator
- keep decor settings in MapGenerationConfig with decor list
- edge detection includes corners

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686340994030832ea44ed8c6ed72d399