### PR TITLE
Support quest prerequisites and gating

### DIFF
--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -17,8 +17,8 @@ namespace TimelessEchoes.Quests
         [TextArea] public string description;
         [TextArea] public string rewardDescription;
         public string npcId;
+        public List<QuestData> requiredQuests = new();
         public List<Requirement> requirements = new();
-        public QuestData nextQuest;
         public GameObject unlockPrefab;
         public List<GameObject> unlockObjects = new();
 

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using UnityEngine.Tilemaps;
 using VinTools.BetterRuleTiles;
 using Random = UnityEngine.Random;
+using static Blindsided.Oracle;
 
 namespace TimelessEchoes.Tasks
 {
@@ -619,6 +620,16 @@ namespace TimelessEchoes.Tasks
             return false;
         }
 
+        private static bool QuestCompleted(string questId)
+        {
+            if (string.IsNullOrEmpty(questId))
+                return true;
+            if (oracle == null)
+                return false;
+            oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
+            return oracle.saveData.Quests.TryGetValue(questId, out var rec) && rec.Completed;
+        }
+
         private bool TaskAllowed(WeightedSpawn spawn, bool allowWater, bool allowGrass, bool allowSand)
         {
             var specific = spawn.spawnOnWater || spawn.spawnOnSand || spawn.spawnOnGrass;
@@ -637,6 +648,16 @@ namespace TimelessEchoes.Tasks
                     continue;
                 if (t.prefab != null && t.prefab.GetComponent<FarmingTask>() != null && !StaticReferences.CompletedNpcTasks.Contains("Witch1"))
                     continue;
+                if (t.prefab != null)
+                {
+                    var baseTask = t.prefab.GetComponent<BaseTask>();
+                    if (baseTask != null)
+                    {
+                        var data = baseTask.taskData;
+                        if (data != null && !string.IsNullOrEmpty(data.requiredQuestId) && !QuestCompleted(data.requiredQuestId))
+                            continue;
+                    }
+                }
                 taskTotalWeight += t.GetWeight(worldX);
             }
 
@@ -650,6 +671,16 @@ namespace TimelessEchoes.Tasks
                     continue;
                 if (t.prefab != null && t.prefab.GetComponent<FarmingTask>() != null && !StaticReferences.CompletedNpcTasks.Contains("Witch1"))
                     continue;
+                if (t.prefab != null)
+                {
+                    var baseTask = t.prefab.GetComponent<BaseTask>();
+                    if (baseTask != null)
+                    {
+                        var data = baseTask.taskData;
+                        if (data != null && !string.IsNullOrEmpty(data.requiredQuestId) && !QuestCompleted(data.requiredQuestId))
+                            continue;
+                    }
+                }
                 r -= t.GetWeight(worldX);
                 if (r > 0f) continue;
                 var isWater = t.spawnOnWater && allowWaterTasks;
@@ -706,6 +737,16 @@ namespace TimelessEchoes.Tasks
                 if (t.prefab != null && t.prefab.GetComponent<FarmingTask>() != null &&
                     !StaticReferences.CompletedNpcTasks.Contains("Witch1"))
                     continue;
+                if (t.prefab != null)
+                {
+                    var baseTask = t.prefab.GetComponent<BaseTask>();
+                    if (baseTask != null)
+                    {
+                        var data = baseTask.taskData;
+                        if (data != null && !string.IsNullOrEmpty(data.requiredQuestId) && !QuestCompleted(data.requiredQuestId))
+                            continue;
+                    }
+                }
                 taskTotalWeight += t.GetWeight(worldX);
             }
 
@@ -733,6 +774,16 @@ namespace TimelessEchoes.Tasks
                     if (t.prefab != null && t.prefab.GetComponent<FarmingTask>() != null &&
                         !StaticReferences.CompletedNpcTasks.Contains("Witch1"))
                         continue;
+                    if (t.prefab != null)
+                    {
+                        var baseTask = t.prefab.GetComponent<BaseTask>();
+                        if (baseTask != null)
+                        {
+                            var data = baseTask.taskData;
+                            if (data != null && !string.IsNullOrEmpty(data.requiredQuestId) && !QuestCompleted(data.requiredQuestId))
+                                continue;
+                        }
+                    }
                     r -= t.GetWeight(worldX);
                     if (r > 0f) continue;
                     var isWater = t.spawnOnWater && allowWaterTasks;

--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -15,6 +15,7 @@ namespace TimelessEchoes.Tasks
         public Sprite taskIcon;
         public Skill associatedSkill;
         public float xpForCompletion;
+        public string requiredQuestId;
         public float taskDuration;
         [Tooltip("Interval between repeated SFX plays while the task is active. Zero disables repeats.")]
         public float sfxInterval;

--- a/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
+++ b/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
@@ -63,14 +63,14 @@ namespace TimelessEchoes.Tests
         }
 
         [Test]
-        public void LoadState_StartsNextQuestWhenCompleted()
+        public void LoadState_StartsQuestWithCompletedPrerequisite()
         {
             var next = ScriptableObject.CreateInstance<QuestData>();
             next.questId = "Q2";
-            quest.nextQuest = next;
+            next.requiredQuests.Add(quest);
 
             typeof(QuestManager).GetField("startingQuests", BindingFlags.NonPublic | BindingFlags.Instance)
-                .SetValue(manager, new List<QuestData> { quest });
+                .SetValue(manager, new List<QuestData> { quest, next });
 
             oracle.saveData.Quests["Q1"] = new GameData.QuestRecord { Completed = true };
 


### PR DESCRIPTION
## Summary
- add `requiredQuests` list to `QuestData` and remove the old next quest field
- allow `TaskData` to specify a `requiredQuestId`
- gate procedural task spawning on quest completion
- update `QuestManager` for new prerequisite logic
- adjust unit tests for updated quest flow

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f2b0d06d0832ea57aeffe05ba08ed