### PR TITLE
Add combat XP and instant kill milestone support

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -35,6 +35,9 @@ namespace TimelessEchoes.Enemies
         private float nextWanderTime;
         private LayerMask blockingMask;
 
+        private static TimelessEchoes.Skills.Skill combatSkill;
+        private static TimelessEchoes.Skills.SkillController skillController;
+
         public bool IsEngaged => setter != null && setter.target == hero;
         public EnemyStats Stats => stats;
 
@@ -220,6 +223,19 @@ namespace TimelessEchoes.Enemies
             tracker?.RegisterKill(stats);
             var statsTracker = FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
             statsTracker?.AddKill();
+
+            GrantCombatExperience();
+        }
+
+        private void GrantCombatExperience()
+        {
+            if (stats == null) return;
+            if (skillController == null)
+                skillController = FindFirstObjectByType<TimelessEchoes.Skills.SkillController>();
+            if (combatSkill == null)
+                combatSkill = Resources.Load<TimelessEchoes.Skills.Skill>("Combat");
+            if (skillController != null && combatSkill != null)
+                skillController.AddExperience(combatSkill, stats.experience);
         }
 
         private void OnDestroy()

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -28,6 +28,7 @@ namespace TimelessEchoes.Hero
         [SerializeField] private bool fourDirectional = true;
         [SerializeField] private Transform projectileOrigin;
         [SerializeField] private DiceRoller diceRoller;
+        [SerializeField] private TimelessEchoes.Skills.Skill combatSkill;
         private bool diceUnlocked;
         [SerializeField] private TimelessEchoes.Buffs.BuffManager buffController;
         [SerializeField] private LayerMask enemyMask = ~0;
@@ -444,7 +445,7 @@ namespace TimelessEchoes.Hero
                 float bonus = killTracker != null ? killTracker.GetDamageMultiplier(enemyStats) : 1f;
                 float dmg = (baseDamage + damageBonus) *
                             (buffController != null ? buffController.DamageMultiplier : 1f);
-                proj.Init(target, dmg * combatDamageMultiplier * bonus, true);
+                proj.Init(target, dmg * combatDamageMultiplier * bonus, true, null, combatSkill);
             }
         }
 

--- a/Assets/Scripts/Skills/MilestoneBonus.cs
+++ b/Assets/Scripts/Skills/MilestoneBonus.cs
@@ -7,6 +7,7 @@ namespace TimelessEchoes.Skills
     public enum MilestoneType
     {
         InstantTask,
+        InstantKill,
         DoubleResources,
         DoubleXP,
         StatIncrease
@@ -49,6 +50,8 @@ namespace TimelessEchoes.Skills
                         ? "tasks"
                         : $"{skillName.ToLowerInvariant()} tasks";
                     return $"Provides a {chance * 100f:0.#}% chance to instantly complete {taskLabel}.";
+                case MilestoneType.InstantKill:
+                    return $"Provides a {chance * 100f:0.#}% chance to instantly kill enemies.";
                 case MilestoneType.DoubleResources:
                     return $"Provides a {chance * 100f:0.#}% chance to double resources gained.";
                 case MilestoneType.DoubleXP:


### PR DESCRIPTION
## Summary
- award Combat XP when enemies die
- enable hero projectiles to roll for Instant Kill milestones
- support InstantKill milestone type and description
- remove Combat skill asset files

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d9734c19c832e8a2c8aecdaef703c