### PR TITLE
Add log categories with Quantum Console toggles

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -227,7 +227,7 @@ namespace TimelessEchoes.Hero
 
         public void SetTask(ITask task)
         {
-            Log($"Hero assigned task: {task?.GetType().Name ?? "None"}", this);
+            Log($"Hero assigned task: {task?.GetType().Name ?? "None"}", TELogCategory.Task, this);
             CurrentTask = task;
             currentTaskName = task != null ? task.GetType().Name : "None";
             currentTaskObject = task as MonoBehaviour;
@@ -269,7 +269,7 @@ namespace TimelessEchoes.Hero
 
             if (state == State.Combat)
             {
-                Log("Hero exiting combat", this);
+                Log("Hero exiting combat", TELogCategory.Combat, this);
                 combatDamageMultiplier = 1f;
                 isRolling = false;
                 diceRoller?.ResetRoll();
@@ -338,7 +338,7 @@ namespace TimelessEchoes.Hero
 
             if (state != State.Combat)
             {
-                Log($"Hero entering combat with {enemy.name}", this);
+                Log($"Hero entering combat with {enemy.name}", TELogCategory.Combat, this);
                 if (diceRoller != null && !isRolling)
                 {
                     var rate = CurrentAttackRate;

--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.Tilemaps;
 using VinTools.BetterRuleTiles;
+using static TimelessEchoes.TELogger;
 
 namespace TimelessEchoes.MapGeneration
 {
@@ -92,7 +93,7 @@ namespace TimelessEchoes.MapGeneration
             {
                 if (decor == null) return;
                 foreach (var entry in decor) entry.UpdateName();
-                Debug.Log("Decor entry names updated for search.");
+                TELogger.Log("Decor entry names updated for search.", TELogCategory.Map);
             }
 
             [Searchable] [ListDrawerSettings(ListElementLabelName = "Name", ShowFoldout = false)]

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -62,7 +62,7 @@ namespace TimelessEchoes.Tasks
             {
                 hero = GetComponentInChildren<HeroController>(true);
                 if (hero == null)
-                    Log("TaskController hero reference is null", this);
+                    Log("TaskController hero reference is null", TELogCategory.Task, this);
             }
         }
 
@@ -154,7 +154,7 @@ namespace TimelessEchoes.Tasks
         {
             AcquireHero();
             if (hero == null)
-                Log("ResetTasks called but hero is null", this);
+                Log("ResetTasks called but hero is null", TELogCategory.Task, this);
             currentIndex = -1;
             tasks.Clear();
             taskMap.Clear();
@@ -268,7 +268,7 @@ namespace TimelessEchoes.Tasks
         public void SelectEarliestTask()
         {
             if (hero == null)
-                Log("SelectEarliestTask called but hero is null", this);
+                Log("SelectEarliestTask called but hero is null", TELogCategory.Task, this);
             RemoveCompletedTasks();
             for (var i = 0; i < tasks.Count; i++)
             {
@@ -282,7 +282,7 @@ namespace TimelessEchoes.Tasks
                     currentTaskObject = obj;
                 else if (task is MonoBehaviour mb)
                     currentTaskObject = mb;
-                Log($"Starting task: {currentTaskName}", this);
+                Log($"Starting task: {currentTaskName}", TELogCategory.Task, this);
                 hero?.SetTask(task);
                 task.StartTask();
                 taskStartTimes[task] = Time.time;
@@ -291,7 +291,7 @@ namespace TimelessEchoes.Tasks
 
             currentTaskName = "Complete";
             currentIndex = tasks.Count;
-            Log("All tasks complete", this);
+            Log("All tasks complete", TELogCategory.Task, this);
             currentTaskObject = null;
         }
 

--- a/Assets/Scripts/Tools/TELogger.cs
+++ b/Assets/Scripts/Tools/TELogger.cs
@@ -1,20 +1,52 @@
+using System.Collections.Generic;
 using System.Diagnostics;
+using QFSW.QC;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
 
 namespace TimelessEchoes
 {
+    public enum TELogCategory
+    {
+        General,
+        Hero,
+        Task,
+        Combat,
+        Map
+    }
+
     public static class TELogger
     {
+        private static readonly HashSet<TELogCategory> _enabledCategories = new()
+        {
+            TELogCategory.General,
+            TELogCategory.Hero,
+            TELogCategory.Task,
+            TELogCategory.Combat,
+            TELogCategory.Map
+        };
+
         [Conditional("UNITY_EDITOR")]
         [Conditional("DEVELOPMENT_BUILD")]
-        public static void Log(string message, Object context = null)
+        public static void Log(string message, TELogCategory category = TELogCategory.General,
+            Object context = null)
         {
+            if (!_enabledCategories.Contains(category)) return;
+
             if (context != null)
                 Debug.Log(message, context);
             else
                 Debug.Log(message);
         }
+
+        [Command("enable-log", "Enable logging for a category")] 
+        public static void EnableLogCategory(TELogCategory category) => _enabledCategories.Add(category);
+
+        [Command("disable-log", "Disable logging for a category")]
+        public static void DisableLogCategory(TELogCategory category) => _enabledCategories.Remove(category);
+
+        [Command("list-log-categories", "Lists currently enabled log categories")]
+        public static IEnumerable<TELogCategory> ListLogCategories() => _enabledCategories;
     }
 }


### PR DESCRIPTION
## Summary
- add `TELogCategory` enumeration and toggle methods
- integrate Quantum Console commands for enabling/disabling log categories
- categorize hero and task logs
- show map generation messages via `TELogger`

## Testing
- `pytest -q` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_686a047e56b8832ebe6423cb4a4fc41f