### PR TITLE
Add weapon swing combat audio option

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -30,6 +30,8 @@ namespace TimelessEchoes.Audio
         [Header("Combat Clips")] [SerializeField]
         private AudioClip[] slimeClips;
 
+        [SerializeField] private AudioClip[] weaponSwingClips;
+
         public enum TaskType
         {
             Woodcutting,
@@ -128,6 +130,11 @@ namespace TimelessEchoes.Audio
         public void PlaySlimeClip()
         {
             PlayCombatClip(slimeClips);
+        }
+
+        public void PlayWeaponSwingClip()
+        {
+            PlayCombatClip(weaponSwingClips);
         }
 
         private void PlaySfx(AudioClip clip)

--- a/Assets/Scripts/Hero/HeroAudio.cs
+++ b/Assets/Scripts/Hero/HeroAudio.cs
@@ -36,5 +36,10 @@ namespace TimelessEchoes.Hero
         {
             Audio?.PlaySlimeClip();
         }
+
+        public void PlayWeaponSwing()
+        {
+            Audio?.PlayWeaponSwingClip();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow AudioManager to hold a Weapon Swing clip array and provide a method to play it
- expose PlayWeaponSwing on HeroAudio to trigger the new clips

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687033ac0b0c832e9804a3b6ae997ff1