### PR TITLE
Add Odin Inspector usage for quests

### DIFF
--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Blindsided.Utilities;
 using TimelessEchoes.Upgrades;
 using TimelessEchoes.Enemies;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace TimelessEchoes.Quests
@@ -25,9 +26,13 @@ namespace TimelessEchoes.Quests
         public class Requirement
         {
             public RequirementType type;
+            [ShowIf("type", RequirementType.Resource)]
             public Resource resource;
             public int amount = 1;
+            [ShowIf("type", RequirementType.Kill)]
             public List<EnemyStats> enemies = new();
+            [ShowIf("type", RequirementType.Kill)]
+            public Sprite killIcon;
         }
 
         public enum RequirementType

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -46,11 +46,15 @@ namespace TimelessEchoes.Quests
                 if (data != null && costSlotPrefab != null)
                     foreach (var req in data.requirements)
                     {
-                        if (req.type != QuestData.RequirementType.Resource) continue;
                         var slot = Instantiate(costSlotPrefab, costParent);
-                        slot.resource = req.resource;
+                        slot.resource = req.type == QuestData.RequirementType.Resource ? req.resource : null;
                         if (slot.iconImage != null)
-                            slot.iconImage.sprite = req.resource ? req.resource.icon : null;
+                        {
+                            if (req.type == QuestData.RequirementType.Resource)
+                                slot.iconImage.sprite = req.resource ? req.resource.icon : null;
+                            else if (req.type == QuestData.RequirementType.Kill)
+                                slot.iconImage.sprite = req.killIcon;
+                        }
                         if (slot.countText != null)
                             slot.countText.text = req.amount.ToString();
                     }


### PR DESCRIPTION
## Summary
- hide quest fields with Odin ShowIf
- add kill sprite field for kill requirements
- display kill icons when showing quest requirements

## Testing
- `nunit3-console --version` *(fails: command not found)*
- `unity-editor -quit -batchmode -runTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b5fcc462c832eaf0e8f9f8c94bcee