### PR TITLE
Add run numbers to recent runs

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -96,6 +96,7 @@ namespace Blindsided.SaveData
         [HideReferenceObjectPicker]
         public class RunRecord
         {
+            public int RunNumber;
             public float Distance;
             public int TasksCompleted;
             public double ResourcesCollected;
@@ -122,6 +123,7 @@ namespace Blindsided.SaveData
             public float LongestRun;
             public float ShortestRun;
             public float AverageRun;
+            public int NextRunNumber = 1;
         }
 
 

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -21,6 +21,7 @@ namespace TimelessEchoes.Stats
         private float damageTaken;
         private double totalResourcesGathered;
         private readonly List<GameData.RunRecord> recentRuns = new();
+        private int nextRunNumber = 1;
         private float currentRunDistance;
         private int currentRunTasks;
         private double currentRunResources;
@@ -106,6 +107,7 @@ namespace TimelessEchoes.Stats
             g.LongestRun = longestRun;
             g.ShortestRun = shortestRun;
             g.AverageRun = averageRun;
+            g.NextRunNumber = nextRunNumber;
             oracle.saveData.General = g;
         }
 
@@ -138,6 +140,12 @@ namespace TimelessEchoes.Stats
             longestRun = g.LongestRun;
             shortestRun = g.ShortestRun;
             averageRun = g.AverageRun;
+            if (g.NextRunNumber > 0)
+                nextRunNumber = g.NextRunNumber;
+            else if (recentRuns.Count > 0)
+                nextRunNumber = recentRuns[recentRuns.Count - 1].RunNumber + 1;
+            else
+                nextRunNumber = 1;
         }
 
         public void RegisterTaskComplete(TaskData data, float duration, float xp)
@@ -240,6 +248,7 @@ namespace TimelessEchoes.Stats
         {
             var record = new GameData.RunRecord
             {
+                RunNumber = nextRunNumber,
                 Distance = currentRunDistance,
                 TasksCompleted = currentRunTasks,
                 ResourcesCollected = currentRunResources,
@@ -249,6 +258,7 @@ namespace TimelessEchoes.Stats
                 Died = died
             };
             AddRunRecord(record);
+            nextRunNumber++;
 
             currentRunDistance = 0f;
             currentRunTasks = 0;

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -96,7 +96,7 @@ namespace TimelessEchoes.UI
             runStatUI.transform.position = pos;
 
             if (runStatUI.runIdText != null)
-                runStatUI.runIdText.text = $"Run {index + 1}";
+                runStatUI.runIdText.text = $"Run {record.RunNumber}";
 
             if (runStatUI.distanceTasksResourcesText != null)
             {


### PR DESCRIPTION
## Summary
- track run numbers in `GameplayStatTracker`
- store/load new run number field in `GameData`
- display `RunNumber` in stats panel

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671f6a1bf8832e9acb003a9fdf3d12