### PR TITLE
Display bonus damage inline

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -41,12 +41,12 @@ namespace TimelessEchoes.Enemies
             var fontSize = isHero ? 6f : 8f;
             if (Application.isPlaying)
             {
-                FloatingText.Spawn(CalcUtils.FormatNumber(amount), transform.position + Vector3.up, colour, fontSize);
+                string text = CalcUtils.FormatNumber(amount);
                 if (bonusDamage != 0f)
                 {
-                    ColorUtility.TryParseHtmlString("#60C560", out var green);
-                    FloatingText.Spawn($"+{CalcUtils.FormatNumber(bonusDamage)}", transform.position + Vector3.up * 1.2f, green, fontSize * 0.8f);
+                    text += $" <size=70%><color=#60C560>+{CalcUtils.FormatNumber(bonusDamage)}</color></size>";
                 }
+                FloatingText.Spawn(text, transform.position + Vector3.up, colour, fontSize);
             }
             if (isHero)
             {

--- a/Assets/Scripts/IDamageable.cs
+++ b/Assets/Scripts/IDamageable.cs
@@ -11,7 +11,7 @@ namespace TimelessEchoes
         /// Applies damage to the object.
         /// </summary>
         /// <param name="amount">Base damage dealt.</param>
-        /// <param name="bonusDamage">Additional bonus damage displayed separately.</param>
+        /// <param name="bonusDamage">Additional bonus damage displayed to the right at a smaller size.</param>
         void TakeDamage(float amount, float bonusDamage = 0f);
     }
 }


### PR DESCRIPTION
## Summary
- combine floating damage text so bonus is shown to the right using `<size=70%>` tag
- update IDamageable comment about bonus damage

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_686e0759a9bc832eb35c4c01cd3221a7