### PR TITLE
Implement run-ending behaviors

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -67,6 +67,7 @@ namespace TimelessEchoes.Hero
         private TaskController taskController;
         public ITask CurrentTask { get; private set; }
         public Animator Animator => animator;
+        public bool InCombat => state == State.Combat;
 
         private float CurrentAttackRate =>
             (baseAttackSpeed + attackSpeedBonus) *

--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -24,6 +24,10 @@ namespace TimelessEchoes.Upgrades
         private readonly List<Resource> resources = new();
         private readonly List<ResourceUIReferences> slots = new();
         private readonly Dictionary<Resource, double> amounts = new();
+        /// <summary>
+        /// Current amounts collected during this run.
+        /// </summary>
+        public IReadOnlyDictionary<Resource, double> Amounts => amounts;
         private int selectedIndex = -1;
 
         private void Awake()
@@ -60,6 +64,14 @@ namespace TimelessEchoes.Upgrades
                     tooltip.gameObject.SetActive(false);
                 DeselectSlot();
             }
+        }
+
+        /// <summary>
+        ///     Clears all collected resource counts.
+        /// </summary>
+        public void ResetDrops()
+        {
+            ClearDrops();
         }
 
         private void ClearDrops()


### PR DESCRIPTION
## Summary
- expose Hero combat status
- allow RunDropUI counters to be reset and queried
- update GameManager to manage death UI and bonus resources
- use `SlicedFilledImage` for the death timer

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ba568660c832ea82ec364b29412db