### PR TITLE
Add buff slot tooltip functionality

### DIFF
--- a/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
+++ b/Assets/Scripts/References/UI/BuffSlotUIReferences.cs
@@ -1,13 +1,28 @@
+using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
 namespace References.UI
 {
-    public class BuffSlotUIReferences : MonoBehaviour
+    public class BuffSlotUIReferences : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
     {
         public Button activateButton;
         public Image iconImage;
         public TMP_Text durationText;
+
+        public event Action<BuffSlotUIReferences> PointerEnter;
+        public event Action<BuffSlotUIReferences> PointerExit;
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            PointerEnter?.Invoke(this);
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            PointerExit?.Invoke(this);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enhance `BuffSlotUIReferences` with pointer events
- update `BuffUIManager` to display run buff cost tooltips
- grey out buff icons when unaffordable and hide empty icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68707d2b5da4832eadecd68a47ee229b