### PR TITLE
Add separate densities for tasks and enemies

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -42,7 +42,9 @@ namespace TimelessEchoes.MapGeneration
         {
             public float minX;
             public float height = 18f;
-            public float density = 0.1f;
+            [FormerlySerializedAs("density")] public float taskDensity = 0.1f;
+
+            public float enemyDensity = 0.1f;
 
             public LayerMask blockingMask;
             [MinValue(0f)] public float otherTaskEdgeOffset = 1f;


### PR DESCRIPTION
## Summary
- split spawn densities for tasks and enemies
- keep old `density` value through `FormerlySerializedAs`
- update task generator to handle separate spawn loops

## Testing
- `echo "No tests specified"`

------
https://chatgpt.com/codex/tasks/task_e_686893da4a20832e8fb1e75f05ea576e