### PR TITLE
Implement detailed run stats UI improvements

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -94,6 +94,18 @@ namespace Blindsided.SaveData
         }
 
         [HideReferenceObjectPicker]
+        public class RunRecord
+        {
+            public float Distance;
+            public int TasksCompleted;
+            public double ResourcesCollected;
+            public int EnemiesKilled;
+            public float DamageDealt;
+            public float DamageTaken;
+            public bool Died;
+        }
+
+        [HideReferenceObjectPicker]
         public class GeneralStats
         {
             public float DistanceTravelled;
@@ -105,8 +117,8 @@ namespace Blindsided.SaveData
             public float DamageTaken;
             public double TotalResourcesGathered;
 
-            // Distances recorded for the most recent runs. Limited to the last 50.
-            public List<float> RecentRunDistances = new();
+            // Records for the most recent runs. Limited to the last 50.
+            public List<RunRecord> RecentRuns = new();
             public float LongestRun;
             public float ShortestRun;
             public float AverageRun;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -126,7 +126,7 @@ namespace TimelessEchoes
             if (tracker != null)
             {
                 tracker.AddDeath();
-                tracker.EndRun();
+                tracker.EndRun(true);
             }
 
             StartRun();
@@ -136,7 +136,7 @@ namespace TimelessEchoes
         {
             HideTooltip();
             var tracker = FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
-            tracker?.EndRun();
+            tracker?.EndRun(false);
             CleanupMap();
             if (tavernCamera != null)
                 tavernCamera.gameObject.SetActive(true);

--- a/Assets/Scripts/UI/RunBarUI.cs
+++ b/Assets/Scripts/UI/RunBarUI.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TimelessEchoes.UI
+{
+    /// <summary>
+    /// Controls a single run bar by setting the fill amount on an Image.
+    /// </summary>
+    public class RunBarUI : MonoBehaviour
+    {
+        [SerializeField] private Image fillImage;
+
+        /// <summary>
+        /// Sets the bar fill based on a 0-1 ratio.
+        /// </summary>
+        /// <param name="ratio">Fill ratio from 0 to 1.</param>
+        public void SetFill(float ratio)
+        {
+            if (fillImage != null)
+                fillImage.fillAmount = Mathf.Clamp01(ratio);
+        }
+    }
+}

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -1,0 +1,74 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using Blindsided.Utilities;
+using TimelessEchoes.Stats;
+
+namespace TimelessEchoes.UI
+{
+    /// <summary>
+    /// Displays recent run statistics on a bar graph and text fields.
+    /// </summary>
+    public class RunStatsPanelUI : MonoBehaviour
+    {
+        [SerializeField] private RunBarUI[] runBars = new RunBarUI[50];
+        [SerializeField] private TMP_Text longestRunText;
+        [SerializeField] private TMP_Text averageRunText;
+        [SerializeField] private Slider averageRunSlider;
+        [SerializeField] private GameplayStatTracker statTracker;
+
+        private void Awake()
+        {
+            if (statTracker == null)
+                statTracker = FindFirstObjectByType<GameplayStatTracker>();
+        }
+
+        private void OnEnable()
+        {
+            UpdateUI();
+        }
+
+        private void Update()
+        {
+            UpdateUI();
+        }
+
+        private void UpdateUI()
+        {
+            if (statTracker == null || runBars == null)
+                return;
+
+            float longest = statTracker.LongestRun;
+            if (longestRunText != null)
+                longestRunText.text = CalcUtils.FormatNumber(longest, true);
+
+            if (averageRunText != null)
+                averageRunText.text = CalcUtils.FormatNumber(statTracker.AverageRun, true);
+
+            if (averageRunSlider != null)
+            {
+                float avgRatio = longest > 0f ? statTracker.AverageRun / longest : 0f;
+                averageRunSlider.value = avgRatio * 100f;
+            }
+
+            var runs = statTracker.RecentRuns;
+            int barCount = runBars.Length;
+            for (int i = 0; i < barCount; i++)
+            {
+                if (runBars[i] == null) continue;
+
+                int index = runs.Count - barCount + i;
+                if (index >= 0 && index < runs.Count)
+                {
+                    float dist = runs[index].Distance;
+                    float ratio = longest > 0f ? dist / longest : 0f;
+                    runBars[i].SetFill(ratio);
+                }
+                else
+                {
+                    runBars[i].SetFill(0f);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RunBarUI` script to control individual bars
- update `RunStatsPanelUI` to use `RunBarUI` and show an average slider
- keep `RunRecord` support in save data and stat tracker from prior work
- revert unintended change to Main scene path

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b86f7b80832ea6de4ca49b20bb18