### PR TITLE
Fix floating text spawn movement logic

### DIFF
--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -91,6 +91,7 @@ namespace TimelessEchoes.Upgrades
             bool newSlot = false;
             bool removedSelected = false;
             int index = resources.IndexOf(resource);
+            bool moved = index > 0;
 
             if (index >= 0)
             {
@@ -199,10 +200,13 @@ namespace TimelessEchoes.Upgrades
 
             if (slot != null)
             {
-                if (newSlot)
+                if (newSlot || moved)
                     StartCoroutine(SpawnFloatingTextNextFrame(slot, amount));
                 else
-                    FloatingText.Spawn($"+{Mathf.FloorToInt((float)amount)}", slot.transform.position + Vector3.up, Color.white, 8f, transform);
+                    FloatingText.Spawn(
+                        $"+{Mathf.FloorToInt((float)amount)}",
+                        slot.transform.position + Vector3.up,
+                        Color.white, 8f, transform);
             }
 
             if (tooltip != null && tooltip.gameObject.activeSelf)


### PR DESCRIPTION
## Summary
- tweak RunDropUI spawn logic
- show floating text on moved items

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868582bd454832e86456cde68974f4e