### PR TITLE
Add Quantum Console debugging commands

### DIFF
--- a/Assets/Scripts/Tools/ConsoleCommands.cs
+++ b/Assets/Scripts/Tools/ConsoleCommands.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using QFSW.QC;
+using UnityEngine;
+using TimelessEchoes.Upgrades;
+using TimelessEchoes.Skills;
+using Blindsided.SaveData;
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Console commands for debugging resource, stat and skill progression.
+    /// </summary>
+    public static class ConsoleCommands
+    {
+        [Command("add-resource", "Add an amount of a resource by name")]
+        public static void AddResource(string resourceName, double amount)
+        {
+            var manager = Object.FindFirstObjectByType<ResourceManager>();
+            if (manager == null) return;
+
+            var res = Resources.LoadAll<Resource>(string.Empty).FirstOrDefault(r => r.name == resourceName);
+            if (res != null)
+            {
+                manager.Add(res, amount);
+            }
+        }
+
+        [Command("set-stat-level", "Set the level of a stat upgrade")]
+        public static void SetStatLevel(string upgradeName, int level)
+        {
+            var upgrade = Resources.FindObjectsOfTypeAll<StatUpgrade>().FirstOrDefault(u => u.name == upgradeName);
+            if (upgrade == null) return;
+            var oracle = Blindsided.Oracle.oracle;
+            if (oracle == null) return;
+            oracle.saveData.UpgradeLevels ??= new Dictionary<string, int>();
+            oracle.saveData.UpgradeLevels[upgrade.name] = level;
+            Blindsided.EventHandler.LoadData();
+        }
+
+        [Command("set-skill-level", "Set the level of a skill")]
+        public static void SetSkillLevel(string skillName, int level)
+        {
+            var skill = Resources.FindObjectsOfTypeAll<Skill>().FirstOrDefault(s => s.name == skillName);
+            if (skill == null) return;
+            var oracle = Blindsided.Oracle.oracle;
+            if (oracle == null) return;
+            oracle.saveData.SkillData ??= new Dictionary<string, GameData.SkillProgress>();
+            if (!oracle.saveData.SkillData.TryGetValue(skill.name, out var prog))
+                prog = new GameData.SkillProgress();
+            prog.Level = level;
+            prog.CurrentXP = 0f;
+            oracle.saveData.SkillData[skill.name] = prog;
+            Blindsided.EventHandler.LoadData();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ConsoleCommands` with Quantum Console commands for debug convenience
  - `add-resource` adds a resource by name
  - `set-stat-level` sets stat upgrade levels directly
  - `set-skill-level` sets skill levels directly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b9d138134832e968efbc7d8a043bd