### PR TITLE
Track total resources gathered

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -103,6 +103,7 @@ namespace Blindsided.SaveData
             public int Deaths;
             public float DamageDealt;
             public float DamageTaken;
+            public double TotalResourcesGathered;
         }
 
 

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -19,6 +19,7 @@ namespace TimelessEchoes.Stats
         private int deaths;
         private float damageDealt;
         private float damageTaken;
+        private double totalResourcesGathered;
 
         public float DistanceTravelled => distanceTravelled;
         public float HighestDistance => highestDistance;
@@ -27,6 +28,7 @@ namespace TimelessEchoes.Stats
         public int Deaths => deaths;
         public float DamageDealt => damageDealt;
         public float DamageTaken => damageTaken;
+        public double TotalResourcesGathered => totalResourcesGathered;
 
         private Vector3 lastHeroPos;
         private static Dictionary<string, Resource> lookup;
@@ -85,6 +87,7 @@ namespace TimelessEchoes.Stats
             g.Deaths = deaths;
             g.DamageDealt = damageDealt;
             g.DamageTaken = damageTaken;
+            g.TotalResourcesGathered = totalResourcesGathered;
             oracle.saveData.General = g;
         }
 
@@ -110,6 +113,7 @@ namespace TimelessEchoes.Stats
             deaths = g.Deaths;
             damageDealt = g.DamageDealt;
             damageTaken = g.DamageTaken;
+            totalResourcesGathered = g.TotalResourcesGathered;
         }
 
         public void RegisterTaskComplete(TaskData data, float duration, float xp)
@@ -170,6 +174,11 @@ namespace TimelessEchoes.Stats
         public void AddDamageTaken(float amount)
         {
             if (amount > 0f) damageTaken += amount;
+        }
+
+        public void AddResources(double amount)
+        {
+            if (amount > 0) totalResourcesGathered += amount;
         }
     }
 }

--- a/Assets/Scripts/UI/GeneralStatsPanelUI.cs
+++ b/Assets/Scripts/UI/GeneralStatsPanelUI.cs
@@ -37,7 +37,9 @@ namespace TimelessEchoes.UI
                 string dist = CalcUtils.FormatNumber(statTracker.DistanceTravelled, true, 400f, false);
                 string longest = CalcUtils.FormatNumber(statTracker.HighestDistance, true, 400f, false);
                 string tasks = CalcUtils.FormatNumber(statTracker.TasksCompleted, true, 400f, false);
-                references.distanceLongestTasksText.text = $"Distance Travelled: {dist}\nLongest Run: {longest}\nTasks Completed: {tasks}";
+                string resources = CalcUtils.FormatNumber(statTracker.TotalResourcesGathered, true, 400f, false);
+                references.distanceLongestTasksText.text =
+                    $"Distance Travelled: {dist}\nLongest Run: {longest}\nTasks Completed: {tasks}\nResources Gathered: {resources}";
             }
 
             if (references.killsDamageDeathsText != null)

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -77,6 +77,8 @@ namespace TimelessEchoes.Upgrades
             else
                 amounts[resource] = amount;
             resource.totalReceived += Mathf.RoundToInt((float)amount);
+            var tracker = FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
+            tracker?.AddResources(amount);
             OnResourceAdded?.Invoke(resource, amount);
             InvokeInventoryChanged();
         }


### PR DESCRIPTION
## Summary
- track total resources gathered in `GameplayStatTracker`
- save/load new stat in `GameData`
- increment stat from `ResourceManager`
- show resources gathered in general stats panel

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651a032a08832e94e322be0560e055