### PR TITLE
Implement General stats UI panel

### DIFF
--- a/Assets/Scripts/References/StatPanel/GeneralStatsUIReferences.cs
+++ b/Assets/Scripts/References/StatPanel/GeneralStatsUIReferences.cs
@@ -1,0 +1,14 @@
+using TMPro;
+using UnityEngine;
+
+namespace TimelessEchoes.References.StatPanel
+{
+    /// <summary>
+    ///     Holds references to TMP_Text objects used by the General stats panel.
+    /// </summary>
+    public class GeneralStatsUIReferences : MonoBehaviour
+    {
+        public TMP_Text distanceLongestTasksText;
+        public TMP_Text killsDamageDeathsText;
+    }
+}

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -20,6 +20,14 @@ namespace TimelessEchoes.Stats
         private float damageDealt;
         private float damageTaken;
 
+        public float DistanceTravelled => distanceTravelled;
+        public float HighestDistance => highestDistance;
+        public int TotalKills => totalKills;
+        public int TasksCompleted => tasksCompleted;
+        public int Deaths => deaths;
+        public float DamageDealt => damageDealt;
+        public float DamageTaken => damageTaken;
+
         private Vector3 lastHeroPos;
         private static Dictionary<string, Resource> lookup;
         private static Dictionary<string, TaskData> taskLookup;

--- a/Assets/Scripts/UI/GeneralStatsPanelUI.cs
+++ b/Assets/Scripts/UI/GeneralStatsPanelUI.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using TimelessEchoes.References.StatPanel;
+using TimelessEchoes.Stats;
+using Blindsided.Utilities;
+
+namespace TimelessEchoes.UI
+{
+    public class GeneralStatsPanelUI : MonoBehaviour
+    {
+        [SerializeField] private GeneralStatsUIReferences references;
+        [SerializeField] private GameplayStatTracker statTracker;
+
+        private void Awake()
+        {
+            if (references == null)
+                references = GetComponent<GeneralStatsUIReferences>();
+            if (statTracker == null)
+                statTracker = FindFirstObjectByType<GameplayStatTracker>();
+        }
+
+        private void OnEnable()
+        {
+            UpdateTexts();
+        }
+
+        private void Update()
+        {
+            UpdateTexts();
+        }
+
+        private void UpdateTexts()
+        {
+            if (references == null || statTracker == null) return;
+
+            if (references.distanceLongestTasksText != null)
+            {
+                string dist = CalcUtils.FormatNumber(statTracker.DistanceTravelled, true, 400f, false);
+                string longest = CalcUtils.FormatNumber(statTracker.HighestDistance, true, 400f, false);
+                string tasks = CalcUtils.FormatNumber(statTracker.TasksCompleted, true, 400f, false);
+                references.distanceLongestTasksText.text = $"Distance Travelled: {dist}\nLongest Run: {longest}\nTasks Completed: {tasks}";
+            }
+
+            if (references.killsDamageDeathsText != null)
+            {
+                string kills = CalcUtils.FormatNumber(statTracker.TotalKills, true, 400f, false);
+                string dealt = CalcUtils.FormatNumber(statTracker.DamageDealt, true, 400f, false);
+                string deaths = CalcUtils.FormatNumber(statTracker.Deaths, true, 400f, false);
+                string taken = CalcUtils.FormatNumber(statTracker.DamageTaken, true, 400f, false);
+                references.killsDamageDeathsText.text = $"Kills: {kills}\nDamage Dealt: {dealt}\nDeaths: {deaths}\nDamage Taken: {taken}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add GeneralStatsUIReferences and GeneralStatsPanelUI
- expose general stat getters in GameplayStatTracker

## Testing
- `mcs Assets/Scripts/UI/GeneralStatsPanelUI.cs -r:/usr/lib/mono/4.5/UnityEngine.dll -r:/usr/lib/mono/4.5/mscorlib.dll` *(fails: `UnityEngine.dll` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865128c9730832e841cc7926fea3278