### PR TITLE
Fix hero movement after death

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -169,6 +169,12 @@ namespace TimelessEchoes
                 var hp = hero.GetComponent<Health>();
                 if (hp != null)
                     hp.OnDeath -= OnHeroDeath;
+
+                // Disable hero so it stops moving during the death window
+                var ai = hero.GetComponent<AIPath>();
+                if (ai != null)
+                    ai.enabled = false;
+                hero.gameObject.SetActive(false);
             }
 
             TELogger.Log("Hero death", TELogCategory.Hero, this);


### PR DESCRIPTION
## Summary
- disable hero object and AI when the hero dies so it no longer moves during the death window

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_686baddcfab8832e82e82794cef1fe8e