### PR TITLE
Separate enemy and task density

### DIFF
--- a/Assets/Scriptables/Settings/Beach.asset
+++ b/Assets/Scriptables/Settings/Beach.asset
@@ -26,7 +26,8 @@ MonoBehaviour:
   taskGeneratorSettings:
     minX: 0
     height: 18
-    density: 0.3
+    enemyDensity: 0.1
+    taskDensity: 0.2
     blockingMask:
       serializedVersion: 2
       m_Bits: 0

--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -42,7 +42,8 @@ namespace TimelessEchoes.MapGeneration
         {
             public float minX;
             public float height = 18f;
-            public float density = 0.1f;
+            public float enemyDensity = 0.1f;
+            public float taskDensity = 0.1f;
 
             public LayerMask blockingMask;
             [MinValue(0f)] public float otherTaskEdgeOffset = 1f;


### PR DESCRIPTION
## Summary
- add distinct enemyDensity and taskDensity fields for map generation
- spawn tasks and enemies using separate densities in `ProceduralTaskGenerator`
- update default Beach settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686890726878832eb8477e8939a704c6