### PR TITLE
Add Game Data Manager window

### DIFF
--- a/Assets/Editor/GameDataManager.cs
+++ b/Assets/Editor/GameDataManager.cs
@@ -1,0 +1,37 @@
+#if UNITY_EDITOR
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+using TimelessEchoes.Skills;
+using TimelessEchoes.Upgrades;
+using TimelessEchoes.Buffs;
+using TimelessEchoes.Hero;
+using TimelessEchoes.Enemies;
+
+namespace TimelessEchoes.Editor
+{
+    public class GameDataManager : OdinMenuEditorWindow
+    {
+        [MenuItem("Tools/Game Data Manager")]
+        private static void Open()
+        {
+            GetWindow<GameDataManager>();
+        }
+
+        protected override OdinMenuTree BuildMenuTree()
+        {
+            var tree = new OdinMenuTree();
+            tree.AddAllAssetsAtPath("Skills", "Assets", typeof(Skill), true);
+            tree.AddAllAssetsAtPath("Stat Upgrades", "Assets", typeof(StatUpgrade), true);
+            tree.AddAllAssetsAtPath("Resources", "Assets", typeof(Resource), true);
+            tree.AddAllAssetsAtPath("Buff Recipes", "Assets", typeof(BuffRecipe), true);
+            tree.AddAllAssetsAtPath("Hero Stats", "Assets", typeof(HeroStats), true);
+            tree.AddAllAssetsAtPath("Enemy Stats", "Assets", typeof(EnemyStats), true);
+
+            tree.Config.DrawSearchToolbar = true;
+            tree.Config.SearchToolbarHeight = 20;
+
+            return tree;
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/Skills/Skill.cs
+++ b/Assets/Scripts/Skills/Skill.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
 using Sirenix.OdinInspector;
+using Blindsided.Utilities;
 using UnityEngine;
 
 namespace TimelessEchoes.Skills
 {
+    [ManageableData]
     [CreateAssetMenu(fileName = "Skill", menuName = "SO/Skill")]
     public class Skill : SerializedScriptableObject
     {


### PR DESCRIPTION
## Summary
- add `GameDataManager` editor window for centralized ScriptableObject editing
- tag `Skill` with `ManageableData` so it shows in existing `DataManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864bbe4e9f0832e9e89e91c6de45237