### PR TITLE
Add title and description to buff recipes

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -10,6 +10,12 @@ namespace TimelessEchoes.Buffs
     [CreateAssetMenu(fileName = "BuffRecipe", menuName = "SO/Buff Recipe")]
     public class BuffRecipe : ScriptableObject
     {
+        [Tooltip("Display name for this buff. If empty the asset name will be used.")]
+        public string title;
+
+        [TextArea]
+        public string description;
+
         public Sprite buffIcon;
         [Min(0f)] public float baseDuration = 30f;
         [Range(-100f, 100f)] public float moveSpeedPercent;
@@ -17,6 +23,8 @@ namespace TimelessEchoes.Buffs
         [Range(-100f, 100f)] public float defensePercent;
         [Range(-100f, 100f)] public float attackSpeedPercent;
         public List<ResourceRequirement> requirements = new();
+
+        public string Title => string.IsNullOrEmpty(title) ? name : title;
     }
 
     [Serializable]

--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -193,6 +193,10 @@ namespace TimelessEchoes.Buffs
                 var panel = Instantiate(recipePrefab, recipeParent);
                 if (panel.iconImage != null)
                     panel.iconImage.sprite = recipe.buffIcon;
+                if (panel.nameText != null)
+                    panel.nameText.text = string.IsNullOrEmpty(recipe.title) ? recipe.name : recipe.title;
+                if (panel.descriptionText != null)
+                    panel.descriptionText.text = recipe.description;
                 if (panel.durationText != null)
                     panel.durationText.text = recipe.baseDuration.ToString();
                 if (panel.purchaseButton != null)


### PR DESCRIPTION
## Summary
- add title and description fields to `BuffRecipe`
- default the title to the asset name if empty through the UI
- display these fields in `BuffUIManager`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687084a36fbc832ea68626576d378db1