### PR TITLE
Fix hero deactivation order in CleanupMap

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -131,16 +131,18 @@ namespace TimelessEchoes
 
         private void CleanupMap()
         {
+            BuffManager.Instance?.Pause();
             if (mapCamera != null)
                 mapCamera.gameObject.SetActive(false);
+
+            if (hero != null) // deactivate AIPath first
+                hero.gameObject.SetActive(false);
+
             if (currentMap != null)
             {
-                Destroy(currentMap);
+                Destroy(currentMap); // safe to destroy AstarPath now
                 currentMap = null;
             }
-
-            if (hero != null)
-                hero.gameObject.SetActive(false);
         }
     }
 }


### PR DESCRIPTION
## Summary
- pause BuffManager when cleaning up the map
- deactivate the hero before destroying the map GameObject

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686476f24858832ea8863ee552bde6be