### PR TITLE
Fix cost slot rebuild timing

### DIFF
--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -78,10 +78,8 @@ namespace TimelessEchoes.Upgrades
 
         private void OnShowLevelTextChanged()
         {
+            BuildAllCostSlots();
             UpdateStatLevels();
-            UpdateAllCostSlotValues();
-            UpdateStatDisplayValues();
-            UpdateUpgradeButtons();
         }
 
         private void OnLoadDataHandler()


### PR DESCRIPTION
## Summary
- rebuild cost slots whenever the level text toggles or data loads so threshold requirements match hero level

## Testing
- `echo no tests`

------
https://chatgpt.com/codex/tasks/task_e_686b22c67d58832eb70ff47afdfea96f