### PR TITLE
Add kills graph mode to RunStatsPanelUI

### DIFF
--- a/Assets/Scripts/UI/StatSortingManager.cs
+++ b/Assets/Scripts/UI/StatSortingManager.cs
@@ -170,6 +170,12 @@ namespace TimelessEchoes.UI
                 if (runStatsPanel != null) runStatsPanel.SetGraphMode(runMode);
                 UpdateButtonStates();
             });
+            CreateButton(RunStatsPanelUI.GraphMode.Kills, () =>
+            {
+                runMode = RunStatsPanelUI.GraphMode.Kills;
+                if (runStatsPanel != null) runStatsPanel.SetGraphMode(runMode);
+                UpdateButtonStates();
+            });
             UpdateButtonStates();
         }
 


### PR DESCRIPTION
## Summary
- extend RunStatsPanelUI with kills graph mode
- provide separate bar colours for distance, resources and kills modes
- enable selection of kills graph in StatSortingManager

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686c43e5cdd4832eb2d8528a1c0849ca