### PR TITLE
Add method to reset fish donations

### DIFF
--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using References.UI;
+using Sirenix.OdinInspector;
 using TimelessEchoes.Enemies;
 using TimelessEchoes.Hero;
 using TimelessEchoes.Upgrades;
@@ -51,6 +52,7 @@ namespace TimelessEchoes.Regen
 
             OnSaveData += SaveState;
             OnLoadData += LoadState;
+            OnResetData += ResetDonations;
             if (resourceManager != null)
                 resourceManager.OnInventoryChanged += UpdateAllEntries;
         }
@@ -59,6 +61,7 @@ namespace TimelessEchoes.Regen
         {
             OnSaveData -= SaveState;
             OnLoadData -= LoadState;
+            OnResetData -= ResetDonations;
             if (resourceManager != null)
                 resourceManager.OnInventoryChanged -= UpdateAllEntries;
             if (Instance == this)
@@ -213,6 +216,17 @@ namespace TimelessEchoes.Regen
             }
 
             return donations.TryGetValue(res, out var val) ? val : 0;
+        }
+
+        /// <summary>
+        ///     Clears all stored fish donations and updates the UI.
+        /// </summary>
+        [Button]
+        public void ResetDonations()
+        {
+            donations.Clear();
+            SaveState();
+            UpdateAllEntries();
         }
 
         private void SaveState()


### PR DESCRIPTION
## Summary
- allow clearing donations via `RegenManager.ResetDonations`
- subscribe `RegenManager` to ResetData so wiping data also clears donations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ef1c8fdd8832e8b4c6c19deba612c