### PR TITLE
Implement buff slot system

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -225,7 +225,10 @@ namespace Blindsided
             saveData.SkillData ??= new Dictionary<string, GameData.SkillProgress>();
             saveData.EnemyKills ??= new Dictionary<string, double>();
             saveData.CompletedNpcTasks ??= new HashSet<string>();
-            saveData.ActiveBuffs ??= new Dictionary<string, float>();
+            saveData.BuffSlots ??= new List<string>(new string[5]);
+            if (saveData.BuffSlots.Count < 5)
+                while (saveData.BuffSlots.Count < 5)
+                    saveData.BuffSlots.Add(null);
             saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
             saveData.FishDonations ??= new Dictionary<string, double>();
         }

--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -23,7 +23,7 @@ namespace Blindsided.SaveData
         public float TimeScale = 0f;
         [HideReferenceObjectPicker] public Dictionary<string, ResourceEntry> Resources = new();
         [HideReferenceObjectPicker] public Dictionary<string, double> EnemyKills = new();
-        [HideReferenceObjectPicker] public Dictionary<string, float> ActiveBuffs = new();
+        [HideReferenceObjectPicker] public List<string> BuffSlots = new(new string[5]);
         [HideReferenceObjectPicker] public Dictionary<string, double> FishDonations = new();
 
         [HideReferenceObjectPicker] public HashSet<string> CompletedNpcTasks = new();

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -250,6 +250,8 @@ namespace TimelessEchoes
                 statTracker.EndRun(true);
             }
 
+            BuffManager.Instance?.ClearActiveBuffs();
+
             runEndedByDeath = true;
             if (runDropUI != null)
                 runDropUI.ResetDrops();
@@ -336,6 +338,7 @@ namespace TimelessEchoes
             }
 
             statTracker?.EndRun(false);
+            BuffManager.Instance?.ClearActiveBuffs();
             yield return StartCoroutine(CleanupMapRoutine());
             if (tavernCamera != null)
                 tavernCamera.gameObject.SetActive(true);

--- a/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
@@ -1,0 +1,13 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace References.UI
+{
+    public class BuffSlotUIReferences : MonoBehaviour
+    {
+        public Button activateButton;
+        public Image iconImage;
+        public TMP_Text durationText;
+    }
+}


### PR DESCRIPTION
## Summary
- add buff slot list to GameData and handle in Oracle
- support buff slot assignments and activations in BuffManager
- overhaul BuffUIManager to assign recipes to slots and activate them
- clear active buffs when a run ends or hero dies
- add BuffSlotUIReferences helper class

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f69d4f974832e8081c817bb915a99