### PR TITLE
Add run status display on RunStatsPanel

### DIFF
--- a/Assets/Scripts/References/UI/RunStatUIReferences.cs
+++ b/Assets/Scripts/References/UI/RunStatUIReferences.cs
@@ -11,5 +11,6 @@ namespace TimelessEchoes.References.UI
         public TMP_Text runIdText;
         public TMP_Text distanceTasksResourcesText;
         public TMP_Text killsDamageDoneDamageTakenText;
+        public TMP_Text statusText;
     }
 }

--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -152,6 +152,7 @@ namespace TimelessEchoes.UI
                     $"Duration: {time}\nDistance: {dist}\nTasks: {tasks}\nResources: {resources}";
             }
 
+
             if (runStatUI.killsDamageDoneDamageTakenText != null)
             {
                 var kills = CalcUtils.FormatNumber(record.EnemiesKilled, true);
@@ -160,6 +161,9 @@ namespace TimelessEchoes.UI
                 runStatUI.killsDamageDoneDamageTakenText.text =
                     $"Kills: {kills}\nDamage Dealt: {dealt}\nDamage Taken: {taken}";
             }
+
+            if (runStatUI.statusText != null)
+                runStatUI.statusText.text = record.Died ? "Status: Died" : "Status: Retreated";
 
             runStatUI.gameObject.SetActive(true);
         }


### PR DESCRIPTION
## Summary
- add a `statusText` reference to `RunStatUIReferences`
- show `Died` or `Retreated` on the Run Stats Panel hover popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c45e3ec0c832eb23bb59ccd6c48dc