### PR TITLE
Fix hero damage text uses defense

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -24,11 +24,12 @@ namespace TimelessEchoes.Enemies
         {
             if (CurrentHealth <= 0f) return;
             var hero = GetComponent<HeroController>();
-            var total = amount + bonusDamage;
+            var full = amount + bonusDamage;
+            var total = full;
             if (hero != null)
             {
-                var min = total * 0.1f;
-                total = Mathf.Max(total - hero.Defense, min);
+                var min = full * 0.1f;
+                total = Mathf.Max(full - hero.Defense, min);
             }
 
             CurrentHealth -= total;
@@ -43,7 +44,7 @@ namespace TimelessEchoes.Enemies
             var fontSize = isHero ? 6f : 8f;
             if (Application.isPlaying)
             {
-                var text = CalcUtils.FormatNumber(amount);
+                var text = CalcUtils.FormatNumber(total);
                 if (bonusDamage != 0f)
                     text += $"<size=70%><color=#60C560>+{CalcUtils.FormatNumber(bonusDamage)}</color></size>";
                 FloatingText.Spawn(text, transform.position + Vector3.up, colour, fontSize);

--- a/Assets/Scripts/Tests/Editor/HealthTests.cs
+++ b/Assets/Scripts/Tests/Editor/HealthTests.cs
@@ -79,5 +79,29 @@ namespace TimelessEchoes.Tests
             Assert.AreEqual(sprite2, bar.sprite);
             Object.DestroyImmediate(barObj);
         }
+
+        [Test]
+        public void DefenseReducesDamage()
+        {
+            var hero = obj.AddComponent<Hero.HeroController>();
+            var field = typeof(Hero.HeroController).GetField("baseDefense", BindingFlags.NonPublic | BindingFlags.Instance);
+            field.SetValue(hero, 2f);
+
+            health.TakeDamage(5f);
+
+            Assert.AreEqual(7f, health.CurrentHealth);
+        }
+
+        [Test]
+        public void DamageHasMinimumValue()
+        {
+            var hero = obj.AddComponent<Hero.HeroController>();
+            var field = typeof(Hero.HeroController).GetField("baseDefense", BindingFlags.NonPublic | BindingFlags.Instance);
+            field.SetValue(hero, 100f);
+
+            health.TakeDamage(10f);
+
+            Assert.AreEqual(9f, health.CurrentHealth);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- display actual damage after hero defense is applied
- update `HealthTests` to verify defense logic and minimum damage

## Testing
- `nunit3-console` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703e23cf38832eaa7b91f36166fc7a