### PR TITLE
Update run stats bar colors

### DIFF
--- a/Assets/Scripts/UI/RunBarUI.cs
+++ b/Assets/Scripts/UI/RunBarUI.cs
@@ -12,6 +12,19 @@ namespace TimelessEchoes.UI
     {
         [SerializeField] private Image fillImage;
 
+        /// <summary>
+        /// Gets or sets the fill color.
+        /// </summary>
+        public Color FillColor
+        {
+            get => fillImage != null ? fillImage.color : Color.white;
+            set
+            {
+                if (fillImage != null)
+                    fillImage.color = value;
+            }
+        }
+
         public int BarIndex { get; set; } = -1;
 
         public event Action<RunBarUI> PointerEnter;

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -19,6 +19,8 @@ namespace TimelessEchoes.UI
         [SerializeField] private GameplayStatTracker statTracker;
         [SerializeField] private RunStatUIReferences runStatUI;
         [SerializeField] private Vector2 statOffset = Vector2.zero;
+        [SerializeField] private Color deathBarColor = Color.red;
+        [SerializeField] private Color retreatBarColor = Color.green;
 
         private void Awake()
         {
@@ -154,11 +156,14 @@ namespace TimelessEchoes.UI
                     var ratio = longest > 0f ? dist / longest : 0f;
                     runBars[i].SetFill(ratio);
                     runBars[i].BarIndex = index;
+                    var color = runs[index].Died ? deathBarColor : retreatBarColor;
+                    runBars[i].FillColor = color;
                 }
                 else
                 {
                     runBars[i].SetFill(0f);
                     runBars[i].BarIndex = -1;
+                    runBars[i].FillColor = new Color(1f, 1f, 1f, 0.3f);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add `FillColor` property to `RunBarUI` to allow custom color
- allow `RunStatsPanelUI` to set death/retreat bar colors in inspector
- update bars with appropriate color based on run result

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_6867018de868832e8ac5d3a39467de36