### PR TITLE
Add milestone window support

### DIFF
--- a/Assets/Scripts/Skills/MilestoneBonus.cs
+++ b/Assets/Scripts/Skills/MilestoneBonus.cs
@@ -1,4 +1,6 @@
 using System;
+using Sirenix.OdinInspector;
+using UnityEngine;
 
 namespace TimelessEchoes.Skills
 {
@@ -18,10 +20,16 @@ namespace TimelessEchoes.Skills
         public string bonusID;
 
         public MilestoneType type;
-        [UnityEngine.Range(0f, 1f)] public float chance = 1f;
 
+        [Range(0f, 1f)]
+        [HideIf("type", MilestoneType.StatIncrease)]
+        public float chance = 1f;
+
+        [ShowIf("type", MilestoneType.StatIncrease)]
         public TimelessEchoes.Upgrades.StatUpgrade statUpgrade;
+        [ShowIf("type", MilestoneType.StatIncrease)]
         public bool percentBonus;
+        [ShowIf("type", MilestoneType.StatIncrease)]
         public float statAmount;
     }
 }

--- a/Assets/Scripts/Skills/MilestoneBonusUI.cs
+++ b/Assets/Scripts/Skills/MilestoneBonusUI.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -8,6 +7,7 @@ namespace TimelessEchoes.Skills
 {
     public class MilestoneBonusUI : MonoBehaviour
     {
+        [SerializeField] private GameObject window;
         [SerializeField] private Transform entryParent;
         [SerializeField] private GameObject entryPrefab;
         [SerializeField] private SkillController controller;
@@ -17,10 +17,26 @@ namespace TimelessEchoes.Skills
             entryParent = parent;
         }
 
+        public void OpenWindow()
+        {
+            if (window == null)
+                window = gameObject;
+            window.SetActive(true);
+        }
+
+        public void CloseWindow()
+        {
+            if (window == null)
+                window = gameObject;
+            window.SetActive(false);
+        }
+
         private void Awake()
         {
             if (controller == null)
                 controller = FindFirstObjectByType<SkillController>();
+            if (window == null)
+                window = gameObject;
         }
 
         public void PopulateMilestones(Skill skill)

--- a/Assets/Scripts/Skills/Skill.cs
+++ b/Assets/Scripts/Skills/Skill.cs
@@ -1,15 +1,17 @@
 using System.Collections.Generic;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace TimelessEchoes.Skills
 {
     [CreateAssetMenu(fileName = "Skill", menuName = "SO/Skill")]
-    public class Skill : ScriptableObject
+    public class Skill : SerializedScriptableObject
     {
         public string skillName;
         public Sprite skillIcon;
         public float xpForFirstLevel = 10f;
         public float xpLevelMultiplier = 1.5f;
+        [TableList]
         public List<MilestoneBonus> milestones = new();
     }
 }

--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -146,9 +146,8 @@ namespace TimelessEchoes.Skills
         {
             if (bonusUI != null && CurrentSkill != null)
             {
-                bonusUI.SetEntryParent(null);
                 bonusUI.PopulateMilestones(CurrentSkill);
-                bonusUI.gameObject.SetActive(true);
+                bonusUI.OpenWindow();
             }
         }
 


### PR DESCRIPTION
## Summary
- open milestone bonus window from SkillUIManager
- allow MilestoneBonusUI to control its own window
- enhance Skill & MilestoneBonus scriptable objects using Odin Inspector

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68638f3414c4832eaf330f02a8933559