### PR TITLE
Implement run UI manager and expose hero stats

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -16,6 +16,7 @@ namespace TimelessEchoes.Enemies
         {
             CurrentHealth = maxHealth;
             UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
         }
 
         public void TakeDamage(float amount)
@@ -29,6 +30,7 @@ namespace TimelessEchoes.Enemies
             }
             CurrentHealth -= amount;
             UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
 
             // Show floating damage text
             ColorUtility.TryParseHtmlString("#C56260", out var red);
@@ -60,18 +62,31 @@ namespace TimelessEchoes.Enemies
             if (amount <= 0f || CurrentHealth >= MaxHealth) return;
             CurrentHealth = Mathf.Min(CurrentHealth + amount, MaxHealth);
             UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
         }
 
         public float CurrentHealth { get; private set; }
         public float MaxHealth => maxHealth;
 
+        public event Action<float, float> OnHealthChanged;
         public event Action OnDeath;
+
+        public SlicedFilledImage HealthBar
+        {
+            get => healthBar;
+            set
+            {
+                healthBar = value;
+                UpdateBar();
+            }
+        }
 
         public void Init(int hp)
         {
             maxHealth = hp;
             CurrentHealth = hp;
             UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
         }
 
         private void UpdateBar()

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -37,6 +37,7 @@ namespace TimelessEchoes
         [SerializeField] private GameObject tavernUI;
         [SerializeField] private GameObject mapUI;
         [SerializeField] private RunDropUI runDropUI;
+        [SerializeField] private RunCalebUIReferences runCalebUI;
         [SerializeField] private GameObject deathWindow;
         [SerializeField] private Button deathRunButton;
         [SerializeField] private Button deathReturnButton;
@@ -160,6 +161,10 @@ namespace TimelessEchoes
                 {
                     hp.Init((int)hp.MaxHealth);
                     hp.OnDeath += OnHeroDeath;
+                    if (runCalebUI == null)
+                        runCalebUI = FindFirstObjectByType<RunCalebUIReferences>();
+                    if (runCalebUI != null)
+                        hp.HealthBar = runCalebUI.healthBar;
                 }
             }
 
@@ -189,6 +194,10 @@ namespace TimelessEchoes
 
             tavernUI?.SetActive(false);
             mapUI?.SetActive(true);
+            if (runCalebUI == null)
+                runCalebUI = FindFirstObjectByType<RunCalebUIReferences>();
+            if (runCalebUI != null)
+                runCalebUI.gameObject.SetActive(true);
             npcObjectStateController?.UpdateObjectStates();
         }
 
@@ -301,6 +310,8 @@ namespace TimelessEchoes
                 tavernCamera.gameObject.SetActive(true);
             tavernUI?.SetActive(true);
             mapUI?.SetActive(false);
+            if (runCalebUI != null)
+                runCalebUI.gameObject.SetActive(false);
             npcObjectStateController?.UpdateObjectStates();
             TELogger.Log("Returned to tavern", TELogCategory.Run, this);
         }
@@ -315,6 +326,9 @@ namespace TimelessEchoes
             BuffManager.Instance?.Pause();
             if (mapCamera != null)
                 mapCamera.gameObject.SetActive(false);
+
+            if (runCalebUI != null)
+                runCalebUI.gameObject.SetActive(false);
 
             if (hero != null)
             {

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -69,6 +69,31 @@ namespace TimelessEchoes.Hero
         public Animator Animator => animator;
         public bool InCombat => state == State.Combat;
 
+        /// <summary>
+        /// Current attack damage after upgrades, buffs and dice multipliers.
+        /// </summary>
+        public float Damage =>
+            (baseDamage + damageBonus) *
+            (buffController != null ? buffController.DamageMultiplier : 1f) *
+            combatDamageMultiplier;
+
+        /// <summary>
+        /// Current attacks per second after upgrades and buffs.
+        /// </summary>
+        public float AttackRate => CurrentAttackRate;
+
+        /// <summary>
+        /// Current movement speed after upgrades and buffs.
+        /// </summary>
+        public float MoveSpeed =>
+            (baseMoveSpeed + moveSpeedBonus) *
+            (buffController != null ? buffController.MoveSpeedMultiplier : 1f);
+
+        /// <summary>
+        /// Maximum health after upgrades.
+        /// </summary>
+        public float MaxHealthValue => baseHealth + healthBonus;
+
         private float CurrentAttackRate =>
             (baseAttackSpeed + attackSpeedBonus) *
             (buffController != null ? buffController.AttackSpeedMultiplier : 1f);

--- a/Assets/Scripts/UI/RunCalebUIManager.cs
+++ b/Assets/Scripts/UI/RunCalebUIManager.cs
@@ -1,0 +1,135 @@
+using References.UI;
+using TimelessEchoes.Hero;
+using TimelessEchoes.Buffs;
+using TimelessEchoes.Regen;
+using TMPro;
+using UnityEngine;
+
+namespace TimelessEchoes.UI
+{
+    /// <summary>
+    /// Updates the run UI with the hero's current stats and handles the skills button.
+    /// </summary>
+    public class RunCalebUIManager : MonoBehaviour
+    {
+        [SerializeField] private RunCalebUIReferences uiReferences;
+        [SerializeField] private GameObject skillsWindow;
+        [SerializeField] private BuffManager buffManager;
+        [SerializeField] private RegenManager regenManager;
+
+        private HeroController hero;
+        private Health heroHealth;
+
+        private float lastDamage;
+        private float lastAttack;
+        private float lastMove;
+        private float lastDefense;
+        private float lastRegen;
+
+        private void Awake()
+        {
+            if (uiReferences == null)
+                uiReferences = GetComponent<RunCalebUIReferences>();
+            if (buffManager == null)
+                buffManager = FindFirstObjectByType<BuffManager>();
+            if (regenManager == null)
+                regenManager = FindFirstObjectByType<RegenManager>();
+            if (uiReferences != null && uiReferences.skillsButton != null && skillsWindow != null)
+                uiReferences.skillsButton.onClick.AddListener(ToggleSkills);
+        }
+
+        private void OnDestroy()
+        {
+            if (uiReferences != null && uiReferences.skillsButton != null)
+                uiReferences.skillsButton.onClick.RemoveListener(ToggleSkills);
+            if (heroHealth != null)
+                heroHealth.OnHealthChanged -= OnHealthChanged;
+        }
+
+        private void OnEnable()
+        {
+            hero = FindFirstObjectByType<HeroController>();
+            heroHealth = hero ? hero.GetComponent<Health>() : null;
+            if (heroHealth != null)
+            {
+                heroHealth.OnHealthChanged += OnHealthChanged;
+                OnHealthChanged(heroHealth.CurrentHealth, heroHealth.MaxHealth);
+                if (uiReferences != null)
+                    heroHealth.HealthBar = uiReferences.healthBar;
+            }
+            UpdateStats(true);
+        }
+
+        private void OnDisable()
+        {
+            if (heroHealth != null)
+                heroHealth.OnHealthChanged -= OnHealthChanged;
+        }
+
+        private void Update()
+        {
+            UpdateStats();
+        }
+
+        private void ToggleSkills()
+        {
+            if (skillsWindow != null)
+                skillsWindow.SetActive(!skillsWindow.activeSelf);
+        }
+
+        private void OnHealthChanged(float current, float max)
+        {
+            if (uiReferences != null && uiReferences.rightText != null)
+            {
+                string[] lines = uiReferences.rightText.text.Split('\n');
+                if (lines.Length >= 3)
+                {
+                    lines[2] = $"HP: {Mathf.FloorToInt(current)} / {Mathf.FloorToInt(max)}";
+                    uiReferences.rightText.text = string.Join("\n", lines);
+                }
+            }
+        }
+
+        private void UpdateStats(bool force = false)
+        {
+            if (uiReferences == null || hero == null)
+                return;
+
+            float damage = hero.Damage;
+            float attack = hero.AttackRate;
+            float move = hero.MoveSpeed;
+            float defense = hero.Defense;
+            float regen = regenManager ? (float)regenManager.GetTotalRegen() : 0f;
+
+            if (!force && Mathf.Approximately(damage, lastDamage) && Mathf.Approximately(attack, lastAttack)
+                && Mathf.Approximately(move, lastMove) && Mathf.Approximately(defense, lastDefense)
+                && Mathf.Approximately(regen, lastRegen))
+                return;
+
+            lastDamage = damage;
+            lastAttack = attack;
+            lastMove = move;
+            lastDefense = defense;
+            lastRegen = regen;
+
+            if (uiReferences.leftText != null)
+            {
+                uiReferences.leftText.text =
+                    $"Damage: {damage:0.##}\n" +
+                    $"Attack Speed: {attack:0.###} /s\n" +
+                    $"Movement Speed {move:0.##}";
+            }
+
+            if (uiReferences.rightText != null)
+            {
+                string hpLine = heroHealth != null
+                    ? $"HP: {Mathf.FloorToInt(heroHealth.CurrentHealth)} / {Mathf.FloorToInt(heroHealth.MaxHealth)}"
+                    : string.Empty;
+                uiReferences.rightText.text =
+                    $"Defense: {defense:0.##}\n" +
+                    $"Regen: {regen:0.###} /s\n" +
+                    hpLine;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add public properties for hero stats
- add events and property on `Health` for external UI updates
- manage health bar and run UI visibility via `GameManager`
- create `RunCalebUIManager` for runtime stat display

## Testing
- `dotnet test -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc2757c8c832e9488c9cabca10ab3