### PR TITLE
Fix tooltip persistence on inventory toggle

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -73,12 +73,20 @@ namespace TimelessEchoes.Upgrades
             if (resourceManager != null)
                 resourceManager.OnInventoryChanged += UpdateSlots;
             UpdateSlots();
+
+            if (selectedIndex >= 0)
+                ShowTooltip(selectedIndex);
         }
 
         private void OnDisable()
         {
             if (resourceManager != null)
                 resourceManager.OnInventoryChanged -= UpdateSlots;
+
+            if (tooltip != null)
+                tooltip.gameObject.SetActive(false);
+
+            DeselectSlot();
         }
 
         private void Update()


### PR DESCRIPTION
## Summary
- reopen inventory without losing selection tooltip
- automatically deselect slots and hide tooltip when closing window

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b2865856c832ebfa3ba1558a44b16