### PR TITLE
Improve milestone descriptions

### DIFF
--- a/Assets/Scripts/Skills/MilestoneBonus.cs
+++ b/Assets/Scripts/Skills/MilestoneBonus.cs
@@ -31,5 +31,37 @@ namespace TimelessEchoes.Skills
         public bool percentBonus;
         [ShowIf("type", MilestoneType.StatIncrease)]
         public float statAmount;
+
+        /// <summary>
+        /// Returns the milestone description based on the configured settings
+        /// if <see cref="bonusDescription"/> is empty.
+        /// </summary>
+        /// <param name="skillName">Optional skill name for instant task bonuses.</param>
+        public string GetDescription(string skillName = null)
+        {
+            if (!string.IsNullOrWhiteSpace(bonusDescription))
+                return bonusDescription;
+
+            switch (type)
+            {
+                case MilestoneType.InstantTask:
+                    string taskLabel = string.IsNullOrWhiteSpace(skillName)
+                        ? "tasks"
+                        : $"{skillName.ToLowerInvariant()} tasks";
+                    return $"Provides a {chance * 100f:0.#}% chance to instantly complete {taskLabel}.";
+                case MilestoneType.DoubleResources:
+                    return $"Provides a {chance * 100f:0.#}% chance to double resources gained.";
+                case MilestoneType.DoubleXP:
+                    return $"Provides a {chance * 100f:0.#}% chance to gain double XP.";
+                case MilestoneType.StatIncrease:
+                    string statName = statUpgrade != null ? statUpgrade.name : "stat";
+                    string amountText = string.Empty;
+                    if (statAmount != 0f)
+                        amountText = percentBonus ? $" by {statAmount * 100f:0.#}%" : $" by {statAmount:0.#}";
+                    return $"Increases {statName}{amountText}.";
+                default:
+                    return string.Empty;
+            }
+        }
     }
 }

--- a/Assets/Scripts/Skills/MilestoneBonusUI.cs
+++ b/Assets/Scripts/Skills/MilestoneBonusUI.cs
@@ -68,17 +68,10 @@ namespace TimelessEchoes.Skills
                     if (refs.levelText != null)
                         refs.levelText.text = $"Lv {milestone.levelRequirement}";
 
-                    string desc = milestone.bonusDescription;
-                    if (milestone.type == MilestoneType.StatIncrease && milestone.statAmount != 0f)
-                    {
-                        if (milestone.percentBonus)
-                            desc += $" (+{milestone.statAmount * 100:0.#}%)";
-                        else
-                            desc += $" (+{milestone.statAmount:0.#})";
-                    }
-
+                    string desc = milestone.GetDescription(skill.skillName);
                     if (refs.descriptionText != null)
                         refs.descriptionText.text = desc;
+
                 }
 
                 var img = entry.GetComponentInChildren<Image>();

--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -140,6 +140,9 @@ namespace TimelessEchoes.Skills
                 popupPanel.SetActive(true);
             }
             UpdateSelectedSkillUI();
+
+            if (bonusUI != null && bonusUI.gameObject.activeSelf)
+                bonusUI.PopulateMilestones(CurrentSkill);
         }
 
         private void OpenBonuses()


### PR DESCRIPTION
## Summary
- generate milestone descriptions from settings when none provided
- simplify MilestoneBonusUI description logic
- refresh milestone window when selecting a new skill
- include skill name for instant task milestone description

## Testing
- `echo "No tests to run"`


------
https://chatgpt.com/codex/tasks/task_e_686391affdac832e87f1bf697091f0a2