### PR TITLE
Add decor list collapse and search

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -68,6 +68,8 @@ namespace TimelessEchoes.MapGeneration
         {
             [HideInInspector] [TabGroup("Decor", "References")] public Tilemap decorMap;
             [Range(0f, 1f)] public float density = 1f;
+            [Searchable]
+            [ListDrawerSettings(Expanded = false)]
             [TabGroup("Decor", "Items")] public List<TilemapChunkGenerator.DecorEntry> decor = new();
         }
     }

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -22,6 +22,8 @@ namespace TimelessEchoes.MapGeneration
         private Tilemap decorMap;
 
         [Serializable]
+        [InlineProperty]
+        [HideLabel]
         public class DecorEntry
         {
             [Required] public TileBase tile;
@@ -34,6 +36,22 @@ namespace TimelessEchoes.MapGeneration
             public bool spawnOnWater;
             public bool spawnOnSand;
             public bool spawnOnGrass;
+
+            [ShowInInspector]
+            [ReadOnly]
+            [LabelText("Areas")]
+            private string AreasDisplay
+            {
+                get
+                {
+                    string areas = string.Empty;
+                    if (spawnOnWater) areas += "Water ";
+                    if (spawnOnSand) areas += "Sand ";
+                    if (spawnOnGrass) areas += "Grass ";
+                    if (string.IsNullOrWhiteSpace(areas)) areas = "None";
+                    return areas.TrimEnd();
+                }
+            }
 
             public float GetWeight(float worldX)
             {


### PR DESCRIPTION
## Summary
- collapse decor entries with inline properties
- show terrain types for searchability
- allow searching decor list

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686349f3ad24832ea0ab74b49536aa62