### PR TITLE
Switch taskID field to int

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -35,7 +35,7 @@ namespace Blindsided.SaveData
         public Dictionary<string, QuestRecord> Quests = new();
 
         [HideReferenceObjectPicker]
-        public Dictionary<string, TaskRecord> TaskRecords = new();
+        public Dictionary<int, TaskRecord> TaskRecords = new();
 
         [HideReferenceObjectPicker]
         public Dictionary<string, ResourceRecord> ResourceStats = new();

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -48,7 +48,7 @@ namespace TimelessEchoes.Stats
 
         private Vector3 lastHeroPos;
         private static Dictionary<string, Resource> lookup;
-        private static Dictionary<string, TaskData> taskLookup;
+        private static Dictionary<int, TaskData> taskLookup;
 
         private void Awake()
         {
@@ -77,10 +77,10 @@ namespace TimelessEchoes.Stats
         private static void EnsureTaskLookup()
         {
             if (taskLookup != null) return;
-            taskLookup = new Dictionary<string, TaskData>();
+            taskLookup = new Dictionary<int, TaskData>();
             foreach (var data in Resources.LoadAll<TaskData>(""))
             {
-                if (data != null && !string.IsNullOrEmpty(data.taskID) && !taskLookup.ContainsKey(data.taskID))
+                if (data != null && !taskLookup.ContainsKey(data.taskID))
                     taskLookup[data.taskID] = data;
             }
         }
@@ -89,7 +89,7 @@ namespace TimelessEchoes.Stats
         {
             if (oracle == null) return;
 
-            var t = new Dictionary<string, GameData.TaskRecord>();
+            var t = new Dictionary<int, GameData.TaskRecord>();
             foreach (var pair in taskRecords)
                 if (pair.Key != null)
                     t[pair.Key.taskID] = pair.Value;
@@ -117,7 +117,7 @@ namespace TimelessEchoes.Stats
             if (oracle == null) return;
             EnsureLookup();
 
-            oracle.saveData.TaskRecords ??= new Dictionary<string, GameData.TaskRecord>();
+            oracle.saveData.TaskRecords ??= new Dictionary<int, GameData.TaskRecord>();
             oracle.saveData.General ??= new GameData.GeneralStats();
 
             taskRecords.Clear();

--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -11,7 +11,7 @@ namespace TimelessEchoes.Tasks
     public class TaskData : ScriptableObject
     {
         public string taskName;
-        public string taskID;
+        public int taskID;
         public Sprite taskIcon;
         public Skill associatedSkill;
         public float xpForCompletion;


### PR DESCRIPTION
## Summary
- update `TaskData` to use an integer `taskID`
- revise `GameData` save structure
- adjust `GameplayStatTracker` for new task ID type

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b34718560832e8b3423bf3696f15a