### PR TITLE
Add SlimeSwarm achievement logic

### DIFF
--- a/Assets/Scripts/Steamworks.NET/AchievementManager.cs
+++ b/Assets/Scripts/Steamworks.NET/AchievementManager.cs
@@ -64,6 +64,14 @@ namespace TimelessEchoes
                 UnlockAchievement("MeetIvan");
             }
         }
+
+        /// <summary>
+        /// Awards the SlimeSwarm achievement.
+        /// </summary>
+        public void UnlockSlimeSwarm()
+        {
+            UnlockAchievement("SlimeSwarm");
+        }
 #else
         public static AchievementManager Instance => null;
 #endif

--- a/Assets/Scripts/Steamworks.NET/SlimeCombatTracker.cs
+++ b/Assets/Scripts/Steamworks.NET/SlimeCombatTracker.cs
@@ -1,0 +1,99 @@
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
+
+using System.Collections.Generic;
+using UnityEngine;
+using TimelessEchoes.Enemies;
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Tracks slimes currently engaged with the hero. When at least five
+    /// are active, awards the SlimeSwarm achievement.
+    /// </summary>
+    public class SlimeCombatTracker : MonoBehaviour
+    {
+#if !DISABLESTEAMWORKS
+        private readonly HashSet<Enemy> engagedSlimes = new();
+        private readonly Dictionary<Enemy, System.Action> deathHandlers = new();
+        private readonly List<Enemy> removalBuffer = new();
+
+        /// <summary>
+        /// Current number of slimes engaging the hero.
+        /// </summary>
+        public int EngagedSlimeCount => engagedSlimes.Count;
+
+        private void OnEnable()
+        {
+            Enemy.OnEngage += OnEnemyEngage;
+        }
+
+        private void OnDisable()
+        {
+            Enemy.OnEngage -= OnEnemyEngage;
+            foreach (var pair in deathHandlers)
+            {
+                var hp = pair.Key != null ? pair.Key.GetComponent<Health>() : null;
+                if (hp != null)
+                    hp.OnDeath -= pair.Value;
+            }
+            engagedSlimes.Clear();
+            deathHandlers.Clear();
+        }
+
+        private void Update()
+        {
+            removalBuffer.Clear();
+            foreach (var slime in engagedSlimes)
+            {
+                if (slime == null || !slime.IsEngaged)
+                    removalBuffer.Add(slime);
+            }
+            foreach (var slime in removalBuffer)
+            {
+                UnregisterSlime(slime);
+            }
+        }
+
+        private void OnEnemyEngage(Enemy enemy)
+        {
+            if (enemy == null || enemy.Stats == null)
+                return;
+
+            var name = enemy.Stats.enemyName;
+            if (string.IsNullOrEmpty(name) || !name.ToLowerInvariant().Contains("slime"))
+                return;
+            if (engagedSlimes.Contains(enemy))
+                return;
+
+            engagedSlimes.Add(enemy);
+            var hp = enemy.GetComponent<Health>();
+            if (hp != null)
+            {
+                System.Action handler = () => UnregisterSlime(enemy);
+                deathHandlers[enemy] = handler;
+                hp.OnDeath += handler;
+            }
+
+            if (engagedSlimes.Count >= 5)
+                AchievementManager.Instance?.UnlockSlimeSwarm();
+        }
+
+        private void UnregisterSlime(Enemy enemy)
+        {
+            if (enemy == null)
+                return;
+            if (engagedSlimes.Remove(enemy) && deathHandlers.TryGetValue(enemy, out var handler))
+            {
+                var hp = enemy.GetComponent<Health>();
+                if (hp != null)
+                    hp.OnDeath -= handler;
+                deathHandlers.Remove(enemy);
+            }
+        }
+#else
+        public int EngagedSlimeCount => 0;
+#endif
+    }
+}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Use **File > Build Settings...** to create standalone builds.
 Achievements are managed through the `AchievementManager` component which uses
 Steamworks.NET. Meeting the NPC with id `Ivan1` awards the `MeetIvan` Steam
 achievement.
+Engaging five slimes at once unlocks the `SlimeSwarm` achievement.
 
 ## Development Guidelines
 Refer to [Unity's official documentation](https://docs.unity3d.com) and ensure all changes work with **Unity 6000.1.6f1**.


### PR DESCRIPTION
## Summary
- track slimes engaged with the hero and award an achievement when five are active
- expose `UnlockSlimeSwarm` on `AchievementManager`
- document new achievement in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686f051ef33c832eb5201ec0fe36bcb2