### PR TITLE
Disable buff purchase button without resources

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -163,7 +163,12 @@ namespace TimelessEchoes.Buffs
         private void OnInventoryChanged()
         {
             foreach (var pair in recipeEntries)
+            {
                 BuildCostSlots(pair.Value, pair.Key);
+                if (pair.Value.purchaseButton != null)
+                    pair.Value.purchaseButton.interactable =
+                        buffManager != null && buffManager.CanPurchase(pair.Key);
+            }
         }
 
         private void OnLoadDataHandler()


### PR DESCRIPTION
## Summary
- update `BuffUIManager` to toggle purchase button interactability based on `BuffManager.CanPurchase`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68649b6cea90832eb2c8b1f2c4300f41