### PR TITLE
Add projectile hit SFX support

### DIFF
--- a/Assets/Scripts/Audio/ProjectileHitSfx.cs
+++ b/Assets/Scripts/Audio/ProjectileHitSfx.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace TimelessEchoes.Audio
+{
+    /// <summary>
+    /// Plays a hit sound effect based on projectile type.
+    /// Attach to projectile prefabs and invoke <see cref="PlayHit"/> on impact.
+    /// </summary>
+    public class ProjectileHitSfx : MonoBehaviour
+    {
+        private AudioManager Audio => AudioManager.Instance ??
+            Object.FindFirstObjectByType<AudioManager>();
+
+        public enum HitType
+        {
+            Slime
+        }
+
+        [SerializeField] private HitType hitType = HitType.Slime;
+
+        public void PlayHit()
+        {
+            switch (hitType)
+            {
+                case HitType.Slime:
+                    Audio?.PlaySlimeClip();
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Blindsided.Utilities.Pooling;
+using TimelessEchoes.Audio;
 
 namespace TimelessEchoes
 {
@@ -101,6 +102,8 @@ namespace TimelessEchoes
                                      FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
                     tracker?.AddDamageDealt(dmgAmount);
                 }
+                var sfx = GetComponent<ProjectileHitSfx>();
+                sfx?.PlayHit();
                 SpawnEffect();
                 Destroy(gameObject);
                 return;


### PR DESCRIPTION
## Summary
- add `ProjectileHitSfx` script for projectile audio
- call new script when a projectile hits a target

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703764c274832ea1cf52aa69710a8f