### PR TITLE
Add steam cloud wipe option

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -127,6 +127,16 @@ namespace Blindsided
 
         [TabGroup("SaveData", "Buttons")]
         [Button]
+        public void WipeCloudData()
+        {
+            EventHandler.ResetData();
+            saveData = new GameData();
+            SteamCloudManager.DeleteFile(_fileName);
+            SceneManager.LoadScene(0);
+        }
+
+        [TabGroup("SaveData", "Buttons")]
+        [Button]
         public void LoadFromClipboard()
         {
             var bytes = beta

--- a/Assets/Scripts/Steamworks.NET/SteamCloudManager.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamCloudManager.cs
@@ -53,6 +53,26 @@ namespace TimelessEchoes
             File.WriteAllBytes(path, buffer);
             return true;
         }
+
+        /// <summary>
+        /// Deletes a save file from both Steam Cloud and local storage.
+        /// </summary>
+        public static void DeleteFile(string fileName)
+        {
+            var path = Path.Combine(Application.persistentDataPath, fileName);
+            if (File.Exists(path))
+                File.Delete(path);
+
+            var backupPath = path + ".bac";
+            if (File.Exists(backupPath))
+                File.Delete(backupPath);
+
+            if (!SteamManager.Initialized)
+                return;
+
+            if (SteamRemoteStorage.FileExists(fileName))
+                SteamRemoteStorage.FileDelete(fileName);
+        }
 #endif
     }
 }


### PR DESCRIPTION
## Summary
- allow deleting save data from Steam Cloud
- expose new `WipeCloudData` button on Oracle

## Testing
- `No automated tests available`

------
https://chatgpt.com/codex/tasks/task_e_686eec7b2044832ea73b8bb083454836