### PR TITLE
Update RunStatsPanel slider scaling

### DIFF
--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -48,7 +48,7 @@ namespace TimelessEchoes.UI
             if (averageRunSlider != null)
             {
                 float avgRatio = longest > 0f ? statTracker.AverageRun / longest : 0f;
-                averageRunSlider.value = avgRatio * 100f;
+                averageRunSlider.value = Mathf.Clamp01(avgRatio);
             }
 
             var runs = statTracker.RecentRuns;


### PR DESCRIPTION
## Summary
- adjust run statistics panel slider scaling to use 0-1 range

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865c206a828832ea77ec3be1574e563