### PR TITLE
Add UI entries for NPC resource generation

### DIFF
--- a/Assets/Scripts/NpcGeneration/NPCResourceGenerator.cs
+++ b/Assets/Scripts/NpcGeneration/NPCResourceGenerator.cs
@@ -26,8 +26,11 @@ namespace TimelessEchoes.NpcGeneration
         [SerializeField] private float generationInterval = 5f;
         [SerializeField] private Slider progressSlider;
         [SerializeField] private Image progressImage;
+        [SerializeField] private Transform progressUIParent;
+        [SerializeField] private NpcGeneratorProgressUI progressUIPrefab;
 
         private readonly Dictionary<Resource, double> stored = new();
+        private readonly List<NpcGeneratorProgressUI> uiEntries = new();
         private float progress;
 
         private static Dictionary<string, Resource> lookup;
@@ -36,6 +39,10 @@ namespace TimelessEchoes.NpcGeneration
         public string NpcId => npcId;
         public float Interval => generationInterval;
         public float Progress => progress;
+        public double GetStoredAmount(Resource resource)
+        {
+            return stored.TryGetValue(resource, out var val) ? val : 0;
+        }
 
         private void Awake()
         {
@@ -46,6 +53,7 @@ namespace TimelessEchoes.NpcGeneration
         private void Start()
         {
             LoadState();
+            BuildProgressUI();
         }
 
         private void OnDestroy()
@@ -147,6 +155,25 @@ namespace TimelessEchoes.NpcGeneration
                 }
             }
             UpdateUI();
+            BuildProgressUI();
+        }
+
+        private void BuildProgressUI()
+        {
+            if (progressUIParent == null || progressUIPrefab == null)
+                return;
+
+            foreach (Transform child in progressUIParent)
+                Destroy(child.gameObject);
+            uiEntries.Clear();
+
+            foreach (var entry in resources)
+            {
+                if (entry.resource == null) continue;
+                var ui = Instantiate(progressUIPrefab, progressUIParent);
+                ui.SetData(this, entry.resource, entry.amount);
+                uiEntries.Add(ui);
+            }
         }
 
         private static void EnsureLookup()

--- a/Assets/Scripts/NpcGeneration/NpcGeneratorProgressUI.cs
+++ b/Assets/Scripts/NpcGeneration/NpcGeneratorProgressUI.cs
@@ -1,3 +1,6 @@
+using Blindsided.Utilities;
+using TimelessEchoes.Upgrades;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,17 +12,75 @@ namespace TimelessEchoes.NpcGeneration
     public class NpcGeneratorProgressUI : MonoBehaviour
     {
         [SerializeField] private NPCResourceGenerator generator;
+        [SerializeField] private Resource resource;
+        [SerializeField] private double amountPerCycle;
         [SerializeField] private Slider slider;
         [SerializeField] private Image image;
+        [SerializeField] private TMP_Text resourceNameText;
+        [SerializeField] private TMP_Text totalCollectedText;
+        [SerializeField] private TMP_Text awaitingCollectionText;
+        [SerializeField] private TMP_Text collectionRateText;
+        [SerializeField] private Image iconImage;
+        [SerializeField] private Button selectButton;
+
+        private ResourceInventoryUI inventoryUI;
+        private ResourceManager resourceManager;
+
+        public void SetData(NPCResourceGenerator gen, Resource res, double perCycle)
+        {
+            generator = gen;
+            resource = res;
+            amountPerCycle = perCycle;
+
+            if (iconImage != null)
+                iconImage.sprite = res ? res.icon : null;
+            if (resourceNameText != null && res != null)
+                resourceNameText.text = res.name;
+
+            if (selectButton != null)
+            {
+                if (inventoryUI == null)
+                    inventoryUI = FindFirstObjectByType<ResourceInventoryUI>();
+                var r = res;
+                selectButton.onClick.RemoveAllListeners();
+                selectButton.onClick.AddListener(() => inventoryUI?.HighlightResource(r));
+            }
+        }
+
+        private void Awake()
+        {
+            if (inventoryUI == null)
+                inventoryUI = FindFirstObjectByType<ResourceInventoryUI>();
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
+        }
+
+        private void OnDestroy()
+        {
+            if (selectButton != null)
+                selectButton.onClick.RemoveAllListeners();
+        }
 
         private void Update()
         {
-            if (generator == null) return;
+            if (generator == null || resource == null) return;
             float pct = generator.Interval > 0f ? Mathf.Clamp01(generator.Progress / generator.Interval) : 0f;
             if (slider != null)
                 slider.value = pct;
             if (image != null)
                 image.fillAmount = pct;
+
+            if (resourceNameText != null)
+                resourceNameText.text = resource.name;
+            if (resourceManager != null && totalCollectedText != null)
+                totalCollectedText.text = CalcUtils.FormatNumber(resource.totalReceived, true);
+            if (awaitingCollectionText != null)
+                awaitingCollectionText.text = CalcUtils.FormatNumber(generator.GetStoredAmount(resource), true);
+            if (collectionRateText != null)
+            {
+                var rate = generator.Interval > 0 ? amountPerCycle / generator.Interval : 0;
+                collectionRateText.text = CalcUtils.FormatNumber(rate, true) + "/s";
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- support spawned progress UI entries per resource
- expand NPCGeneratorProgressUI with data display and button linking to inventory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868e18d4cd8832e8de25c8ca5cb9ffb