### PR TITLE
Reset Animator triggers after tasks

### DIFF
--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -1,6 +1,7 @@
 using Blindsided.Utilities;
 using TimelessEchoes.Hero;
 using UnityEngine;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Tasks
 {
@@ -38,7 +39,7 @@ namespace TimelessEchoes.Tasks
         {
             if (ShouldInstantComplete())
             {
-                hero.Animator.SetTrigger(InterruptTriggerName);
+                AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, InterruptTriggerName);
                 isComplete = true;
                 HideProgressBar();
                 GenerateDrops();
@@ -57,7 +58,7 @@ namespace TimelessEchoes.Tasks
 
             if (timer >= taskDuration)
             {
-                hero.Animator.SetTrigger(InterruptTriggerName);
+                AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, InterruptTriggerName);
                 isComplete = true;
                 HideProgressBar();
                 GenerateDrops();
@@ -68,7 +69,7 @@ namespace TimelessEchoes.Tasks
 
         public override void OnInterrupt(HeroController hero)
         {
-            hero.Animator.SetTrigger(InterruptTriggerName);
+            AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, InterruptTriggerName);
             HideProgressBar();
         }
 

--- a/Assets/Scripts/Tasks/OpenChestTask.cs
+++ b/Assets/Scripts/Tasks/OpenChestTask.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using TimelessEchoes.Hero;
 using UnityEngine;
+using TimelessEchoes.Utilities;
 
 namespace TimelessEchoes.Tasks
 {
@@ -36,7 +37,7 @@ namespace TimelessEchoes.Tasks
             if (ShouldInstantComplete())
             {
                 if (chestAnimator != null)
-                    chestAnimator.SetTrigger("Open");
+                    AnimatorUtils.SetTriggerAndReset(this, chestAnimator, "Open");
                 GenerateDrops();
                 GrantCompletionXP();
                 opened = true;
@@ -46,7 +47,7 @@ namespace TimelessEchoes.Tasks
 
             // Trigger the chest's own animation (e.g., lid opening)
             if (chestAnimator != null)
-                chestAnimator.SetTrigger("Open");
+                AnimatorUtils.SetTriggerAndReset(this, chestAnimator, "Open");
 
             // Start the delay coroutine
             hero.StartCoroutine(DelayedLoot());

--- a/Assets/Scripts/Utilities/AnimatorUtils.cs
+++ b/Assets/Scripts/Utilities/AnimatorUtils.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using UnityEngine;
+
+namespace TimelessEchoes.Utilities
+{
+    /// <summary>
+    /// Utility helpers for working with Animator triggers.
+    /// </summary>
+    public static class AnimatorUtils
+    {
+        /// <summary>
+        /// Sets a trigger and resets it on the next frame to ensure it does not remain active.
+        /// </summary>
+        public static void SetTriggerAndReset(MonoBehaviour runner, Animator animator, string triggerName)
+        {
+            if (runner == null || animator == null || string.IsNullOrEmpty(triggerName))
+                return;
+            animator.SetTrigger(triggerName);
+            runner.StartCoroutine(ResetNextFrame(animator, triggerName));
+        }
+
+        private static IEnumerator ResetNextFrame(Animator animator, string triggerName)
+        {
+            yield return null;
+            animator.ResetTrigger(triggerName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add AnimatorUtils helper to reset animator triggers
- use AnimatorUtils for ContinuousTask trigger handling
- use AnimatorUtils for OpenChestTask trigger handling

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b12c4e64832ea7522b67711a1074