### PR TITLE
Fix task stats default ordering

### DIFF
--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -60,7 +60,10 @@ namespace TimelessEchoes.UI
                 Destroy(child.gameObject);
 
             var allTasks = Resources.LoadAll<TaskData>("Tasks");
-            var sorted = allTasks.OrderBy(t => t.taskName).ToList();
+            var sorted = allTasks
+                .OrderBy(t => t.taskID)
+                .ThenBy(t => t.taskName)
+                .ToList();
             defaultOrder = sorted;
             entries.Clear();
 


### PR DESCRIPTION
## Summary
- sort task stats UI entries by taskID first and then by name

## Testing
- `unity --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686872d62498832ea576df39f6591af9