### PR TITLE
Allow assigning quest data to tasks

### DIFF
--- a/Assets/Scripts/NpcGeneration/NPCResourceGenerator.cs
+++ b/Assets/Scripts/NpcGeneration/NPCResourceGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Blindsided.SaveData;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.Quests;
 using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
@@ -23,7 +24,7 @@ namespace TimelessEchoes.NpcGeneration
 
         [SerializeField] private string npcId;
         [SerializeField] private List<ResourceEntry> resources = new();
-        [SerializeField] private string requiredQuestId;
+        [SerializeField] private QuestData requiredQuest;
         [SerializeField] private float generationInterval = 5f;
         [SerializeField] private Transform progressUIParent;
         [SerializeField] private NpcGeneratorProgressUI progressUIPrefab;
@@ -52,12 +53,12 @@ namespace TimelessEchoes.NpcGeneration
 
         private bool QuestCompleted()
         {
-            if (string.IsNullOrEmpty(requiredQuestId))
+            if (requiredQuest == null)
                 return true;
             if (oracle == null)
                 return false;
             oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
-            return oracle.saveData.Quests.TryGetValue(requiredQuestId, out var rec) && rec.Completed;
+            return oracle.saveData.Quests.TryGetValue(requiredQuest.questId, out var rec) && rec.Completed;
         }
 
         private void Awake()
@@ -219,7 +220,7 @@ namespace TimelessEchoes.NpcGeneration
 
         private void OnQuestHandinEvent(string questId)
         {
-            if (!setup && questId == requiredQuestId && QuestCompleted())
+            if (!setup && requiredQuest != null && questId == requiredQuest.questId && QuestCompleted())
                 LoadState();
         }
 

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Sirenix.OdinInspector;
 using Blindsided.SaveData;
 using TimelessEchoes.MapGeneration;
+using TimelessEchoes.Quests;
 using UnityEngine;
 using UnityEngine.Tilemaps;
 using VinTools.BetterRuleTiles;
@@ -654,7 +655,7 @@ namespace TimelessEchoes.Tasks
                     if (baseTask != null)
                     {
                         var data = baseTask.taskData;
-                        if (data != null && !string.IsNullOrEmpty(data.requiredQuestId) && !QuestCompleted(data.requiredQuestId))
+                        if (data != null && data.requiredQuest != null && !QuestCompleted(data.requiredQuest.questId))
                             continue;
                     }
                 }
@@ -677,7 +678,7 @@ namespace TimelessEchoes.Tasks
                     if (baseTask != null)
                     {
                         var data = baseTask.taskData;
-                        if (data != null && !string.IsNullOrEmpty(data.requiredQuestId) && !QuestCompleted(data.requiredQuestId))
+                        if (data != null && data.requiredQuest != null && !QuestCompleted(data.requiredQuest.questId))
                             continue;
                     }
                 }
@@ -743,7 +744,7 @@ namespace TimelessEchoes.Tasks
                     if (baseTask != null)
                     {
                         var data = baseTask.taskData;
-                        if (data != null && !string.IsNullOrEmpty(data.requiredQuestId) && !QuestCompleted(data.requiredQuestId))
+                        if (data != null && data.requiredQuest != null && !QuestCompleted(data.requiredQuest.questId))
                             continue;
                     }
                 }
@@ -780,7 +781,7 @@ namespace TimelessEchoes.Tasks
                         if (baseTask != null)
                         {
                             var data = baseTask.taskData;
-                            if (data != null && !string.IsNullOrEmpty(data.requiredQuestId) && !QuestCompleted(data.requiredQuestId))
+                            if (data != null && data.requiredQuest != null && !QuestCompleted(data.requiredQuest.questId))
                                 continue;
                         }
                     }

--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Blindsided.Utilities;
 using TimelessEchoes.Skills;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.Quests;
 using UnityEngine;
 
 namespace TimelessEchoes.Tasks
@@ -15,7 +16,7 @@ namespace TimelessEchoes.Tasks
         public Sprite taskIcon;
         public Skill associatedSkill;
         public float xpForCompletion;
-        public string requiredQuestId;
+        public QuestData requiredQuest;
         public float taskDuration;
         [Tooltip("Interval between repeated SFX plays while the task is active. Zero disables repeats.")]
         public float sfxInterval;


### PR DESCRIPTION
## Summary
- let tasks reference quest data directly
- adapt NPC resource generator to check quest data
- update procedural generator to block tasks until quests complete
- revert scene file changes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f30d55734832e9f53052ebb475dcd