### PR TITLE
Track run duration

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -97,6 +97,7 @@ namespace Blindsided.SaveData
         public class RunRecord
         {
             public int RunNumber;
+            public float Duration;
             public float Distance;
             public int TasksCompleted;
             public double ResourcesCollected;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -67,6 +67,8 @@ namespace TimelessEchoes
         private IEnumerator StartRunRoutine()
         {
             CleanupMap();
+            var tracker = FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
+            tracker?.BeginRun();
             currentMap = Instantiate(mapPrefab);
             taskController = currentMap.GetComponentInChildren<TaskController>();
             if (taskController == null)

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -22,6 +22,7 @@ namespace TimelessEchoes.Stats
         private double totalResourcesGathered;
         private readonly List<GameData.RunRecord> recentRuns = new();
         private int nextRunNumber = 1;
+        private float runStartTime;
         private float currentRunDistance;
         private int currentRunTasks;
         private double currentRunResources;
@@ -229,6 +230,12 @@ namespace TimelessEchoes.Stats
             }
         }
 
+        public void BeginRun()
+        {
+            runStartTime = Time.time;
+            lastHeroPos = Vector3.zero;
+        }
+
         private void AddRunRecord(GameData.RunRecord record)
         {
             if (record == null || record.Distance <= 0f) return;
@@ -249,6 +256,7 @@ namespace TimelessEchoes.Stats
             var record = new GameData.RunRecord
             {
                 RunNumber = nextRunNumber,
+                Duration = Time.time - runStartTime,
                 Distance = currentRunDistance,
                 TasksCompleted = currentRunTasks,
                 ResourcesCollected = currentRunResources,
@@ -267,6 +275,7 @@ namespace TimelessEchoes.Stats
             currentRunDamageDealt = 0f;
             currentRunDamageTaken = 0f;
             lastHeroPos = Vector3.zero;
+            runStartTime = Time.time;
         }
     }
 }

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -100,11 +100,12 @@ namespace TimelessEchoes.UI
 
             if (runStatUI.distanceTasksResourcesText != null)
             {
+                var time = CalcUtils.FormatTime(record.Duration);
                 var dist = CalcUtils.FormatNumber(record.Distance, true);
                 var tasks = CalcUtils.FormatNumber(record.TasksCompleted, true);
                 var resources = CalcUtils.FormatNumber(record.ResourcesCollected, true);
                 runStatUI.distanceTasksResourcesText.text =
-                    $"Distance: {dist}\nTasks: {tasks}\nResources: {resources}";
+                    $"Duration: {time}\nDistance: {dist}\nTasks: {tasks}\nResources: {resources}";
             }
 
             if (runStatUI.killsDamageDoneDamageTakenText != null)


### PR DESCRIPTION
## Summary
- add `Duration` field to `RunRecord`
- record run start time in `GameplayStatTracker`
- show formatted run duration in run details UI
- initialize new runs with `BeginRun()` from `GameManager`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867390c06d8832e9b8334f9283e5ae1