### PR TITLE
Fix milestone bonus calculations and instant tasks

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -136,12 +136,13 @@ namespace TimelessEchoes.Hero
             {
                 if (upgrade == null) continue;
                 var baseVal = controller.GetBaseValue(upgrade);
-                var increase = controller.GetIncrease(upgrade);
-                if (skillController)
-                {
-                    increase += skillController.GetFlatStatBonus(upgrade);
-                    increase += baseVal * skillController.GetPercentStatBonus(upgrade);
-                }
+                var levelIncrease = controller.GetIncrease(upgrade);
+                var flatBonus = skillController ? skillController.GetFlatStatBonus(upgrade) : 0f;
+                var percentBonus = skillController ? skillController.GetPercentStatBonus(upgrade) : 0f;
+
+                var totalBeforePercent = baseVal + levelIncrease + flatBonus;
+                var finalValue = totalBeforePercent * (1f + percentBonus);
+                var increase = finalValue - baseVal;
                 switch (upgrade.name)
                 {
                     case "Health":

--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -36,6 +36,16 @@ namespace TimelessEchoes.Tasks
 
         public override void OnArrival(HeroController hero)
         {
+            if (ShouldInstantComplete())
+            {
+                hero.Animator.SetTrigger(InterruptTriggerName);
+                isComplete = true;
+                HideProgressBar();
+                GenerateDrops();
+                GrantCompletionXP();
+                return;
+            }
+
             hero.Animator.Play(AnimationName);
             ShowProgressBar();
         }

--- a/Assets/Scripts/Tasks/OpenChestTask.cs
+++ b/Assets/Scripts/Tasks/OpenChestTask.cs
@@ -33,6 +33,17 @@ namespace TimelessEchoes.Tasks
         {
             if (opened || isWaiting) return;
 
+            if (ShouldInstantComplete())
+            {
+                if (chestAnimator != null)
+                    chestAnimator.SetTrigger("Open");
+                GenerateDrops();
+                GrantCompletionXP();
+                opened = true;
+                isWaiting = false;
+                return;
+            }
+
             // Trigger the chest's own animation (e.g., lid opening)
             if (chestAnimator != null)
                 chestAnimator.SetTrigger("Open");

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -209,8 +209,12 @@ namespace TimelessEchoes.Upgrades
             var lvl = controller ? controller.GetLevel(upgrade) : 0;
             float flat = skillController ? skillController.GetFlatStatBonus(upgrade) : 0f;
             float percent = skillController ? skillController.GetPercentStatBonus(upgrade) : 0f;
-            var current = upgrade.baseValue + lvl * upgrade.statIncreasePerLevel + flat + upgrade.baseValue * percent;
-            var next = upgrade.baseValue + (lvl + 1) * upgrade.statIncreasePerLevel + flat + upgrade.baseValue * percent;
+
+            var baseCurrent = upgrade.baseValue + lvl * upgrade.statIncreasePerLevel + flat;
+            var current = baseCurrent * (1f + percent);
+
+            var baseNext = upgrade.baseValue + (lvl + 1) * upgrade.statIncreasePerLevel + flat;
+            var next = baseNext * (1f + percent);
             references.statUpgradeInfoText.text = $"{current:0.###} -> {next:0.###}";
         }
 


### PR DESCRIPTION
## Summary
- calculate milestone percentage bonuses after flat increases
- show updated stat values in the upgrade UI
- allow continuous tasks and chest tasks to instantly complete when the milestone succeeds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863a3a975b0832e9b41b960f430d9b8