### PR TITLE
Implement milestone health increase during runs

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -210,7 +210,23 @@ namespace TimelessEchoes.Hero
         private void OnMilestoneUnlocked(Skill skill, MilestoneBonus milestone)
         {
             if (milestone != null && milestone.type == MilestoneType.StatIncrease)
+            {
+                float oldMax = health != null ? health.MaxHealth : 0f;
+                float oldCurrent = health != null ? health.CurrentHealth : 0f;
                 ApplyStatUpgrades();
+
+                if (health != null)
+                {
+                    int newMax = Mathf.RoundToInt(baseHealth + healthBonus);
+                    if (newMax > 0 && Mathf.Abs(newMax - oldMax) > 0.01f)
+                    {
+                        float newCurrent = Mathf.Min(oldCurrent + (newMax - oldMax), newMax);
+                        health.Init(newMax);
+                        if (newCurrent < newMax)
+                            health.TakeDamage(newMax - newCurrent);
+                    }
+                }
+            }
         }
 
         private void ApplyStatUpgrades()


### PR DESCRIPTION
## Summary
- update `HeroController` so health milestones immediately increase HP during a run

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686f1b79de14832e99d2475ff941c327