### PR TITLE
Refactor task audio handling

### DIFF
--- a/Assets/Scripts/Hero/HeroAudio.cs
+++ b/Assets/Scripts/Hero/HeroAudio.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+using TimelessEchoes.Audio;
+
+namespace TimelessEchoes.Hero
+{
+    /// <summary>
+    /// Provides audio hooks for the hero. Public methods can be triggered via
+    /// animation events or tags to play appropriate sound effects.
+    /// </summary>
+    public class HeroAudio : MonoBehaviour
+    {
+        private AudioManager Audio => AudioManager.Instance ??
+            Object.FindFirstObjectByType<AudioManager>();
+
+        public void PlayWoodcutting()
+        {
+            Audio?.PlayTaskClip(AudioManager.TaskType.Woodcutting);
+        }
+
+        public void PlayFarming()
+        {
+            Audio?.PlayTaskClip(AudioManager.TaskType.Farming);
+        }
+
+        public void PlayFishing()
+        {
+            Audio?.PlayTaskClip(AudioManager.TaskType.Fishing);
+        }
+
+        public void PlayMining()
+        {
+            Audio?.PlayTaskClip(AudioManager.TaskType.Mining);
+        }
+
+        public void PlayCombat()
+        {
+            Audio?.PlaySlimeClip();
+        }
+    }
+}

--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -3,7 +3,6 @@ using TimelessEchoes.Hero;
 using UnityEngine;
 using TimelessEchoes.Utilities;
 using TimelessEchoes.Skills;
-using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -19,19 +18,11 @@ namespace TimelessEchoes.Tasks
         private bool isComplete;
 
         private float timer;
-        private float sfxTimer;
 
         protected float TaskDuration => taskData != null ? taskData.taskDuration : 0f;
 
-        protected virtual float SfxInterval => taskData != null ? taskData.sfxInterval : 0f;
-
         protected abstract string AnimationName { get; }
         protected abstract string InterruptTriggerName { get; }
-
-        /// <summary>
-        ///     The audio task type associated with this task.
-        /// </summary>
-        protected abstract AudioManager.TaskType TaskType { get; }
 
         public override bool BlocksMovement => true;
 
@@ -44,7 +35,6 @@ namespace TimelessEchoes.Tasks
         {
             isComplete = false;
             timer = 0f;
-            sfxTimer = 0f;
             HideProgressBar();
         }
 
@@ -64,9 +54,7 @@ namespace TimelessEchoes.Tasks
                 GrantCompletionXP();
                 return;
             }
-            var audio = AudioManager.Instance ?? Object.FindFirstObjectByType<AudioManager>();
-            audio?.PlayTaskClip(TaskType);
-            sfxTimer = 0f;
+
 
             hero.Animator.Play(AnimationName);
             ShowProgressBar();
@@ -81,15 +69,9 @@ namespace TimelessEchoes.Tasks
                 delta *= controller.GetTaskSpeedMultiplier(associatedSkill);
             }
             timer += delta;
-            if (!isComplete && SfxInterval > 0f)
+            if (!isComplete)
             {
-                sfxTimer += delta;
-                while (sfxTimer >= SfxInterval)
-                {
-                    var audio = AudioManager.Instance ?? Object.FindFirstObjectByType<AudioManager>();
-                    audio?.PlayTaskClip(TaskType);
-                    sfxTimer -= SfxInterval;
-                }
+                // No audio playback here; sounds are triggered via animation events.
             }
             UpdateProgressBar();
 
@@ -108,7 +90,6 @@ namespace TimelessEchoes.Tasks
         {
             AnimatorUtils.SetTriggerAndReset(hero, hero.Animator, InterruptTriggerName);
             HideProgressBar();
-            sfxTimer = 0f;
         }
 
         private void ShowProgressBar()

--- a/Assets/Scripts/Tasks/FarmingTask.cs
+++ b/Assets/Scripts/Tasks/FarmingTask.cs
@@ -1,7 +1,6 @@
 using System.Reflection;
 using TimelessEchoes.Hero;
 using UnityEngine;
-using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -21,7 +20,6 @@ namespace TimelessEchoes.Tasks
 
         protected override string AnimationName => "Water";
         protected override string InterruptTriggerName => "StopWatering";
-        protected override AudioManager.TaskType TaskType => AudioManager.TaskType.Farming;
 
         public override Transform Target => wateringPoint != null ? wateringPoint : transform;
 

--- a/Assets/Scripts/Tasks/FishingTask.cs
+++ b/Assets/Scripts/Tasks/FishingTask.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -9,6 +8,4 @@ namespace TimelessEchoes.Tasks
         public override Transform Target => fishingPoint != null ? fishingPoint : transform;
 
         protected override string AnimationName => "Fishing";
-        protected override string InterruptTriggerName => "CatchFish";
-        protected override AudioManager.TaskType TaskType => AudioManager.TaskType.Fishing;
-    }}
+        protected override string InterruptTriggerName => "CatchFish";    }}

--- a/Assets/Scripts/Tasks/MiningTask.cs
+++ b/Assets/Scripts/Tasks/MiningTask.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -7,7 +6,5 @@ namespace TimelessEchoes.Tasks
     {
         protected override string AnimationName => "Mining";
         protected override string InterruptTriggerName => "StopMining";
-        protected override AudioManager.TaskType TaskType => AudioManager.TaskType.Mining;
 
-        public override Transform Target => transform;
-    }}
+        public override Transform Target => transform;    }}

--- a/Assets/Scripts/Tasks/WoodcuttingTask.cs
+++ b/Assets/Scripts/Tasks/WoodcuttingTask.cs
@@ -1,6 +1,5 @@
 using TimelessEchoes.Hero;
 using UnityEngine;
-using TimelessEchoes.Audio;
 
 namespace TimelessEchoes.Tasks
 {
@@ -21,7 +20,6 @@ namespace TimelessEchoes.Tasks
 
         protected override string AnimationName => "Chopping";
         protected override string InterruptTriggerName => "StopChopping";
-        protected override AudioManager.TaskType TaskType => AudioManager.TaskType.Woodcutting;
         public override Transform Target => cuttingPoint != null ? cuttingPoint : transform;
 
         public override void StartTask()


### PR DESCRIPTION
## Summary
- strip automatic audio playback from `ContinuousTask` and derived tasks
- create `HeroAudio` with hooks for task/combat sounds
- keep logic for progress bars and animation triggers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e510ef4cc832eb64f7cf1662e02c4