### PR TITLE
Sync buff timers with save data

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -85,12 +85,21 @@ namespace TimelessEchoes.Buffs
         private void TickBuffs(float delta)
         {
             if (delta <= 0f) return;
+            oracle.saveData.ActiveBuffs ??= new Dictionary<string, float>();
             for (var i = activeBuffs.Count - 1; i >= 0; i--)
             {
                 var buff = activeBuffs[i];
                 buff.remaining -= delta;
                 if (buff.remaining <= 0f)
+                {
                     activeBuffs.RemoveAt(i);
+                    if (buff.recipe != null)
+                        oracle.saveData.ActiveBuffs.Remove(buff.recipe.name);
+                }
+                else if (buff.recipe != null)
+                {
+                    oracle.saveData.ActiveBuffs[buff.recipe.name] = buff.remaining;
+                }
             }
         }
 
@@ -124,6 +133,10 @@ namespace TimelessEchoes.Buffs
                     extra *= diminishingCurve.Evaluate(buff.remaining);
                 buff.remaining += extra;
             }
+
+            oracle.saveData.ActiveBuffs ??= new Dictionary<string, float>();
+            if (recipe != null)
+                oracle.saveData.ActiveBuffs[recipe.name] = buff.remaining;
 
             return true;
         }

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -117,6 +117,7 @@ namespace TimelessEchoes.Hero
 
             if (buffController == null)
                 buffController = BuffManager.Instance ?? FindFirstObjectByType<TimelessEchoes.Buffs.BuffManager>();
+            buffController?.Resume();
 
             if (mapUI == null)
                 mapUI = FindFirstObjectByType<MapUI>();
@@ -141,6 +142,11 @@ namespace TimelessEchoes.Hero
             state = State.Idle;
             destinationOverride = false;
             lastAttack = Time.time - 1f / CurrentAttackRate;
+        }
+
+        private void OnDisable()
+        {
+            buffController?.Pause();
         }
 
         private void ApplyStatUpgrades()


### PR DESCRIPTION
## Summary
- resume BuffManager when hero becomes active
- pause BuffManager when hero is disabled
- sync buff timers to save data every tick and on purchase

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686490ce56f0832ea8517db90df8647e