### PR TITLE
Set manager execution order

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -11,6 +11,7 @@ namespace TimelessEchoes.Buffs
     /// <summary>
     ///     Manages active buffs and persists them across scenes.
     /// </summary>
+    [DefaultExecutionOrder(-1)]
     public class BuffManager : MonoBehaviour
     {
         public static BuffManager Instance { get; private set; }

--- a/Assets/Scripts/Enemies/EnemyKillTracker.cs
+++ b/Assets/Scripts/Enemies/EnemyKillTracker.cs
@@ -7,6 +7,7 @@ using static Blindsided.Oracle;
 
 namespace TimelessEchoes.Stats
 {
+    [DefaultExecutionOrder(-1)]
     public class EnemyKillTracker : MonoBehaviour
     {
         public static EnemyKillTracker Instance { get; private set; }

--- a/Assets/Scripts/NpcGeneration/GenerationManager.cs
+++ b/Assets/Scripts/NpcGeneration/GenerationManager.cs
@@ -6,6 +6,7 @@ namespace TimelessEchoes.NpcGeneration
     /// <summary>
     /// Central manager that updates all NPC resource generators and applies offline progress.
     /// </summary>
+    [DefaultExecutionOrder(-1)]
     public class GenerationManager : MonoBehaviour
     {
         public static GenerationManager Instance { get; private set; }

--- a/Assets/Scripts/Quests/QuestUIManager.cs
+++ b/Assets/Scripts/Quests/QuestUIManager.cs
@@ -7,6 +7,7 @@ namespace TimelessEchoes.Quests
     /// <summary>
     ///     Manages quest UI entries.
     /// </summary>
+    [DefaultExecutionOrder(-1)]
     public class QuestUIManager : MonoBehaviour
     {
         public static QuestUIManager Instance { get; private set; }

--- a/Assets/Scripts/Skills/SkillController.cs
+++ b/Assets/Scripts/Skills/SkillController.cs
@@ -10,6 +10,7 @@ namespace TimelessEchoes.Skills
     /// <summary>
     /// Handles skill experience and levels.
     /// </summary>
+    [DefaultExecutionOrder(-1)]
     public class SkillController : MonoBehaviour
     {
         public static SkillController Instance { get; private set; }

--- a/Assets/Scripts/Upgrades/ResourceManager.cs
+++ b/Assets/Scripts/Upgrades/ResourceManager.cs
@@ -8,6 +8,7 @@ using static TimelessEchoes.TELogger;
 
 namespace TimelessEchoes.Upgrades
 {
+    [DefaultExecutionOrder(-1)]
     public class ResourceManager : MonoBehaviour
     {
         public static ResourceManager Instance { get; private set; }


### PR DESCRIPTION
## Summary
- ensure early initialization of managers by adding `DefaultExecutionOrder(-1)`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db0b30f3c832eb33f1099fef637b3