### PR TITLE
Implement task speed scaling by skill

### DIFF
--- a/Assets/Scripts/Skills/Skill.cs
+++ b/Assets/Scripts/Skills/Skill.cs
@@ -13,6 +13,6 @@ namespace TimelessEchoes.Skills
         public Sprite skillIcon;
         public float xpForFirstLevel = 10f;
         public float xpLevelMultiplier = 1.5f;
+        public float taskSpeedPerLevel = 0.01f;
         public List<MilestoneBonus> milestones = new();
-    }
-}
+    }}

--- a/Assets/Scripts/Skills/SkillController.cs
+++ b/Assets/Scripts/Skills/SkillController.cs
@@ -236,5 +236,14 @@ namespace TimelessEchoes.Skills
             }
             return total;
         }
+
+        public float GetTaskSpeedMultiplier(Skill skill)
+        {
+            if (skill == null) return 1f;
+            if (!progress.TryGetValue(skill, out var prog))
+                return 1f;
+
+            return 1f + prog.Level * skill.taskSpeedPerLevel;
+        }
     }
 }

--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -2,6 +2,7 @@ using Blindsided.Utilities;
 using TimelessEchoes.Hero;
 using UnityEngine;
 using TimelessEchoes.Utilities;
+using TimelessEchoes.Skills;
 
 namespace TimelessEchoes.Tasks
 {
@@ -60,7 +61,13 @@ namespace TimelessEchoes.Tasks
 
         public override void Tick(HeroController hero)
         {
-            timer += Time.deltaTime;
+            float delta = Time.deltaTime;
+            var controller = SkillController.Instance ?? Object.FindFirstObjectByType<SkillController>();
+            if (controller != null && associatedSkill != null)
+            {
+                delta *= controller.GetTaskSpeedMultiplier(associatedSkill);
+            }
+            timer += delta;
             UpdateProgressBar();
 
             if (timer >= TaskDuration)

--- a/Assets/Scripts/Tests/Editor/TaskSpeedTests.cs
+++ b/Assets/Scripts/Tests/Editor/TaskSpeedTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using TimelessEchoes.Tasks;
+using TimelessEchoes.Skills;
+
+namespace TimelessEchoes.Tests
+{
+    public class TaskSpeedTests
+    {
+        private GameObject controllerObj;
+        private SkillController controller;
+        private Skill skillLow;
+        private Skill skillHigh;
+        private TaskData data;
+        private MiningTask taskLow;
+        private MiningTask taskHigh;
+        private GameObject objLow;
+        private GameObject objHigh;
+
+        [SetUp]
+        public void SetUp()
+        {
+            controllerObj = new GameObject();
+            controller = controllerObj.AddComponent<SkillController>();
+
+            skillLow = ScriptableObject.CreateInstance<Skill>();
+            skillLow.taskSpeedPerLevel = 0.5f;
+            skillHigh = ScriptableObject.CreateInstance<Skill>();
+            skillHigh.taskSpeedPerLevel = 0.5f;
+
+            var skillsField = typeof(SkillController).GetField("skills", BindingFlags.NonPublic | BindingFlags.Instance);
+            skillsField.SetValue(controller, new List<Skill> { skillLow, skillHigh });
+
+            var progressField = typeof(SkillController).GetField("progress", BindingFlags.NonPublic | BindingFlags.Instance);
+            var dict = (Dictionary<Skill, SkillController.SkillProgress>)progressField.GetValue(controller);
+            dict[skillLow] = new SkillController.SkillProgress { Level = 0, CurrentXP = 0f };
+            dict[skillHigh] = new SkillController.SkillProgress { Level = 2, CurrentXP = 0f };
+
+            data = ScriptableObject.CreateInstance<TaskData>();
+            data.taskDuration = 10f;
+
+            objLow = new GameObject();
+            taskLow = objLow.AddComponent<MiningTask>();
+            taskLow.associatedSkill = skillLow;
+            taskLow.taskData = data;
+
+            objHigh = new GameObject();
+            taskHigh = objHigh.AddComponent<MiningTask>();
+            taskHigh.associatedSkill = skillHigh;
+            taskHigh.taskData = data;
+
+            taskLow.StartTask();
+            taskHigh.StartTask();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(objLow);
+            Object.DestroyImmediate(objHigh);
+            Object.DestroyImmediate(controllerObj);
+            Object.DestroyImmediate(skillLow);
+            Object.DestroyImmediate(skillHigh);
+            Object.DestroyImmediate(data);
+        }
+
+        [UnityTest]
+        public System.Collections.IEnumerator TickUsesSkillSpeedMultiplier()
+        {
+            yield return null; // wait a frame to get valid deltaTime
+            float dt = Time.deltaTime;
+
+            taskLow.Tick(null);
+            taskHigh.Tick(null);
+
+            var timerField = typeof(ContinuousTask).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance);
+            float lowTimer = (float)timerField.GetValue(taskLow);
+            float highTimer = (float)timerField.GetValue(taskHigh);
+
+            Assert.AreEqual(dt * 1f, lowTimer, 0.0001f);
+            Assert.AreEqual(dt * 2f, highTimer, 0.0001f);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Skill` with `taskSpeedPerLevel`
- expose multiplier via new `SkillController.GetTaskSpeedMultiplier`
- apply multiplier in `ContinuousTask.Tick`
- add new edit mode test for task speed behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df3a533bc832ebdbd88529335f409