### PR TITLE
Preserve total counts when drops expire

### DIFF
--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -89,6 +89,7 @@ namespace TimelessEchoes.Upgrades
 
             ResourceUIReferences slot = null;
             bool newSlot = false;
+            bool removedSelected = false;
             int index = resources.IndexOf(resource);
 
             if (index >= 0)
@@ -119,22 +120,29 @@ namespace TimelessEchoes.Upgrades
             }
             else
             {
-                amounts[resource] = amount;
+                double current = 0;
+                if (amounts.TryGetValue(resource, out var val))
+                    current = val;
+                amounts[resource] = current + amount;
 
                 if (resources.Count >= maxVisibleDrops)
                 {
                     int removeIndex = resources.Count - 1;
-                    var removedResource = resources[removeIndex];
                     resources.RemoveAt(removeIndex);
-                    amounts.Remove(removedResource);
                     var removedSlot = slots[removeIndex];
                     if (removedSlot != null)
                         Destroy(removedSlot.gameObject);
                     slots.RemoveAt(removeIndex);
+
                     if (selectedIndex == removeIndex)
-                        selectedIndex = -1;
+                    {
+                        removedSelected = true;
+                        selectedIndex = removeIndex - 1;
+                    }
                     else if (selectedIndex > removeIndex)
+                    {
                         selectedIndex--;
+                    }
                 }
 
                 slot = Instantiate(slotPrefab, slotParent);
@@ -169,8 +177,16 @@ namespace TimelessEchoes.Upgrades
                     };
                 }
 
-                if (selectedIndex >= 0)
+                if (selectedIndex >= 0 || removedSelected)
                     selectedIndex++;
+
+                if (removedSelected)
+                {
+                    if (tooltip != null && tooltip.gameObject.activeSelf)
+                        ShowTooltip(selectedIndex);
+                    else
+                        SelectSlot(selectedIndex);
+                }
             }
 
             if (slot != null && slot.highlightImage != null)


### PR DESCRIPTION
## Summary
- maintain resource totals even after a drop slot is removed
- accumulate amounts for resources reappearing after removal

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686787650c30832e82501063f20874f1