### PR TITLE
Add Mildred achievement and startup check

### DIFF
--- a/Assets/Scripts/Steamworks.NET/AchievementManager.cs
+++ b/Assets/Scripts/Steamworks.NET/AchievementManager.cs
@@ -4,7 +4,12 @@
 
 using UnityEngine;
 #if !DISABLESTEAMWORKS
+using System.Collections;
+using System.Collections.Generic;
+using Blindsided.SaveData;
 using Steamworks;
+using static Blindsided.EventHandler;
+using static Blindsided.Oracle;
 #endif
 
 namespace TimelessEchoes
@@ -75,6 +80,72 @@ namespace TimelessEchoes
         public void UnlockSlimeSwarm()
         {
             UnlockAchievement("SlimeSwarm");
+        }
+
+        private void OnEnable()
+        {
+            OnQuestHandin += OnQuestHandinHandler;
+            OnLoadData += OnLoadDataHandler;
+        }
+
+        private void OnDisable()
+        {
+            OnQuestHandin -= OnQuestHandinHandler;
+            OnLoadData -= OnLoadDataHandler;
+        }
+
+        private void OnQuestHandinHandler(string questId)
+        {
+            var mildredId = GameManager.Instance != null ? GameManager.Instance.mildredQuestId : null;
+            if (!string.IsNullOrEmpty(mildredId) && questId == mildredId)
+                UnlockAchievement("Mildred");
+        }
+
+        private void OnLoadDataHandler()
+        {
+            StartCoroutine(DeferredCheck());
+        }
+
+        private IEnumerator DeferredCheck()
+        {
+            yield return null; // wait one frame after data loads
+            CheckExistingAchievements();
+        }
+
+        private void CheckExistingAchievements()
+        {
+            if (!SteamManager.Initialized)
+                return;
+
+            bool achieved;
+            if (StaticReferences.CompletedNpcTasks.Contains("Ivan1") &&
+                SteamUserStats.GetAchievement("MeetIvan", out achieved) && !achieved)
+            {
+                UnlockAchievement("MeetIvan");
+            }
+
+            if (StaticReferences.CompletedNpcTasks.Contains("Witch1") &&
+                SteamUserStats.GetAchievement("MeetEva", out achieved) && !achieved)
+            {
+                UnlockAchievement("MeetEva");
+            }
+
+            var mildredId = GameManager.Instance != null ? GameManager.Instance.mildredQuestId : null;
+            if (!string.IsNullOrEmpty(mildredId) && QuestCompleted(mildredId) &&
+                SteamUserStats.GetAchievement("Mildred", out achieved) && !achieved)
+            {
+                UnlockAchievement("Mildred");
+            }
+        }
+
+        private static bool QuestCompleted(string questId)
+        {
+            if (string.IsNullOrEmpty(questId))
+                return true;
+            if (oracle == null)
+                return false;
+            oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
+            return oracle.saveData.Quests.TryGetValue(questId, out var rec) && rec.Completed;
         }
 #else
         public static AchievementManager Instance => null;

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Steamworks.NET. Meeting the NPC with id `Ivan1` awards the `MeetIvan` Steam
 achievement, while meeting the NPC with id `Witch1` unlocks the `MeetEva`
 achievement.
 Engaging five slimes at once unlocks the `SlimeSwarm` achievement.
+Completing Mildred's quest unlocks the `Mildred` achievement.
 
 ## Development Guidelines
 Refer to [Unity's official documentation](https://docs.unity3d.com) and ensure all changes work with **Unity 6000.1.6f1**.


### PR DESCRIPTION
## Summary
- extend `AchievementManager` to support quest achievements
- unlock new `Mildred` achievement when the Mildred quest is completed
- check existing achievements after save data loads
- document the new achievement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f14faef48832eb3f81888ac8605c5