### PR TITLE
Add NPC generator resource tracking

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -100,6 +100,8 @@ namespace Blindsided.SaveData
         public class NpcGenerationRecord
         {
             public Dictionary<string, double> StoredResources = new();
+            public Dictionary<string, double> TotalCollected = new();
+            public float Progress;
             public double LastGenerationTime;
         }
 

--- a/Assets/Scripts/NpcGeneration/NpcGeneratorProgressUI.cs
+++ b/Assets/Scripts/NpcGeneration/NpcGeneratorProgressUI.cs
@@ -79,7 +79,7 @@ namespace TimelessEchoes.NpcGeneration
             if (resourceNameText != null)
                 resourceNameText.text = resource.name;
             if (resourceManager != null && totalCollectedText != null)
-                totalCollectedText.text = CalcUtils.FormatNumber(resource.totalReceived, true);
+                totalCollectedText.text = CalcUtils.FormatNumber(generator.GetTotalCollected(resource), true);
             if (awaitingCollectionText != null)
                 awaitingCollectionText.text = CalcUtils.FormatNumber(generator.GetStoredAmount(resource), true);
             if (collectionRateText != null)


### PR DESCRIPTION
## Summary
- track total collected amounts and progress per NPC generator
- store collected totals and progress in `NpcGenerationRecord`
- display each generator's collected total in UI

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868e8bc1c3c832ebaf66a74a35f0718