### PR TITLE
Add run details tooltip on RunStats hover

### DIFF
--- a/Assets/Scripts/References/UI/RunStatUIReferences.cs
+++ b/Assets/Scripts/References/UI/RunStatUIReferences.cs
@@ -1,0 +1,15 @@
+using TMPro;
+using UnityEngine;
+
+namespace TimelessEchoes.References.UI
+{
+    /// <summary>
+    /// Holds text references for displaying details about a specific run.
+    /// </summary>
+    public class RunStatUIReferences : MonoBehaviour
+    {
+        public TMP_Text runIdText;
+        public TMP_Text distanceTasksResourcesText;
+        public TMP_Text killsDamageDoneDamageTakenText;
+    }
+}

--- a/Assets/Scripts/UI/RunBarUI.cs
+++ b/Assets/Scripts/UI/RunBarUI.cs
@@ -1,14 +1,21 @@
+using System;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
 namespace TimelessEchoes.UI
 {
     /// <summary>
     /// Controls a single run bar by setting the fill amount on an Image.
     /// </summary>
-    public class RunBarUI : MonoBehaviour
+    public class RunBarUI : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
     {
         [SerializeField] private Image fillImage;
+
+        public int BarIndex { get; set; } = -1;
+
+        public event Action<RunBarUI> PointerEnter;
+        public event Action<RunBarUI> PointerExit;
 
         /// <summary>
         /// Sets the bar fill based on a 0-1 ratio.
@@ -18,6 +25,16 @@ namespace TimelessEchoes.UI
         {
             if (fillImage != null)
                 fillImage.fillAmount = Mathf.Clamp01(ratio);
+        }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            PointerEnter?.Invoke(this);
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            PointerExit?.Invoke(this);
         }
     }
 }

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using Blindsided.Utilities;
 using TimelessEchoes.Stats;
+using TimelessEchoes.References.UI;
 
 namespace TimelessEchoes.UI
 {
@@ -16,11 +17,37 @@ namespace TimelessEchoes.UI
         [SerializeField] private TMP_Text averageRunText;
         [SerializeField] private Slider averageRunSlider;
         [SerializeField] private GameplayStatTracker statTracker;
+        [SerializeField] private RunStatUIReferences runStatUI;
+        [SerializeField] private Vector2 statOffset = Vector2.zero;
 
         private void Awake()
         {
             if (statTracker == null)
                 statTracker = FindFirstObjectByType<GameplayStatTracker>();
+            if (runStatUI == null)
+                runStatUI = FindFirstObjectByType<RunStatUIReferences>(true);
+            foreach (var bar in runBars)
+            {
+                if (bar != null)
+                {
+                    bar.PointerEnter += OnBarEnter;
+                    bar.PointerExit += OnBarExit;
+                }
+            }
+            if (runStatUI != null)
+                runStatUI.gameObject.SetActive(false);
+        }
+
+        private void OnDestroy()
+        {
+            foreach (var bar in runBars)
+            {
+                if (bar != null)
+                {
+                    bar.PointerEnter -= OnBarEnter;
+                    bar.PointerExit -= OnBarExit;
+                }
+            }
         }
 
         private void OnEnable()
@@ -28,9 +55,61 @@ namespace TimelessEchoes.UI
             UpdateUI();
         }
 
+        private void OnDisable()
+        {
+            if (runStatUI != null)
+                runStatUI.gameObject.SetActive(false);
+        }
+
         private void Update()
         {
             UpdateUI();
+        }
+
+        private void OnBarEnter(RunBarUI bar)
+        {
+            if (runStatUI == null || statTracker == null || bar == null)
+                return;
+
+            var runs = statTracker.RecentRuns;
+            int index = bar.BarIndex;
+            if (index < 0 || index >= runs.Count)
+            {
+                runStatUI.gameObject.SetActive(false);
+                return;
+            }
+
+            var record = runs[index];
+            runStatUI.transform.position = bar.transform.position + (Vector3)statOffset;
+
+            if (runStatUI.runIdText != null)
+                runStatUI.runIdText.text = $"Run {index + 1}";
+
+            if (runStatUI.distanceTasksResourcesText != null)
+            {
+                string dist = CalcUtils.FormatNumber(record.Distance, true);
+                string tasks = CalcUtils.FormatNumber(record.TasksCompleted, true);
+                string resources = CalcUtils.FormatNumber(record.ResourcesCollected, true);
+                runStatUI.distanceTasksResourcesText.text =
+                    $"Distance: {dist}\nTasks: {tasks}\nResources: {resources}";
+            }
+
+            if (runStatUI.killsDamageDoneDamageTakenText != null)
+            {
+                string kills = CalcUtils.FormatNumber(record.EnemiesKilled, true);
+                string dealt = CalcUtils.FormatNumber(record.DamageDealt, true);
+                string taken = CalcUtils.FormatNumber(record.DamageTaken, true);
+                runStatUI.killsDamageDoneDamageTakenText.text =
+                    $"Kills: {kills}\nDamage Dealt: {dealt}\nDamage Taken: {taken}";
+            }
+
+            runStatUI.gameObject.SetActive(true);
+        }
+
+        private void OnBarExit(RunBarUI bar)
+        {
+            if (runStatUI != null)
+                runStatUI.gameObject.SetActive(false);
         }
 
         private void UpdateUI()
@@ -63,10 +142,12 @@ namespace TimelessEchoes.UI
                     float dist = runs[index].Distance;
                     float ratio = longest > 0f ? dist / longest : 0f;
                     runBars[i].SetFill(ratio);
+                    runBars[i].BarIndex = index;
                 }
                 else
                 {
                     runBars[i].SetFill(0f);
+                    runBars[i].BarIndex = -1;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- create `RunStatUIReferences` for run info texts
- extend `RunBarUI` with pointer events and an index
- update `RunStatsPanelUI` to show run details when hovering over bars

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865c454b124832eb1465e0697a49227