### PR TITLE
Fix sand task spawn depth

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -432,16 +432,16 @@ namespace TimelessEchoes.Tasks
                 if (terrainMap.GetTile(new Vector3Int(cell.x, y + 1, 0)) == sandTile)
                     continue;
 
-                var candidateY = y - 1;
-                if (candidateY < minY)
-                    continue;
-                if (terrainMap.GetTile(new Vector3Int(cell.x, candidateY, 0)) != sandTile)
-                    continue;
+                for (var candidateY = y - 1; candidateY >= minY; candidateY--)
+                {
+                    if (terrainMap.GetTile(new Vector3Int(cell.x, candidateY, 0)) != sandTile)
+                        break;
 
-                if (IsEdge(new Vector3Int(cell.x, candidateY, 0), sandTile))
-                    continue;
+                    if (IsEdge(new Vector3Int(cell.x, candidateY, 0), sandTile))
+                        continue;
 
-                validYs.Add(candidateY);
+                    validYs.Add(candidateY);
+                }
             }
 
             if (validYs.Count == 0)


### PR DESCRIPTION
## Summary
- allow ProceduralTaskGenerator to choose a random sand tile below the surface rather than always the highest one

## Testing
- `git diff --cached --stat`
- `grep -R "CinemachineVirtualCamera" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_6864c71d2258832ea80dea68ab58c0f8