### PR TITLE
Shift xp and drops to TaskData

### DIFF
--- a/Assets/Prefabs/Tasks/Chests/ChestTask.prefab
+++ b/Assets/Prefabs/Tasks/Chests/ChestTask.prefab
@@ -125,12 +125,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
-  xpGrantedOnCompletion: 5
   taskData: {fileID: 11400000, guid: 70c2ebf6cde62bb4ebd4275e6ff6373a, type: 2}
-  resourceDrops:
-  - resource: {fileID: 11400000, guid: f96c4a57aabf68c42a298a2de063e3a8, type: 2}
-    dropRange: {x: 1, y: 5}
-    dropChance: 1
   chestAnimator: {fileID: 6892406957738032772}
   openPoint: {fileID: 973583102418991227}
   openDuration: 0.5

--- a/Assets/Prefabs/Tasks/Farming/Farming_Wheat.prefab
+++ b/Assets/Prefabs/Tasks/Farming/Farming_Wheat.prefab
@@ -180,13 +180,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
-  xpGrantedOnCompletion: 5
   taskData: {fileID: 11400000, guid: 42f81ca90b736cd4bb035112a8b22ad3, type: 2}
-  resourceDrops:
-  - resource: {fileID: 11400000, guid: d0108dc3e7727584d9523efdc3d331a0, type: 2}
-    dropRange: {x: 1, y: 5}
-    dropChance: 1
-  taskDuration: 2
   progressBarObject: {fileID: 7625599681903135373}
   progressBar: {fileID: 6170718072525463737}
   spriteRenderer: {fileID: 2863051399734410759}

--- a/Assets/Prefabs/Tasks/Fishing/Fish.prefab
+++ b/Assets/Prefabs/Tasks/Fishing/Fish.prefab
@@ -543,13 +543,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
-  xpGrantedOnCompletion: 2
   taskData: {fileID: 11400000, guid: 724dfa9212cf3434599b833938990967, type: 2}
-  resourceDrops:
-  - resource: {fileID: 11400000, guid: 691350e69adc08a4082225a8015d2955, type: 2}
-    dropRange: {x: 1, y: 5}
-    dropChance: 1
-  taskDuration: 2
   progressBarObject: {fileID: 7311250231813555340}
   progressBar: {fileID: 567852907585319674}
   fishingPoint: {fileID: 1391531017378201527}

--- a/Assets/Prefabs/Tasks/Mining/Rock_Small.prefab
+++ b/Assets/Prefabs/Tasks/Mining/Rock_Small.prefab
@@ -399,19 +399,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
-  xpGrantedOnCompletion: 3
   taskData: {fileID: 11400000, guid: ba3b6a5aed10ba14299ebe98151f3018, type: 2}
-  resourceDrops:
-  - resource: {fileID: 11400000, guid: 5bbcfec123bdb15458219aa5fcddc841, type: 2}
-    dropRange: {x: 4, y: 12}
-    dropChance: 1
-  - resource: {fileID: 11400000, guid: f9dad579683f8b343b6db9ed58886a07, type: 2}
-    dropRange: {x: 2, y: 5}
-    dropChance: 0.5
-  - resource: {fileID: 11400000, guid: eac487199cf71634491bac5855d2e4f5, type: 2}
-    dropRange: {x: 1, y: 4}
-    dropChance: 0.2
-  taskDuration: 2
   progressBarObject: {fileID: 6903395814371763851}
   progressBar: {fileID: 2992031436270654903}
 --- !u!1 &2865883067036561459

--- a/Assets/Prefabs/Tasks/NPC/IvanMeetingTask.prefab
+++ b/Assets/Prefabs/Tasks/NPC/IvanMeetingTask.prefab
@@ -407,7 +407,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   associatedSkill: {fileID: 0}
-  xpGrantedOnCompletion: 0
   npcId: Ivan1
   chatPoint: {fileID: 7016541045683963271}
   dialogueObject: {fileID: 870632893699405823}

--- a/Assets/Prefabs/Tasks/NPC/WitchMeetingTask.prefab
+++ b/Assets/Prefabs/Tasks/NPC/WitchMeetingTask.prefab
@@ -628,7 +628,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   associatedSkill: {fileID: 0}
-  xpGrantedOnCompletion: 0
   taskData: {fileID: 0}
   npcId: Witch1
   chatPoint: {fileID: 4487724683361477651}

--- a/Assets/Prefabs/Tasks/Woodcutting/Tree.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Tree.prefab
@@ -492,13 +492,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
-  xpGrantedOnCompletion: 4
   taskData: {fileID: 11400000, guid: be28fd76aeb073b499a5fe6d63225d6b, type: 2}
-  resourceDrops:
-  - resource: {fileID: 11400000, guid: 024c1162874b64e43be92b8892b40efb, type: 2}
-    dropRange: {x: 12, y: 36}
-    dropChance: 1
-  taskDuration: 2
   progressBarObject: {fileID: 2490411964500561272}
   progressBar: {fileID: 4821827099416284749}
   spriteRenderer: {fileID: 6777865665299753724}

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -11,7 +11,6 @@ namespace TimelessEchoes.Tasks
     public abstract class BaseTask : MonoBehaviour, ITask
     {
         [SerializeField] public Skill associatedSkill;
-        [SerializeField] private float xpGrantedOnCompletion;
         [SerializeField] public TaskData taskData;
 
         private float lastGrantedXp;
@@ -70,14 +69,17 @@ namespace TimelessEchoes.Tasks
         protected float GrantCompletionXP()
         {
             lastGrantedXp = 0f;
-            if (associatedSkill == null || xpGrantedOnCompletion <= 0f) return 0f;
+            if (associatedSkill == null || taskData == null || taskData.xpForCompletion <= 0f)
+                return 0f;
+
             var controller = FindFirstObjectByType<SkillController>();
-            var amount = xpGrantedOnCompletion;
+            var amount = taskData.xpForCompletion;
             if (controller)
             {
                 int mult = controller.GetEffectMultiplier(associatedSkill, MilestoneType.DoubleXP);
                 amount *= mult;
             }
+
             controller?.AddExperience(associatedSkill, amount);
             lastGrantedXp = amount;
             return amount;

--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -11,12 +11,14 @@ namespace TimelessEchoes.Tasks
     /// </summary>
     public abstract class ContinuousTask : ResourceGeneratingTask
     {
-        [SerializeField] private float taskDuration = 2f;
+        // Duration for the task is defined on the TaskData
         [SerializeField] private GameObject progressBarObject;
         [SerializeField] private SlicedFilledImage progressBar;
         private bool isComplete;
 
         private float timer;
+
+        protected float TaskDuration => taskData != null ? taskData.taskDuration : 0f;
 
         protected abstract string AnimationName { get; }
         protected abstract string InterruptTriggerName { get; }
@@ -56,7 +58,7 @@ namespace TimelessEchoes.Tasks
             timer += Time.deltaTime;
             UpdateProgressBar();
 
-            if (timer >= taskDuration)
+            if (timer >= TaskDuration)
             {
                 AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, InterruptTriggerName);
                 isComplete = true;
@@ -94,7 +96,8 @@ namespace TimelessEchoes.Tasks
 
         private void UpdateProgressBar()
         {
-            if (progressBar != null) progressBar.fillAmount = Mathf.Clamp01((taskDuration - timer) / taskDuration);
+            if (progressBar != null && TaskDuration > 0f)
+                progressBar.fillAmount = Mathf.Clamp01((TaskDuration - timer) / TaskDuration);
         }
     }
 }

--- a/Assets/Scripts/Tasks/FarmingTask.cs
+++ b/Assets/Scripts/Tasks/FarmingTask.cs
@@ -30,7 +30,7 @@ namespace TimelessEchoes.Tasks
                 spriteRenderer = GetComponent<SpriteRenderer>();
             localTimer = 0f;
             currentStage = 0;
-            duration = GetTaskDuration();
+            duration = TaskDuration;
             if (spriteRenderer != null && spriteRenderer.enabled == false)
                 spriteRenderer.enabled = true;
         }
@@ -69,10 +69,6 @@ namespace TimelessEchoes.Tasks
             }
         }
 
-        private float GetTaskDuration()
-        {
-            var field = typeof(ContinuousTask).GetField("taskDuration", BindingFlags.NonPublic | BindingFlags.Instance);
-            return field != null ? (float)field.GetValue(this) : 0f;
-        }
+        // TaskDuration property from ContinuousTask provides the duration
     }
 }

--- a/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
+++ b/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
@@ -9,7 +9,7 @@ namespace TimelessEchoes.Tasks
     /// </summary>
     public abstract class ResourceGeneratingTask : BaseTask
     {
-        [SerializeField] private List<ResourceDrop> resourceDrops = new();
+        // Resource drops are now configured via TaskData
 
         private ResourceManager resourceManager;
 
@@ -22,7 +22,10 @@ namespace TimelessEchoes.Tasks
 
             if (resourceManager == null) return;
 
-            foreach (var drop in resourceDrops)
+            if (taskData == null)
+                return;
+
+            foreach (var drop in taskData.resourceDrops)
             {
                 if (drop.resource == null || Random.value > drop.dropChance) continue;
 


### PR DESCRIPTION
## Summary
- let TaskData drive XP, duration and drops
- trim obsolete parameters from prefabs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867259badc8832e892b6f7e945b71e5