### PR TITLE
Fix resource slot selection

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -158,6 +158,8 @@ namespace TimelessEchoes.Upgrades
         public void HighlightResource(Resource resource)
         {
             var index = resources.IndexOf(resource);
+            if (index < 0)
+                index = resources.FindIndex(r => r != null && resource != null && r.name == resource.name);
             if (index >= 0)
             {
                 if (inventoryWindow != null && !inventoryWindow.activeSelf)

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -95,9 +95,12 @@ namespace TimelessEchoes.Upgrades
             costSlots.Clear();
             for (int i = 0; i < statReferences.Count && i < upgrades.Count; i++)
             {
+                var refs = statReferences[i];
                 var list = new List<CostResourceUIReferences>();
-                var parent = statReferences[i].costGridLayoutParent;
-                if (parent != null && costSlotPrefab != null)
+                var parent = refs.costGridLayoutParent;
+                var prefab = refs.costSlotPrefab != null ? refs.costSlotPrefab : costSlotPrefab;
+
+                if (parent != null && prefab != null)
                 {
                     foreach (Transform child in parent.transform)
                         Destroy(child.gameObject);
@@ -107,11 +110,12 @@ namespace TimelessEchoes.Upgrades
                     {
                         foreach (var req in threshold.requirements)
                         {
-                            var slot = Instantiate(costSlotPrefab, parent.transform);
+                            var slot = Instantiate(prefab, parent.transform);
                             slot.resource = req.resource;
                             if (slot.selectButton != null)
                             {
                                 var res = req.resource;
+                                slot.selectButton.onClick.RemoveAllListeners();
                                 slot.selectButton.onClick.AddListener(() => resourceInventoryUI?.HighlightResource(res));
                             }
                             list.Add(slot);


### PR DESCRIPTION
## Summary
- instantiate upgrade cost slots per requirement and use stat-specific prefabs
- improve resource highlighting by falling back to matching by name

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af40a3cec832e930b68348fdf11d5