### PR TITLE
Implement dynamic retreat bonus

### DIFF
--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -45,6 +45,7 @@ namespace TimelessEchoes.Stats
         public float LongestRun => longestRun;
         public float ShortestRun => shortestRun;
         public float AverageRun => averageRun;
+        public int CurrentRunKills => currentRunKills;
 
         private Vector3 lastHeroPos;
         private static Dictionary<string, Resource> lookup;


### PR DESCRIPTION
## Summary
- show retreat bonus percent in UI
- reward bonus resources based on kill count
- track kill count via GameplayStatTracker
- ensure run history includes retreat bonus

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c986ce15c832e8a28a20e241a96dd