### PR TITLE
Fix offline progress for NPC generators

### DIFF
--- a/Assets/Scripts/NpcGeneration/NPCResourceGenerator.cs
+++ b/Assets/Scripts/NpcGeneration/NPCResourceGenerator.cs
@@ -66,6 +66,12 @@ namespace TimelessEchoes.NpcGeneration
             OnQuestHandin += OnQuestHandinEvent;
         }
 
+        private void OnEnable()
+        {
+            if (!setup && QuestCompleted())
+                LoadState();
+        }
+
         private void OnDestroy()
         {
             OnSaveData -= SaveState;


### PR DESCRIPTION
## Summary
- ensure `NPCResourceGenerator` loads state when activated after quests

## Testing
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6869ff24f8d4832ea83afd6375c84e6e