### PR TITLE
Implement NPC resource generation

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -29,6 +29,9 @@ namespace Blindsided.SaveData
         public HashSet<string> CompletedNpcTasks = new();
 
         [HideReferenceObjectPicker]
+        public Dictionary<string, NpcGenerationRecord> NpcGeneration = new();
+
+        [HideReferenceObjectPicker]
         public Dictionary<string, TaskRecord> TaskRecords = new();
 
         [HideReferenceObjectPicker]
@@ -91,6 +94,13 @@ namespace Blindsided.SaveData
         {
             public int TotalReceived;
             public int TotalSpent;
+        }
+
+        [HideReferenceObjectPicker]
+        public class NpcGenerationRecord
+        {
+            public Dictionary<string, double> StoredResources = new();
+            public double LastGenerationTime;
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/NpcGeneration/GenerationManager.cs
+++ b/Assets/Scripts/NpcGeneration/GenerationManager.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using UnityEngine;
+using static Blindsided.EventHandler;
+
+namespace TimelessEchoes.NpcGeneration
+{
+    /// <summary>
+    /// Central manager that updates all NPC resource generators and applies offline progress.
+    /// </summary>
+    public class GenerationManager : MonoBehaviour
+    {
+        [SerializeField] private List<NPCResourceGenerator> generators = new();
+
+        private void OnEnable()
+        {
+            AwayFor += OnAwayForTime;
+        }
+
+        private void OnDisable()
+        {
+            AwayFor -= OnAwayForTime;
+        }
+
+        private void Update()
+        {
+            float dt = Time.deltaTime;
+            foreach (var gen in generators)
+            {
+                if (gen != null)
+                    gen.Tick(dt);
+            }
+        }
+
+        private void OnAwayForTime(float seconds)
+        {
+            foreach (var gen in generators)
+            {
+                if (gen != null)
+                    gen.ApplyOfflineProgress(seconds);
+            }
+        }
+
+        public NPCResourceGenerator GetGenerator(string npcId)
+        {
+            return generators.Find(g => g != null && g.NpcId == npcId);
+        }
+    }
+}

--- a/Assets/Scripts/NpcGeneration/NPCResourceGenerator.cs
+++ b/Assets/Scripts/NpcGeneration/NPCResourceGenerator.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using TimelessEchoes.Upgrades;
+using UnityEngine;
+using UnityEngine.UI;
+using Blindsided.SaveData;
+using static Blindsided.EventHandler;
+using static Blindsided.Oracle;
+
+namespace TimelessEchoes.NpcGeneration
+{
+    /// <summary>
+    /// Generates resources over time for a single NPC.
+    /// </summary>
+    public class NPCResourceGenerator : MonoBehaviour
+    {
+        [Serializable]
+        public class ResourceEntry
+        {
+            public Resource resource;
+            public double amount = 1;
+        }
+
+        [SerializeField] private string npcId;
+        [SerializeField] private List<ResourceEntry> resources = new();
+        [SerializeField] private float generationInterval = 5f;
+        [SerializeField] private Slider progressSlider;
+        [SerializeField] private Image progressImage;
+
+        private readonly Dictionary<Resource, double> stored = new();
+        private float progress;
+
+        private static Dictionary<string, Resource> lookup;
+        private ResourceManager resourceManager;
+
+        public string NpcId => npcId;
+        public float Interval => generationInterval;
+        public float Progress => progress;
+
+        private void Awake()
+        {
+            OnSaveData += SaveState;
+            OnLoadData += LoadState;
+        }
+
+        private void Start()
+        {
+            LoadState();
+        }
+
+        private void OnDestroy()
+        {
+            OnSaveData -= SaveState;
+            OnLoadData -= LoadState;
+        }
+
+        public void Tick(float deltaTime)
+        {
+            progress += deltaTime;
+            while (progress >= generationInterval && generationInterval > 0f)
+            {
+                progress -= generationInterval;
+                AddCycle();
+            }
+            UpdateUI();
+        }
+
+        public void ApplyOfflineProgress(double seconds)
+        {
+            if (seconds <= 0) return;
+            progress += (float)seconds;
+            while (progress >= generationInterval && generationInterval > 0f)
+            {
+                progress -= generationInterval;
+                AddCycle();
+            }
+            UpdateUI();
+        }
+
+        public void CollectResources()
+        {
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
+            if (resourceManager == null) return;
+
+            foreach (var pair in stored)
+            {
+                resourceManager.Add(pair.Key, pair.Value);
+            }
+            stored.Clear();
+        }
+
+        private void AddCycle()
+        {
+            foreach (var entry in resources)
+            {
+                if (entry.resource == null || entry.amount <= 0) continue;
+                if (stored.ContainsKey(entry.resource))
+                    stored[entry.resource] += entry.amount;
+                else
+                    stored[entry.resource] = entry.amount;
+            }
+        }
+
+        private void UpdateUI()
+        {
+            float pct = generationInterval > 0f ? Mathf.Clamp01(progress / generationInterval) : 0f;
+            if (progressSlider != null)
+                progressSlider.value = pct;
+            if (progressImage != null)
+                progressImage.fillAmount = pct;
+        }
+
+        private void SaveState()
+        {
+            if (oracle == null || string.IsNullOrEmpty(npcId)) return;
+            if (oracle.saveData.NpcGeneration == null)
+                oracle.saveData.NpcGeneration = new Dictionary<string, GameData.NpcGenerationRecord>();
+
+            var rec = new GameData.NpcGenerationRecord
+            {
+                StoredResources = new Dictionary<string, double>(),
+                LastGenerationTime = DateTime.UtcNow.Subtract(DateTime.UnixEpoch).TotalSeconds
+            };
+            foreach (var pair in stored)
+            {
+                if (pair.Key != null)
+                    rec.StoredResources[pair.Key.name] = pair.Value;
+            }
+            oracle.saveData.NpcGeneration[npcId] = rec;
+        }
+
+        private void LoadState()
+        {
+            if (oracle == null || string.IsNullOrEmpty(npcId)) return;
+            EnsureLookup();
+            oracle.saveData.NpcGeneration ??= new Dictionary<string, GameData.NpcGenerationRecord>();
+
+            stored.Clear();
+            progress = 0f;
+            if (oracle.saveData.NpcGeneration.TryGetValue(npcId, out var rec) && rec != null)
+            {
+                foreach (var pair in rec.StoredResources)
+                {
+                    if (lookup.TryGetValue(pair.Key, out var res) && res != null)
+                        stored[res] = pair.Value;
+                }
+            }
+            UpdateUI();
+        }
+
+        private static void EnsureLookup()
+        {
+            if (lookup != null) return;
+            lookup = new Dictionary<string, Resource>();
+            foreach (var res in Resources.LoadAll<Resource>(""))
+            {
+                if (res != null && !lookup.ContainsKey(res.name))
+                    lookup[res.name] = res;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/NpcGeneration/NpcGeneratorProgressUI.cs
+++ b/Assets/Scripts/NpcGeneration/NpcGeneratorProgressUI.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TimelessEchoes.NpcGeneration
+{
+    /// <summary>
+    /// Updates a slider or image to reflect the progress of an NPC generator.
+    /// </summary>
+    public class NpcGeneratorProgressUI : MonoBehaviour
+    {
+        [SerializeField] private NPCResourceGenerator generator;
+        [SerializeField] private Slider slider;
+        [SerializeField] private Image image;
+
+        private void Update()
+        {
+            if (generator == null) return;
+            float pct = generator.Interval > 0f ? Mathf.Clamp01(generator.Progress / generator.Interval) : 0f;
+            if (slider != null)
+                slider.value = pct;
+            if (image != null)
+                image.fillAmount = pct;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `GameData` with saved generation info for NPCs
- add `NPCResourceGenerator` component for accumulating resources
- create `GenerationManager` to tick generators and handle offline progress
- implement `NpcGeneratorProgressUI` for displaying generation progress

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6868c67e9590832ea1886c8c6979f9cd