### PR TITLE
Implement inventory persist and right-click close

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -6,8 +6,9 @@ using UnityEngine.UI;
 namespace TimelessEchoes.UI
 {
     /// <summary>
-    /// Manages the town UI windows. Clicking a button closes all windows and
-    /// opens the associated one. The Start Run button only closes the windows.
+    /// Manages the town UI windows. Clicking a button closes all windows except
+    /// the inventory and opens the associated one. The Start Run button only
+    /// closes the windows. Right-click closes all windows.
     /// </summary>
     public class TownWindowManager : MonoBehaviour
     {
@@ -61,6 +62,12 @@ namespace TimelessEchoes.UI
                 startRunButton.onClick.RemoveListener(CloseAllWindows);
         }
 
+        private void Update()
+        {
+            if (Input.GetMouseButtonDown(1))
+                CloseAllWindows();
+        }
+
         private void OpenUpgrades() => OpenWindow(upgrades.window);
         private void OpenBuffs() => OpenWindow(buffs.window);
         private void OpenQuests() => OpenWindow(quests.window);
@@ -73,9 +80,21 @@ namespace TimelessEchoes.UI
 
         private void OpenWindow(GameObject window)
         {
-            CloseAllWindows();
+            CloseAllWindowsExceptInventory();
             if (window != null)
                 window.SetActive(true);
+        }
+
+        private void CloseAllWindowsExceptInventory()
+        {
+            if (upgrades.window != null)
+                upgrades.window.SetActive(false);
+            if (buffs.window != null)
+                buffs.window.SetActive(false);
+            if (quests.window != null)
+                quests.window.SetActive(false);
+            if (credits.window != null)
+                credits.window.SetActive(false);
         }
 
         private void CloseAllWindows()


### PR DESCRIPTION
## Summary
- allow other buttons to keep the inventory open
- close all windows when the user right-clicks
- clarify behaviour in the class summary

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b2d1c0ad4832e80b3584f2512fb32