### PR TITLE
Fix quest state loading

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -46,12 +46,8 @@ namespace TimelessEchoes.Quests
             if (killTracker != null)
                 killTracker.OnKillRegistered += OnKill;
 
-            oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
-
-            foreach (var q in startingQuests)
-                TryStartQuest(q);
-
-            RefreshNoticeboard();
+            LoadState();
+            OnLoadData += LoadState;
         }
 
         private void OnDestroy()
@@ -60,6 +56,17 @@ namespace TimelessEchoes.Quests
                 resourceManager.OnInventoryChanged -= UpdateAllProgress;
             if (killTracker != null)
                 killTracker.OnKillRegistered -= OnKill;
+            OnLoadData -= LoadState;
+        }
+
+        private void LoadState()
+        {
+            if (oracle == null) return;
+            oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
+            active.Clear();
+            foreach (var q in startingQuests)
+                TryStartQuest(q);
+            RefreshNoticeboard();
         }
 
         private void OnKill(EnemyStats stats)


### PR DESCRIPTION
## Summary
- refresh quests on data load to avoid re-starting completed ones
- hook quest manager into OnLoadData

## Testing
- `npm test` *(fails: package.json not found)*
- `unity-editor --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869fedd1e7c832e9eff4872ebca5b70