### PR TITLE
Enable repeating SFX for tasks

### DIFF
--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -19,8 +19,11 @@ namespace TimelessEchoes.Tasks
         private bool isComplete;
 
         private float timer;
+        private float sfxTimer;
 
         protected float TaskDuration => taskData != null ? taskData.taskDuration : 0f;
+
+        protected virtual float SfxInterval => taskData != null ? taskData.sfxInterval : 0f;
 
         protected abstract string AnimationName { get; }
         protected abstract string InterruptTriggerName { get; }
@@ -41,6 +44,7 @@ namespace TimelessEchoes.Tasks
         {
             isComplete = false;
             timer = 0f;
+            sfxTimer = 0f;
             HideProgressBar();
         }
 
@@ -62,6 +66,7 @@ namespace TimelessEchoes.Tasks
             }
             var audio = AudioManager.Instance ?? Object.FindFirstObjectByType<AudioManager>();
             audio?.PlayTaskClip(TaskType);
+            sfxTimer = 0f;
 
             hero.Animator.Play(AnimationName);
             ShowProgressBar();
@@ -76,6 +81,16 @@ namespace TimelessEchoes.Tasks
                 delta *= controller.GetTaskSpeedMultiplier(associatedSkill);
             }
             timer += delta;
+            if (!isComplete && SfxInterval > 0f)
+            {
+                sfxTimer += delta;
+                while (sfxTimer >= SfxInterval)
+                {
+                    var audio = AudioManager.Instance ?? Object.FindFirstObjectByType<AudioManager>();
+                    audio?.PlayTaskClip(TaskType);
+                    sfxTimer -= SfxInterval;
+                }
+            }
             UpdateProgressBar();
 
             if (timer >= TaskDuration)
@@ -93,6 +108,7 @@ namespace TimelessEchoes.Tasks
         {
             AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, InterruptTriggerName);
             HideProgressBar();
+            sfxTimer = 0f;
         }
 
         private void ShowProgressBar()

--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -16,6 +16,8 @@ namespace TimelessEchoes.Tasks
         public Skill associatedSkill;
         public float xpForCompletion;
         public float taskDuration;
+        [Tooltip("Interval between repeated SFX plays while the task is active. Zero disables repeats.")]
+        public float sfxInterval;
         public List<ResourceDrop> resourceDrops = new();
 
         [Tooltip("Restart task progress when returning after an interrupt.")]


### PR DESCRIPTION
## Summary
- allow tasks to specify an SFX interval
- track SFX timer in `ContinuousTask`
- play task SFX repeatedly while the task is active

## Testing
- `unity-editor -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4c4e3f50832ebb05ce75e70a75fa