### PR TITLE
Hide active buff UI when no buffs remain

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -81,6 +81,9 @@ namespace TimelessEchoes.Buffs
                     entry.refs.durationText.text = Mathf.Ceil(entry.buff.remaining).ToString();
             }
 
+            if (iconEntries.Count == 0 && activeBuffParent != null)
+                activeBuffParent.gameObject.SetActive(false);
+
             foreach (var pair in recipeEntries)
             {
                 var panel = pair.Value;


### PR DESCRIPTION
## Summary
- update BuffUIManager to deactivate the active buff parent when all buffs expire

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868561a3b90832eb5fef12692c55faa