### PR TITLE
Add persistent run distance tracking

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -104,6 +104,12 @@ namespace Blindsided.SaveData
             public float DamageDealt;
             public float DamageTaken;
             public double TotalResourcesGathered;
+
+            // Distances recorded for the most recent runs. Limited to the last 50.
+            public List<float> RecentRunDistances = new();
+            public float LongestRun;
+            public float ShortestRun;
+            public float AverageRun;
         }
 
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -123,7 +123,11 @@ namespace TimelessEchoes
             }
 
             var tracker = FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
-            tracker?.AddDeath();
+            if (tracker != null)
+            {
+                tracker.AddDeath();
+                tracker.EndRun();
+            }
 
             StartRun();
         }
@@ -131,6 +135,8 @@ namespace TimelessEchoes
         private void ReturnToTavern()
         {
             HideTooltip();
+            var tracker = FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
+            tracker?.EndRun();
             CleanupMap();
             if (tavernCamera != null)
                 tavernCamera.gameObject.SetActive(true);

--- a/Assets/Scripts/UI/GeneralStatsPanelUI.cs
+++ b/Assets/Scripts/UI/GeneralStatsPanelUI.cs
@@ -35,11 +35,13 @@ namespace TimelessEchoes.UI
             if (references.distanceLongestTasksText != null)
             {
                 string dist = CalcUtils.FormatNumber(statTracker.DistanceTravelled, true, 400f, false);
-                string longest = CalcUtils.FormatNumber(statTracker.HighestDistance, true, 400f, false);
+                string longest = CalcUtils.FormatNumber(statTracker.LongestRun, true, 400f, false);
+                string shortest = CalcUtils.FormatNumber(statTracker.ShortestRun, true, 400f, false);
+                string average = CalcUtils.FormatNumber(statTracker.AverageRun, true, 400f, false);
                 string tasks = CalcUtils.FormatNumber(statTracker.TasksCompleted, true, 400f, false);
                 string resources = CalcUtils.FormatNumber(statTracker.TotalResourcesGathered, true, 400f, false);
                 references.distanceLongestTasksText.text =
-                    $"Distance Travelled: {dist}\nLongest Run: {longest}\nTasks Completed: {tasks}\nResources Gathered: {resources}";
+                    $"Distance Travelled: {dist}\nLongest Run: {longest}\nShortest Run: {shortest}\nAverage Run: {average}\nTasks Completed: {tasks}\nResources Gathered: {resources}";
             }
 
             if (references.killsDamageDeathsText != null)


### PR DESCRIPTION
## Summary
- track the last 50 run distances in `GeneralStats`
- compute longest, shortest and average run
- update `GameplayStatTracker` to manage run history
- mark run end in `GameManager`
- display new run stats in the General Stats panel

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652494b830832e98769138df163b31