### PR TITLE
Refresh milestones after leveling up

### DIFF
--- a/Assets/Scripts/Skills/SkillUIManager.cs
+++ b/Assets/Scripts/Skills/SkillUIManager.cs
@@ -68,6 +68,7 @@ namespace TimelessEchoes.Skills
             {
                 controller.OnExperienceGained += OnExperienceGained;
                 controller.OnLevelUp += OnLevelUp;
+                controller.OnMilestoneUnlocked += OnMilestoneUnlocked;
             }
             ShowLevelTextChanged += OnShowLevelTextChanged;
             OnLoadData += OnLoadDataHandler;
@@ -85,6 +86,7 @@ namespace TimelessEchoes.Skills
             {
                 controller.OnExperienceGained -= OnExperienceGained;
                 controller.OnLevelUp -= OnLevelUp;
+                controller.OnMilestoneUnlocked -= OnMilestoneUnlocked;
             }
             ShowLevelTextChanged -= OnShowLevelTextChanged;
             OnLoadData -= OnLoadDataHandler;
@@ -108,6 +110,16 @@ namespace TimelessEchoes.Skills
             if (selector != null && selector.highlightImage != null && selectedIndex != index)
                 selector.highlightImage.enabled = true;
             UpdateSkillSelectorLevels();
+
+            if (bonusUI != null && selectedIndex == index && bonusUI.gameObject.activeSelf)
+                bonusUI.PopulateMilestones(skill);
+        }
+
+        private void OnMilestoneUnlocked(Skill skill, MilestoneBonus milestone)
+        {
+            int index = skills.IndexOf(skill);
+            if (bonusUI != null && selectedIndex == index && bonusUI.gameObject.activeSelf)
+                bonusUI.PopulateMilestones(skill);
         }
 
         private void SelectSkill(int index, bool recordPrevious = true)


### PR DESCRIPTION
## Summary
- refresh milestone list when the active skill levels up
- update MilestoneBonus UI after milestones unlock

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db3be5ef8832eb34a2fc2a76ec214