### PR TITLE
Fix task generator minX application

### DIFF
--- a/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
+++ b/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
@@ -102,7 +102,11 @@ namespace TimelessEchoes.MapGeneration
 
             var tasksRoot = new GameObject($"SegmentTasks_{offset.x}");
             tasksRoot.transform.SetParent(segmentParent, false);
-            taskGenerator.GenerateSegment(offset.x, offset.x + segmentSize.x, tasksRoot.transform);
+
+            var minX = Mathf.Max(taskGenerator.MinX, offset.x);
+            var maxX = offset.x + segmentSize.x;
+            if (maxX > minX)
+                taskGenerator.GenerateSegment(minX, maxX, tasksRoot.transform);
 
             segments.Enqueue(new Segment { startX = offset.x, tasks = tasksRoot });
             nextSegmentX += segmentSize.x;

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -87,6 +87,11 @@ namespace TimelessEchoes.Tasks
         /// </summary>
         public Transform SpawnParent { get; set; }
 
+        /// <summary>
+        /// Minimum world X value allowed for spawned tasks.
+        /// </summary>
+        public float MinX => minX;
+
         private TaskController controller;
 
         /// <summary>


### PR DESCRIPTION
## Summary
- expose minX via `MinX` property on `ProceduralTaskGenerator`
- ensure `SegmentedMapGenerator` uses the global minX when spawning tasks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b2fb40350832eaefb87c41e5084f7