### PR TITLE
Add configurable health bar visuals

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -9,6 +9,8 @@ namespace TimelessEchoes.Enemies
     {
         [SerializeField] private int maxHealth = 10;
         [SerializeField] private SlicedFilledImage healthBar;
+        [SerializeField, Range(0f, 1f)] private float minFillPercent = 0.05f;
+        [SerializeField] private HealthBarSpriteOption[] barSprites;
 
         private void Awake()
         {
@@ -67,8 +69,35 @@ namespace TimelessEchoes.Enemies
 
         private void UpdateBar()
         {
-            if (healthBar != null)
-                healthBar.fillAmount = CurrentHealth / MaxHealth;
+            if (healthBar == null) return;
+
+            float percent = MaxHealth > 0f ? CurrentHealth / MaxHealth : 0f;
+            healthBar.fillAmount = Mathf.Max(percent, minFillPercent);
+
+            if (barSprites != null && barSprites.Length > 0)
+            {
+                Sprite chosen = healthBar.sprite;
+                float best = -1f;
+                foreach (var opt in barSprites)
+                {
+                    if (opt.sprite == null) continue;
+                    if (percent >= opt.minPercent && opt.minPercent > best)
+                    {
+                        chosen = opt.sprite;
+                        best = opt.minPercent;
+                    }
+                }
+
+                if (chosen != null)
+                    healthBar.sprite = chosen;
+            }
+        }
+
+        [Serializable]
+        public struct HealthBarSpriteOption
+        {
+            public Sprite sprite;
+            [Range(0f, 1f)] public float minPercent;
         }
     }
 }

--- a/Assets/Scripts/Tests/Editor/HealthTests.cs
+++ b/Assets/Scripts/Tests/Editor/HealthTests.cs
@@ -1,6 +1,8 @@
 using NUnit.Framework;
 using UnityEngine;
 using TimelessEchoes.Enemies;
+using Blindsided.Utilities;
+using System.Reflection;
 
 namespace TimelessEchoes.Tests
 {
@@ -35,6 +37,47 @@ namespace TimelessEchoes.Tests
         {
             health.TakeDamage(3f);
             Assert.AreEqual(7f, health.CurrentHealth);
+        }
+
+        [Test]
+        public void FillAmountClampedToMinimum()
+        {
+            var barObj = new GameObject();
+            var bar = barObj.AddComponent<SlicedFilledImage>();
+            var barField = typeof(Health).GetField("healthBar", BindingFlags.NonPublic | BindingFlags.Instance);
+            barField.SetValue(health, bar);
+            var minField = typeof(Health).GetField("minFillPercent", BindingFlags.NonPublic | BindingFlags.Instance);
+            minField.SetValue(health, 0.2f);
+
+            health.TakeDamage(10f);
+
+            Assert.AreEqual(0.2f, bar.fillAmount);
+            Object.DestroyImmediate(barObj);
+        }
+
+        [Test]
+        public void SpriteChangesWithHealthPercent()
+        {
+            var barObj = new GameObject();
+            var bar = barObj.AddComponent<SlicedFilledImage>();
+            var barField = typeof(Health).GetField("healthBar", BindingFlags.NonPublic | BindingFlags.Instance);
+            barField.SetValue(health, bar);
+
+            var sprite1 = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+            var sprite2 = Sprite.Create(Texture2D.blackTexture, new Rect(0, 0, 1, 1), Vector2.zero);
+
+            var options = new Health.HealthBarSpriteOption[2];
+            options[0] = new Health.HealthBarSpriteOption { sprite = sprite1, minPercent = 0.25f };
+            options[1] = new Health.HealthBarSpriteOption { sprite = sprite2, minPercent = 0f };
+            var optField = typeof(Health).GetField("barSprites", BindingFlags.NonPublic | BindingFlags.Instance);
+            optField.SetValue(health, options);
+
+            health.TakeDamage(0f); // update bar
+            Assert.AreEqual(sprite1, bar.sprite);
+
+            health.TakeDamage(8f); // drop below 25%
+            Assert.AreEqual(sprite2, bar.sprite);
+            Object.DestroyImmediate(barObj);
         }
     }
 }


### PR DESCRIPTION
## Summary
- improve health bar script with sprite options and minimum fill amount
- test health bar visual updates

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b304e4148832e9909198d1ac9aa8f