### PR TITLE
Hide buff UI when no active buffs

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -198,8 +198,18 @@ namespace TimelessEchoes.Buffs
             iconEntries.Clear();
 
             var manager = buffManager;
-            if (activeBuffParent == null || activeBuffPrefab == null || manager == null)
+
+            if (activeBuffParent != null)
+            {
+                var hasBuffs = manager != null && manager.ActiveBuffs.Count > 0;
+                activeBuffParent.gameObject.SetActive(hasBuffs);
+                if (!hasBuffs || activeBuffPrefab == null || manager == null)
+                    return;
+            }
+            else if (activeBuffPrefab == null || manager == null)
+            {
                 return;
+            }
 
             foreach (var buff in manager.ActiveBuffs)
             {


### PR DESCRIPTION
## Summary
- hide the BuffUIManager's active buff parent GameObject when no buffs are active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864a283fd8c832e9f121fc9ef2aee89