### PR TITLE
Add console logs for gameplay events

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -4,6 +4,7 @@ using TimelessEchoes.Upgrades;
 using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
+using static TimelessEchoes.TELogger;
 
 namespace TimelessEchoes.Buffs
 {
@@ -95,6 +96,8 @@ namespace TimelessEchoes.Buffs
                     activeBuffs.RemoveAt(i);
                     if (buff.recipe != null)
                         oracle.saveData.ActiveBuffs.Remove(buff.recipe.name);
+                    if (buff.recipe != null)
+                        TELogger.Log($"Buff {buff.recipe.name} expired", TELogCategory.Buff, this);
                 }
                 else if (buff.recipe != null)
                 {
@@ -125,6 +128,7 @@ namespace TimelessEchoes.Buffs
             {
                 buff = new ActiveBuff { recipe = recipe, remaining = recipe.baseDuration };
                 activeBuffs.Add(buff);
+                TELogger.Log($"Buff {recipe.name} added", TELogCategory.Buff, this);
             }
             else
             {
@@ -132,6 +136,7 @@ namespace TimelessEchoes.Buffs
                 if (diminishingCurve != null)
                     extra *= diminishingCurve.Evaluate(buff.remaining);
                 buff.remaining += extra;
+                TELogger.Log($"Buff {recipe.name} extended", TELogCategory.Buff, this);
             }
 
             oracle.saveData.ActiveBuffs ??= new Dictionary<string, float>();

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using TimelessEchoes.Upgrades;
 using TimelessEchoes.Stats;
 using System.Collections.Generic;
+using static TimelessEchoes.TELogger;
 
 namespace TimelessEchoes.Enemies
 {
@@ -195,6 +196,8 @@ namespace TimelessEchoes.Enemies
                 resourceManager = FindFirstObjectByType<ResourceManager>();
             if (resourceManager == null) return;
 
+            TELogger.Log($"Enemy {name} died", TELogCategory.Combat, this);
+
             foreach (var drop in resourceDrops)
             {
                 if (drop.resource == null) continue;
@@ -209,6 +212,7 @@ namespace TimelessEchoes.Enemies
                 if (count > 0)
                 {
                     resourceManager.Add(drop.resource, count);
+                    TELogger.Log($"Dropped {count} {drop.resource.name}", TELogCategory.Resource, this);
                 }
             }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -10,6 +10,7 @@ using Unity.Cinemachine;
 using UnityEngine;
 using UnityEngine.UI;
 using TimelessEchoes.NPC;
+using static TimelessEchoes.TELogger;
 
 namespace TimelessEchoes
 {
@@ -62,6 +63,7 @@ namespace TimelessEchoes
         private void StartRun()
         {
             HideTooltip();
+            TELogger.Log("Run starting", TELogCategory.Run, this);
             StartCoroutine(StartRunRoutine());
         }
 
@@ -125,6 +127,8 @@ namespace TimelessEchoes
                     hp.OnDeath -= OnHeroDeath;
             }
 
+            TELogger.Log("Hero death", TELogCategory.Hero, this);
+
             var tracker = FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
             if (tracker != null)
             {
@@ -151,6 +155,7 @@ namespace TimelessEchoes
             tavernUI?.SetActive(true);
             mapUI?.SetActive(false);
             npcObjectStateController?.UpdateObjectStates();
+            TELogger.Log("Returned to tavern", TELogCategory.Run, this);
         }
 
         private void CleanupMap()

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -7,6 +7,7 @@ using TimelessEchoes.Upgrades;
 using UnityEngine;
 using static Blindsided.Oracle;
 using static Blindsided.EventHandler;
+using static TimelessEchoes.TELogger;
 
 namespace TimelessEchoes.Quests
 {
@@ -159,6 +160,7 @@ namespace TimelessEchoes.Quests
                 TryStartQuest(inst.data.nextQuest);
 
             RefreshNoticeboard();
+            TELogger.Log($"Quest {id} completed", TELogCategory.Quest, this);
             QuestHandin(id);
         }
 

--- a/Assets/Scripts/Tools/TELogger.cs
+++ b/Assets/Scripts/Tools/TELogger.cs
@@ -13,7 +13,12 @@ namespace TimelessEchoes
         Hero,
         Task,
         Combat,
-        Map
+        Map,
+        Resource,
+        Quest,
+        Buff,
+        Upgrade,
+        Run
     }
 
     public static class TELogger
@@ -24,7 +29,12 @@ namespace TimelessEchoes
             TELogCategory.Hero,
             TELogCategory.Task,
             TELogCategory.Combat,
-            TELogCategory.Map
+            TELogCategory.Map,
+            TELogCategory.Resource,
+            TELogCategory.Quest,
+            TELogCategory.Buff,
+            TELogCategory.Upgrade,
+            TELogCategory.Run
         };
 
         [Conditional("UNITY_EDITOR")]

--- a/Assets/Scripts/Upgrades/StatUpgradeController.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
+using static TimelessEchoes.TELogger;
 
 namespace TimelessEchoes.Upgrades
 {
@@ -92,6 +93,7 @@ namespace TimelessEchoes.Upgrades
             }
 
             levels[upgrade] = GetLevel(upgrade) + 1;
+            TELogger.Log($"Upgraded {upgrade.name} to level {levels[upgrade]}", TELogCategory.Upgrade, this);
             return true;
         }
 


### PR DESCRIPTION
## Summary
- extend `TELogCategory` with new categories
- log enemy deaths and resource drops
- log quest completion
- log stat upgrades
- log buff additions/expiry
- log run start, hero death and returning to tavern

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b7529cd80832e9753b639da55ae2c