### PR TITLE
Restore StatUpgradeUIReferences script

### DIFF
--- a/Assets/Scripts/References/UI/StatUpgradeUIReferences.cs
+++ b/Assets/Scripts/References/UI/StatUpgradeUIReferences.cs
@@ -1,0 +1,14 @@
+using References.UI;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class StatUpgradeUIReferences : MonoBehaviour
+{
+    public CostResourceUIReferences costSlotPrefab;
+    public GameObject costGridLayoutParent;
+    public TMP_Text statUpgradeInfoText;
+    public Button upgradeButton;
+    public Button descriptionButton;
+    public GameObject descriptionPanel;
+}


### PR DESCRIPTION
## Summary
- restore missing `StatUpgradeUIReferences` script used by StatCost_Popup

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686af32247d8832eb79f9983c224f17a