### PR TITLE
Add NPC-based object toggling

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -8,6 +8,7 @@ using TimelessEchoes.Buffs;
 using Unity.Cinemachine;
 using UnityEngine;
 using UnityEngine.UI;
+using TimelessEchoes.NPC;
 
 namespace TimelessEchoes
 {
@@ -31,6 +32,7 @@ namespace TimelessEchoes
         private HeroController hero;
         private CinemachineCamera mapCamera;
         private TaskController taskController;
+        [SerializeField] private NpcObjectStateController npcObjectStateController;
 
         private void Awake()
         {
@@ -38,12 +40,15 @@ namespace TimelessEchoes
                 startRunButton.onClick.AddListener(StartRun);
             if (returnToTavernButton != null)
                 returnToTavernButton.onClick.AddListener(ReturnToTavern);
+            if (npcObjectStateController == null)
+                npcObjectStateController = FindFirstObjectByType<NpcObjectStateController>();
         }
 
         private void Start()
         {
             tavernUI?.SetActive(true);
             mapUI?.SetActive(false);
+            npcObjectStateController?.UpdateObjectStates();
         }
 
         private void HideTooltip()
@@ -105,6 +110,7 @@ namespace TimelessEchoes
 
             tavernUI?.SetActive(false);
             mapUI?.SetActive(true);
+            npcObjectStateController?.UpdateObjectStates();
         }
 
         private void OnHeroDeath()
@@ -127,6 +133,7 @@ namespace TimelessEchoes
                 tavernCamera.gameObject.SetActive(true);
             tavernUI?.SetActive(true);
             mapUI?.SetActive(false);
+            npcObjectStateController?.UpdateObjectStates();
         }
 
         private void CleanupMap()

--- a/Assets/Scripts/NPC/NpcObjectStateController.cs
+++ b/Assets/Scripts/NPC/NpcObjectStateController.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using Blindsided;
+using Blindsided.SaveData;
+using UnityEngine;
+
+namespace TimelessEchoes.NPC
+{
+    /// <summary>
+    /// Enables or disables objects based on whether specific NPCs have been met.
+    /// </summary>
+    public class NpcObjectStateController : MonoBehaviour
+    {
+        [System.Serializable]
+        public class Entry
+        {
+            public string npcId;
+            public List<GameObject> disableUntilMet = new();
+            public List<GameObject> enableUntilMet = new();
+        }
+
+        [SerializeField]
+        private List<Entry> entries = new();
+
+        private void OnEnable()
+        {
+            EventHandler.OnLoadData += UpdateObjectStates;
+        }
+
+        private void OnDisable()
+        {
+            EventHandler.OnLoadData -= UpdateObjectStates;
+        }
+
+        private void Start()
+        {
+            UpdateObjectStates();
+        }
+
+        /// <summary>
+        /// Iterates over all entries and updates the active state of their objects.
+        /// </summary>
+        public void UpdateObjectStates()
+        {
+            foreach (var entry in entries)
+            {
+                if (entry == null) continue;
+                bool met = !string.IsNullOrEmpty(entry.npcId) &&
+                           StaticReferences.CompletedNpcTasks.Contains(entry.npcId);
+                foreach (var obj in entry.disableUntilMet)
+                    if (obj != null)
+                        obj.SetActive(met);
+                foreach (var obj in entry.enableUntilMet)
+                    if (obj != null)
+                        obj.SetActive(!met);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable/disable objects when NPCs are met
- hook into GameManager to update on game start and run changes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b6491960832ea890fbab9288fe2a