### PR TITLE
Add basic quest system

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -208,6 +208,7 @@ namespace Blindsided
             saveData.EnemyKills ??= new Dictionary<string, double>();
             saveData.CompletedNpcTasks ??= new HashSet<string>();
             saveData.ActiveBuffs ??= new Dictionary<string, float>();
+            saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
         }
 
         public static void AwayForSeconds()

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -32,6 +32,9 @@ namespace Blindsided.SaveData
         public Dictionary<string, NpcGenerationRecord> NpcGeneration = new();
 
         [HideReferenceObjectPicker]
+        public Dictionary<string, QuestRecord> Quests = new();
+
+        [HideReferenceObjectPicker]
         public Dictionary<string, TaskRecord> TaskRecords = new();
 
         [HideReferenceObjectPicker]
@@ -103,6 +106,13 @@ namespace Blindsided.SaveData
             public Dictionary<string, double> TotalCollected = new();
             public float Progress;
             public double LastGenerationTime;
+        }
+
+        [HideReferenceObjectPicker]
+        public class QuestRecord
+        {
+            public bool Completed;
+            public Dictionary<string, double> KillBaseline = new();
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Enemies/EnemyKillTracker.cs
+++ b/Assets/Scripts/Enemies/EnemyKillTracker.cs
@@ -11,6 +11,8 @@ namespace TimelessEchoes.Stats
     {
         public static readonly int[] Thresholds = { 10, 100, 1000, 10000 };
 
+        public event System.Action<EnemyStats> OnKillRegistered;
+
         private readonly Dictionary<EnemyStats, double> kills = new();
 
         private void Awake()
@@ -33,6 +35,7 @@ namespace TimelessEchoes.Stats
                 kills[stats] += 1;
             else
                 kills[stats] = 1;
+            OnKillRegistered?.Invoke(stats);
         }
 
         public double GetKills(EnemyStats stats)

--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using Blindsided.Utilities;
+using TimelessEchoes.Upgrades;
+using TimelessEchoes.Enemies;
+using UnityEngine;
+
+namespace TimelessEchoes.Quests
+{
+    [ManageableData]
+    [CreateAssetMenu(fileName = "QuestData", menuName = "SO/Quest Data")]
+    public class QuestData : ScriptableObject
+    {
+        public string questId;
+        public string questName;
+        [TextArea] public string description;
+        [TextArea] public string rewardDescription;
+        public string npcId;
+        public List<Requirement> requirements = new();
+        public QuestData nextQuest;
+        public GameObject unlockPrefab;
+        public List<GameObject> unlockObjects = new();
+
+        [Serializable]
+        public class Requirement
+        {
+            public RequirementType type;
+            public Resource resource;
+            public int amount = 1;
+            public List<EnemyStats> enemies = new();
+        }
+
+        public enum RequirementType
+        {
+            Resource,
+            Kill
+        }
+    }
+}

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -1,0 +1,71 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using References.UI;
+using Blindsided.Utilities;
+
+namespace TimelessEchoes.Quests
+{
+    /// <summary>
+    ///     Displays a single quest entry and handles its progress bar and turn in button.
+    /// </summary>
+    public class QuestEntryUI : MonoBehaviour
+    {
+        public TMP_Text nameText;
+        public TMP_Text descriptionText;
+        public TMP_Text rewardText;
+        public Button turnInButton;
+        public SlicedFilledImage progressImage;
+        public References.UI.CostResourceUIReferences costSlotPrefab;
+        public Transform costParent;
+
+        private Action onTurnIn;
+
+        public void Setup(QuestData data, Action turnIn)
+        {
+            onTurnIn = turnIn;
+            if (nameText != null)
+                nameText.text = data != null ? data.questName : string.Empty;
+            if (descriptionText != null)
+                descriptionText.text = data != null ? data.description : string.Empty;
+            if (rewardText != null)
+                rewardText.text = data != null ? data.rewardDescription : string.Empty;
+
+            if (turnInButton != null)
+            {
+                turnInButton.onClick.RemoveAllListeners();
+                if (onTurnIn != null)
+                    turnInButton.onClick.AddListener(() => onTurnIn());
+            }
+
+            if (costParent != null)
+            {
+                foreach (Transform child in costParent)
+                    Destroy(child.gameObject);
+                if (data != null && costSlotPrefab != null)
+                {
+                    foreach (var req in data.requirements)
+                    {
+                        if (req.type != QuestData.RequirementType.Resource) continue;
+                        var slot = Instantiate(costSlotPrefab, costParent);
+                        slot.resource = req.resource;
+                        if (slot.iconImage != null)
+                            slot.iconImage.sprite = req.resource ? req.resource.icon : null;
+                        if (slot.countText != null)
+                            slot.countText.text = req.amount.ToString();
+                    }
+                }
+            }
+        }
+
+        public void SetProgress(float pct)
+        {
+            pct = Mathf.Clamp01(pct);
+            if (progressImage != null)
+                progressImage.fillAmount = pct;
+            if (turnInButton != null)
+                turnInButton.interactable = pct >= 1f;
+        }
+    }
+}

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -1,0 +1,189 @@
+using System.Collections.Generic;
+using UnityEngine;
+using TimelessEchoes.Upgrades;
+using TimelessEchoes.Enemies;
+using TimelessEchoes.NpcGeneration;
+using Blindsided.SaveData;
+using static Blindsided.Oracle;
+
+namespace TimelessEchoes.Quests
+{
+    /// <summary>
+    ///     Handles quest logic and progress tracking.
+    /// </summary>
+    public class QuestManager : MonoBehaviour
+    {
+        [SerializeField] private ResourceManager resourceManager;
+        [SerializeField] private EnemyKillTracker killTracker;
+        [SerializeField] private GenerationManager generationManager;
+        [SerializeField] private QuestUIManager uiManager;
+        [SerializeField] private List<QuestData> startingQuests = new();
+
+        private readonly Dictionary<string, QuestInstance> active = new();
+
+        private class QuestInstance
+        {
+            public QuestData data;
+            public QuestEntryUI ui;
+            public Dictionary<EnemyStats, double> baselineKills = new();
+        }
+
+        private void Awake()
+        {
+            if (resourceManager == null)
+                resourceManager = FindFirstObjectByType<ResourceManager>();
+            if (killTracker == null)
+                killTracker = FindFirstObjectByType<EnemyKillTracker>();
+            if (generationManager == null)
+                generationManager = FindFirstObjectByType<GenerationManager>();
+            if (uiManager == null)
+                uiManager = FindFirstObjectByType<QuestUIManager>();
+
+            if (resourceManager != null)
+                resourceManager.OnInventoryChanged += UpdateAllProgress;
+            if (killTracker != null)
+                killTracker.OnKillRegistered += OnKill;
+
+            oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
+
+            foreach (var q in startingQuests)
+                TryStartQuest(q);
+
+            RefreshNoticeboard();
+        }
+
+        private void OnDestroy()
+        {
+            if (resourceManager != null)
+                resourceManager.OnInventoryChanged -= UpdateAllProgress;
+            if (killTracker != null)
+                killTracker.OnKillRegistered -= OnKill;
+        }
+
+        private void OnKill(EnemyStats stats)
+        {
+            if (stats == null) return;
+            foreach (var inst in active.Values)
+                if (ContainsEnemy(inst.data, stats))
+                    UpdateProgress(inst);
+        }
+
+        private static bool ContainsEnemy(QuestData data, EnemyStats stats)
+        {
+            foreach (var req in data.requirements)
+                if (req.type == QuestData.RequirementType.Kill && req.enemies.Contains(stats))
+                    return true;
+            return false;
+        }
+
+        private void UpdateAllProgress()
+        {
+            foreach (var inst in active.Values)
+                UpdateProgress(inst);
+        }
+
+        private void UpdateProgress(QuestInstance inst)
+        {
+            float progress = 0f;
+            int count = 0;
+            foreach (var req in inst.data.requirements)
+            {
+                count++;
+                float pct = 0f;
+                if (req.type == QuestData.RequirementType.Resource)
+                {
+                    double have = resourceManager ? resourceManager.GetAmount(req.resource) : 0;
+                    if (req.amount > 0)
+                        pct = (float)(have / req.amount);
+                }
+                else if (req.type == QuestData.RequirementType.Kill)
+                {
+                    double total = 0;
+                    foreach (var enemy in req.enemies)
+                    {
+                        double baseVal = 0;
+                        if (inst.baselineKills.TryGetValue(enemy, out var b))
+                            baseVal = b;
+                        double current = killTracker ? killTracker.GetKills(enemy) : 0;
+                        total += current - baseVal;
+                    }
+                    if (req.amount > 0)
+                        pct = (float)(total / req.amount);
+                }
+                progress += Mathf.Clamp01(pct);
+            }
+            if (count > 0)
+                progress /= count;
+
+            inst.ui?.SetProgress(progress);
+        }
+
+        private void CompleteQuest(QuestInstance inst)
+        {
+            if (inst == null) return;
+            var id = inst.data.questId;
+            if (!oracle.saveData.Quests.TryGetValue(id, out var record))
+            {
+                record = new GameData.QuestRecord();
+                oracle.saveData.Quests[id] = record;
+            }
+            record.Completed = true;
+            if (inst.data.unlockPrefab != null)
+                Instantiate(inst.data.unlockPrefab);
+            foreach (var obj in inst.data.unlockObjects)
+                if (obj != null)
+                    obj.SetActive(true);
+            if (!string.IsNullOrEmpty(inst.data.npcId))
+                StaticReferences.CompletedNpcTasks.Add(inst.data.npcId);
+            if (inst.ui != null)
+                uiManager?.RemoveEntry(inst.ui);
+            active.Remove(id);
+            if (inst.data.nextQuest != null)
+                TryStartQuest(inst.data.nextQuest);
+
+            RefreshNoticeboard();
+        }
+
+        private void TryStartQuest(QuestData quest)
+        {
+            if (quest == null) return;
+            if (oracle.saveData.Quests.TryGetValue(quest.questId, out var rec) && rec.Completed)
+                return;
+
+            var inst = new QuestInstance { data = quest };
+            if (!oracle.saveData.Quests.TryGetValue(quest.questId, out rec))
+            {
+                rec = new GameData.QuestRecord();
+                oracle.saveData.Quests[quest.questId] = rec;
+            }
+
+            foreach (var req in quest.requirements)
+            {
+                if (req.type != QuestData.RequirementType.Kill) continue;
+                foreach (var enemy in req.enemies)
+                {
+                    double kills = killTracker ? killTracker.GetKills(enemy) : 0;
+                    if (!rec.KillBaseline.ContainsKey(enemy.name))
+                        rec.KillBaseline[enemy.name] = kills;
+                    inst.baselineKills[enemy] = rec.KillBaseline[enemy.name];
+                }
+            }
+
+            inst.ui = null;
+            active[quest.questId] = inst;
+            UpdateProgress(inst);
+        }
+
+        private void RefreshNoticeboard()
+        {
+            if (uiManager == null)
+                return;
+            uiManager.Clear();
+            foreach (var inst in active.Values)
+            {
+                inst.ui = uiManager.CreateEntry(inst.data, () => CompleteQuest(inst));
+                UpdateProgress(inst);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Quests/QuestUIManager.cs
+++ b/Assets/Scripts/Quests/QuestUIManager.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TimelessEchoes.Quests
+{
+    /// <summary>
+    ///     Manages quest UI entries.
+    /// </summary>
+    public class QuestUIManager : MonoBehaviour
+    {
+        [SerializeField] private QuestEntryUI questEntryPrefab;
+        [SerializeField] private Transform questParent;
+
+        private readonly List<QuestEntryUI> entries = new();
+
+        public QuestEntryUI CreateEntry(QuestData quest, Action onTurnIn)
+        {
+            if (questEntryPrefab == null || questParent == null)
+                return null;
+            var ui = Instantiate(questEntryPrefab, questParent);
+            ui.Setup(quest, onTurnIn);
+            entries.Add(ui);
+            return ui;
+        }
+
+        public void Clear()
+        {
+            foreach (var entry in entries)
+                if (entry != null)
+                    Destroy(entry.gameObject);
+            entries.Clear();
+        }
+
+        public void RemoveEntry(QuestEntryUI entry)
+        {
+            if (entry == null) return;
+            entries.Remove(entry);
+            Destroy(entry.gameObject);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement new `QuestData` scriptable object
- extend `GameData` with quest records
- ensure `Oracle` initializes quest save data
- fire a kill event from `EnemyKillTracker`
- create quest manager and UI components
- display resource costs in `QuestEntryUI`
- refresh noticeboard only with current quests

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6869cf0cc4dc832ebd3ead66db4d8b6e