### PR TITLE
Fix resource sorting on stat screen

### DIFF
--- a/Assets/Scripts/UI/ItemStatsPanelUI.cs
+++ b/Assets/Scripts/UI/ItemStatsPanelUI.cs
@@ -60,7 +60,7 @@ namespace TimelessEchoes.UI
 
             var allResources = Resources.LoadAll<Resource>("Resources");
             var sorted = allResources
-                .OrderBy(r => r.resourceID)
+                .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
                 .ThenBy(r => r.name)
                 .ToList();
             defaultOrder = sorted;


### PR DESCRIPTION
## Summary
- ensure resources are ordered numerically by casting IDs to integers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b29ac6340832ea63d9b652b958a0c