### PR TITLE
Fix BuffUI refresh timing

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections;
 using References.UI;
 using TimelessEchoes.Upgrades;
 using UnityEngine;
@@ -167,6 +168,13 @@ namespace TimelessEchoes.Buffs
 
         private void OnLoadDataHandler()
         {
+            StartCoroutine(DeferredRefresh());
+        }
+
+        private IEnumerator DeferredRefresh()
+        {
+            // Wait one frame so BuffManager.LoadState has time to repopulate ActiveBuffs
+            yield return null;
             UpdateActiveIcons();
             OnInventoryChanged();
         }


### PR DESCRIPTION
## Summary
- ensure BuffUI waits until BuffManager loads buffs before refreshing icons

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686497a993e4832e81d5d2daaa864590