### PR TITLE
Deduct resources when turning in quests

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -170,6 +170,13 @@ namespace TimelessEchoes.Quests
                 oracle.saveData.Quests[id] = record;
             }
 
+            if (resourceManager != null)
+            {
+                foreach (var req in inst.data.requirements)
+                    if (req.type == QuestData.RequirementType.Resource)
+                        resourceManager.Spend(req.resource, req.amount);
+            }
+
             record.Completed = true;
             if (inst.data.unlockPrefab != null)
                 Instantiate(inst.data.unlockPrefab);


### PR DESCRIPTION
## Summary
- deduct required items from inventory when handing in quests

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f1df32254832eb623439b4f90922a