### PR TITLE
Ensure quests unlock only after meeting NPCs

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -65,7 +65,11 @@ namespace TimelessEchoes.Quests
             oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
             active.Clear();
             foreach (var q in startingQuests)
-                TryStartQuest(q);
+            {
+                if (q == null) continue;
+                if (string.IsNullOrEmpty(q.npcId) || StaticReferences.CompletedNpcTasks.Contains(q.npcId))
+                    TryStartQuest(q);
+            }
             RefreshNoticeboard();
         }
 
@@ -158,9 +162,26 @@ namespace TimelessEchoes.Quests
             QuestHandin(id);
         }
 
+        /// <summary>
+        /// Called when an NPC with the given id is met. Starts any pending quests tied to that NPC.
+        /// </summary>
+        public void OnNpcMet(string id)
+        {
+            if (string.IsNullOrEmpty(id)) return;
+            foreach (var q in startingQuests)
+            {
+                if (q == null) continue;
+                if (q.npcId == id)
+                    TryStartQuest(q);
+            }
+            RefreshNoticeboard();
+        }
+
         private void TryStartQuest(QuestData quest)
         {
             if (quest == null) return;
+            if (!string.IsNullOrEmpty(quest.npcId) && !StaticReferences.CompletedNpcTasks.Contains(quest.npcId))
+                return;
             if (oracle.saveData.Quests.TryGetValue(quest.questId, out var rec) && rec.Completed)
                 return;
 

--- a/Assets/Scripts/Tasks/TalkToNpcTask.cs
+++ b/Assets/Scripts/Tasks/TalkToNpcTask.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Blindsided.SaveData;
 using TMPro;
+using TimelessEchoes.Quests;
 using UnityEngine;
 using UnityEngine.UI;
 using TimelessEchoes.Hero;
@@ -78,7 +79,11 @@ namespace TimelessEchoes.Tasks
                 dialogueObject.SetActive(false);
             talked = true;
             if (!string.IsNullOrEmpty(npcId))
+            {
                 StaticReferences.CompletedNpcTasks.Add(npcId);
+                var qm = FindFirstObjectByType<QuestManager>();
+                qm?.OnNpcMet(npcId);
+            }
             GrantCompletionXP();
         }
 

--- a/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
+++ b/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using Blindsided;
+using Blindsided.SaveData;
+using TimelessEchoes.Quests;
+
+namespace TimelessEchoes.Tests
+{
+    public class QuestManagerTests
+    {
+        private GameObject oracleObj;
+        private Oracle oracle;
+        private GameObject managerObj;
+        private QuestManager manager;
+        private QuestData quest;
+
+        [SetUp]
+        public void SetUp()
+        {
+            oracleObj = new GameObject();
+            oracle = oracleObj.AddComponent<Oracle>();
+            managerObj = new GameObject();
+            manager = managerObj.AddComponent<QuestManager>();
+            quest = ScriptableObject.CreateInstance<QuestData>();
+            quest.questId = "Q1";
+            quest.npcId = "NPC1";
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(managerObj);
+            Object.DestroyImmediate(oracleObj);
+            Object.DestroyImmediate(quest);
+            Oracle.oracle = null;
+        }
+
+        [Test]
+        public void TryStartQuest_DoesNotActivateWithoutNpc()
+        {
+            var method = typeof(QuestManager).GetMethod("TryStartQuest", BindingFlags.NonPublic | BindingFlags.Instance);
+            method.Invoke(manager, new object[] { quest });
+            var field = typeof(QuestManager).GetField("active", BindingFlags.NonPublic | BindingFlags.Instance);
+            var dict = (System.Collections.IDictionary)field.GetValue(manager);
+            Assert.IsFalse(dict.Contains("Q1"));
+        }
+
+        [Test]
+        public void OnNpcMet_StartsQuest()
+        {
+            typeof(QuestManager).GetField("startingQuests", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(manager, new List<QuestData> { quest });
+
+            StaticReferences.CompletedNpcTasks.Add("NPC1");
+            manager.OnNpcMet("NPC1");
+
+            var field = typeof(QuestManager).GetField("active", BindingFlags.NonPublic | BindingFlags.Instance);
+            var dict = (System.Collections.IDictionary)field.GetValue(manager);
+            Assert.IsTrue(dict.Contains("Q1"));
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- refresh quests when NPCs are first met
- skip starting quests until their NPC has been encountered
- notify `QuestManager` when ending NPC conversations
- unit tests for new `QuestManager` behaviour

## Testing
- `unity-editor -runTests -projectPath .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3be51888832eb1c59b85e5d73312