### PR TITLE
Separate reveal bonus floating text

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -19,16 +19,17 @@ namespace TimelessEchoes.Enemies
             OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
         }
 
-        public void TakeDamage(float amount)
+        public void TakeDamage(float amount, float bonusDamage = 0f)
         {
             if (CurrentHealth <= 0f) return;
             var hero = GetComponent<HeroController>();
+            float total = amount + bonusDamage;
             if (hero != null)
             {
-                float min = amount * 0.1f;
-                amount = Mathf.Max(amount - hero.Defense, min);
+                float min = total * 0.1f;
+                total = Mathf.Max(total - hero.Defense, min);
             }
-            CurrentHealth -= amount;
+            CurrentHealth -= total;
             UpdateBar();
             OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
 
@@ -41,12 +42,17 @@ namespace TimelessEchoes.Enemies
             if (Application.isPlaying)
             {
                 FloatingText.Spawn(CalcUtils.FormatNumber(amount), transform.position + Vector3.up, colour, fontSize);
+                if (bonusDamage != 0f)
+                {
+                    ColorUtility.TryParseHtmlString("#60C560", out var green);
+                    FloatingText.Spawn($"+{CalcUtils.FormatNumber(bonusDamage)}", transform.position + Vector3.up * 1.2f, green, fontSize * 0.8f);
+                }
             }
             if (isHero)
             {
                 var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance ??
                               FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
-                tracker?.AddDamageTaken(amount);
+                tracker?.AddDamageTaken(total);
             }
             if (CurrentHealth <= 0f)
             {

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -475,9 +475,12 @@ namespace TimelessEchoes.Hero
                     TELogger.Log("EnemyKillTracker missing", TELogCategory.Combat, this);
                 var enemyStats = target.GetComponent<Enemy>()?.Stats;
                 float bonus = killTracker != null ? killTracker.GetDamageMultiplier(enemyStats) : 1f;
-                float dmg = (baseDamage + damageBonus) *
-                            (buffController != null ? buffController.DamageMultiplier : 1f);
-                proj.Init(target, dmg * combatDamageMultiplier * bonus, true, null, combatSkill);
+                float dmgBase = (baseDamage + damageBonus) *
+                                (buffController != null ? buffController.DamageMultiplier : 1f) *
+                                combatDamageMultiplier;
+                float total = dmgBase * bonus;
+                float bonusDamage = total - dmgBase;
+                proj.Init(target, total, true, null, combatSkill, bonusDamage);
             }
         }
 

--- a/Assets/Scripts/IDamageable.cs
+++ b/Assets/Scripts/IDamageable.cs
@@ -7,6 +7,11 @@ namespace TimelessEchoes
     /// </summary>
     public interface IDamageable
     {
-        void TakeDamage(float amount);
+        /// <summary>
+        /// Applies damage to the object.
+        /// </summary>
+        /// <param name="amount">Base damage dealt.</param>
+        /// <param name="bonusDamage">Additional bonus damage displayed separately.</param>
+        void TakeDamage(float amount, float bonusDamage = 0f);
     }
 }

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -22,6 +22,7 @@ namespace TimelessEchoes
 
         private Transform target;
         private float damage;
+        private float bonusDamage;
         private bool fromHero;
         private TimelessEchoes.Skills.Skill combatSkill;
 
@@ -40,10 +41,12 @@ namespace TimelessEchoes
         public void Init(Transform target, float damage,
             bool fromHero = false,
             GameObject hitEffect = null,
-            TimelessEchoes.Skills.Skill combatSkill = null)
+            TimelessEchoes.Skills.Skill combatSkill = null,
+            float bonusDamage = 0f)
         {
             this.target = target;
             this.damage = damage;
+            this.bonusDamage = bonusDamage;
             this.fromHero = fromHero;
             this.combatSkill = combatSkill;
             effectPrefab = hitEffect ?? hitEffectPrefab;
@@ -90,11 +93,12 @@ namespace TimelessEchoes
                 }
 
                 var dmg = target.GetComponent<IDamageable>();
-                dmg?.TakeDamage(dmgAmount);
+                float baseAmount = dmgAmount - bonusDamage;
+                dmg?.TakeDamage(baseAmount, bonusDamage);
                 if (fromHero)
                 {
                     var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance ??
-                                   FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
+                                     FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
                     tracker?.AddDamageDealt(dmgAmount);
                 }
                 SpawnEffect();


### PR DESCRIPTION
## Summary
- allow damageables to include optional bonus damage for display
- split bonus damage display in Health so extra reveal damage shows as green text
- track bonus damage info in Projectile and forward it on hit
- calculate bonus damage for hero attacks and pass to projectiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e049ece24832e8de18e9e89aaf141