### PR TITLE
Update woodcutting bar sprites

### DIFF
--- a/Assets/Prefabs/Tasks/Woodcutting/Large Birch.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Large Birch.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Large Fruit.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Large Fruit.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Large Oak.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Large Oak.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Large Spruce.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Large Spruce.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Medium Birch.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Medium Birch.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Medium Fruit.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Medium Fruit.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Medium Oak.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Medium Oak.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Medium Spruce.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Medium Spruce.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Small Birch.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Small Birch.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Small Fruit.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Small Fruit.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Small Oak.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Small Oak.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Tasks/Woodcutting/Small Spruce.prefab
+++ b/Assets/Prefabs/Tasks/Woodcutting/Small Spruce.prefab
@@ -359,7 +359,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 9035060615272221303, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
+  m_Sprite: {fileID: -5162992721624225379, guid: 1fd662efbd65948b38ca87c1bc1bab06, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1


### PR DESCRIPTION
## Summary
- adjust woodcutting tree prefabs so progress bars use **UI_Bars_23** sprite

## Testing
- `grep -r -n -- '-5162992721624225379' Assets/Prefabs/Tasks/Woodcutting | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_686b312e10f4832eab4171545a405437