### PR TITLE
Limit task resource drops by world position

### DIFF
--- a/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
+++ b/Assets/Scripts/Tasks/ResourceGeneratingTask.cs
@@ -25,9 +25,12 @@ namespace TimelessEchoes.Tasks
             if (taskData == null)
                 return;
 
+            var worldX = transform.position.x;
+
             foreach (var drop in taskData.resourceDrops)
             {
                 if (drop.resource == null || Random.value > drop.dropChance) continue;
+                if (worldX < drop.minX || worldX > drop.maxX) continue;
 
                 var min = drop.dropRange.x;
                 var max = drop.dropRange.y;

--- a/Assets/Scripts/Upgrades/ResourceDrop.cs
+++ b/Assets/Scripts/Upgrades/ResourceDrop.cs
@@ -8,5 +8,9 @@ namespace TimelessEchoes.Upgrades
         public Resource resource;
         public Vector2Int dropRange = new Vector2Int(1, 1);
         [Range(0f, 1f)] public float dropChance = 1f;
+        // Minimum world X position required for this drop to occur
+        public float minX;
+        // Maximum world X position allowed for this drop to occur
+        public float maxX = float.PositiveInfinity;
     }
 }


### PR DESCRIPTION
## Summary
- extend `ResourceDrop` with `minX` and `maxX` fields
- check the hero's x-position in `ResourceGeneratingTask` so drops occur only within that range

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686761465430832e925025057257c706