### PR TITLE
Auto-select first skill

### DIFF
--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -56,6 +56,8 @@ namespace TimelessEchoes.Skills
                 bonusUI.gameObject.SetActive(true);
             DeselectSkill();
             UpdateSkillSelectorLevels();
+            if (skills.Count > 0)
+                SelectSkill(0);
         }
 
         private void OnEnable()
@@ -70,7 +72,10 @@ namespace TimelessEchoes.Skills
             OnShowLevelTextChanged();
             if (selectedIndex < 0)
             {
-                DeselectSkill();
+                if (skills.Count > 0)
+                    SelectSkill(0);
+                else
+                    DeselectSkill();
             }
             else
             {


### PR DESCRIPTION
## Summary
- select the first skill during `Awake`
- if no skill is selected when enabling the UI, pick the first one

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cdb367680832e8a9e53806321d5df