### PR TITLE
Support stacked milestone rewards

### DIFF
--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -67,8 +67,11 @@ namespace TimelessEchoes.Tasks
             if (associatedSkill == null || xpGrantedOnCompletion <= 0f) return;
             var controller = FindFirstObjectByType<SkillController>();
             var amount = xpGrantedOnCompletion;
-            if (controller && controller.RollForEffect(associatedSkill, MilestoneType.DoubleXP))
-                amount *= 2f;
+            if (controller)
+            {
+                int mult = controller.GetEffectMultiplier(associatedSkill, MilestoneType.DoubleXP);
+                amount *= mult;
+            }
             controller?.AddExperience(associatedSkill, amount);
         }
     }

--- a/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
+++ b/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
@@ -35,8 +35,11 @@ namespace TimelessEchoes.Tasks
 
                 if (count > 0)
                 {
-                    if (skillController && skillController.RollForEffect(associatedSkill, TimelessEchoes.Skills.MilestoneType.DoubleResources))
-                        count *= 2;
+                    if (skillController)
+                    {
+                        int mult = skillController.GetEffectMultiplier(associatedSkill, TimelessEchoes.Skills.MilestoneType.DoubleResources);
+                        count *= mult;
+                    }
                     resourceManager.Add(drop.resource, count);
                 }
             }


### PR DESCRIPTION
## Summary
- add `GetEffectMultiplier` to `SkillController` for cumulative milestone chances
- use new multiplier for XP and resource rewards
- route boolean checks for doubled rewards through the new method

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863b9267574832eb55c1f46f26be16e