### PR TITLE
Fix tooltip after resource removal

### DIFF
--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -89,6 +89,7 @@ namespace TimelessEchoes.Upgrades
 
             ResourceUIReferences slot = null;
             bool newSlot = false;
+            bool removedSelected = false;
             int index = resources.IndexOf(resource);
 
             if (index >= 0)
@@ -131,10 +132,16 @@ namespace TimelessEchoes.Upgrades
                     if (removedSlot != null)
                         Destroy(removedSlot.gameObject);
                     slots.RemoveAt(removeIndex);
+
                     if (selectedIndex == removeIndex)
-                        selectedIndex = -1;
+                    {
+                        removedSelected = true;
+                        selectedIndex = removeIndex - 1;
+                    }
                     else if (selectedIndex > removeIndex)
+                    {
                         selectedIndex--;
+                    }
                 }
 
                 slot = Instantiate(slotPrefab, slotParent);
@@ -169,8 +176,16 @@ namespace TimelessEchoes.Upgrades
                     };
                 }
 
-                if (selectedIndex >= 0)
+                if (selectedIndex >= 0 || removedSelected)
                     selectedIndex++;
+
+                if (removedSelected)
+                {
+                    if (tooltip != null && tooltip.gameObject.activeSelf)
+                        ShowTooltip(selectedIndex);
+                    else
+                        SelectSlot(selectedIndex);
+                }
             }
 
             if (slot != null && slot.highlightImage != null)


### PR DESCRIPTION
## Summary
- ensure selected resource index stays valid when a drop is removed
- update tooltip/highlight to the resource that replaces the removed slot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686787650c30832e82501063f20874f1