### PR TITLE
Add automatic milestone bonus ID editor

### DIFF
--- a/Assets/Editor/SkillEditor.cs
+++ b/Assets/Editor/SkillEditor.cs
@@ -1,0 +1,37 @@
+#if UNITY_EDITOR
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+
+namespace TimelessEchoes.Skills
+{
+    [CustomEditor(typeof(Skill))]
+    public class SkillEditor : OdinEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            var skill = (Skill)target;
+            if (skill == null || skill.milestones == null)
+                return;
+
+            bool changed = false;
+            foreach (var milestone in skill.milestones)
+            {
+                if (milestone == null) continue;
+                string expected = $"{skill.skillName.ToLowerInvariant().Replace(" ", string.Empty)}{milestone.levelRequirement}";
+                if (milestone.bonusID != expected)
+                {
+                    milestone.bonusID = expected;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                EditorUtility.SetDirty(skill);
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add custom Odin editor `SkillEditor` that autofills milestone `bonusID`s based on the skill name and the level requirement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863b47a378c832eb7aa50164b339c54