### PR TITLE
Fix quest progress updating after donations

### DIFF
--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -167,8 +167,8 @@ namespace TimelessEchoes.Regen
             if (resourceManager == null || res == null) return;
             double amount = Mathf.Floor((float)(resourceManager.GetAmount(res) * pct));
             if (amount <= 0) return;
-            resourceManager.Spend(res, amount);
             AddDonation(res, amount);
+            resourceManager.Spend(res, amount);
             UpdateAllEntries();
         }
 
@@ -177,8 +177,8 @@ namespace TimelessEchoes.Regen
             if (resourceManager == null || res == null) return;
             var amount = resourceManager.GetAmount(res);
             if (amount <= 0) return;
-            resourceManager.Spend(res, amount);
             AddDonation(res, amount);
+            resourceManager.Spend(res, amount);
             UpdateAllEntries();
         }
 


### PR DESCRIPTION
## Summary
- ensure fish donations count toward quests immediately by adding donations before spending resources

## Testing
- `dotnet test` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ef4b2241c832ebbb7eee9341d8750