### PR TITLE
Refactor buff assignment UI and logic

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -18,9 +18,6 @@ namespace TimelessEchoes.Buffs
 
         private ResourceManager resourceManager;
 
-        [SerializeField] private AnimationCurve diminishingCurve =
-            AnimationCurve.Linear(0f, 1f, 60f, 0f);
-
         [SerializeField] private List<BuffRecipe> allRecipes = new();
 
         private readonly List<ActiveBuff> activeBuffs = new();
@@ -28,7 +25,6 @@ namespace TimelessEchoes.Buffs
         private bool ticking = true;
 
         public IReadOnlyList<ActiveBuff> ActiveBuffs => activeBuffs;
-        public AnimationCurve DiminishingCurve => diminishingCurve;
         public IEnumerable<BuffRecipe> Recipes =>
             allRecipes?.Count > 0 ? allRecipes : Resources.LoadAll<BuffRecipe>("");
 
@@ -123,10 +119,7 @@ namespace TimelessEchoes.Buffs
             }
             else
             {
-                var extra = recipe.baseDuration;
-                if (diminishingCurve != null)
-                    extra *= diminishingCurve.Evaluate(buff.remaining);
-                buff.remaining += extra;
+                buff.remaining += recipe.baseDuration;
                 TELogger.Log($"Buff {recipe.name} extended", TELogCategory.Buff, this);
             }
 

--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -171,12 +171,7 @@ namespace TimelessEchoes.Buffs
                 var panel = pair.Value;
                 if (panel.durationText == null) continue;
                 var recipe = pair.Key;
-                var remaining = buffManager != null ? buffManager.GetRemaining(recipe) : 0f;
-                var extra = recipe.baseDuration;
-                if (buffManager != null && buffManager.DiminishingCurve != null)
-                    extra *= buffManager.DiminishingCurve.Evaluate(remaining);
-                panel.durationText.text =
-                    $"Time remaining: {Mathf.Ceil(remaining)} -> {Mathf.Ceil(remaining + extra)}";
+                panel.durationText.text = $"Duration: {Mathf.Ceil(recipe.baseDuration)}";
             }
         }
 
@@ -198,7 +193,7 @@ namespace TimelessEchoes.Buffs
                 if (panel.descriptionText != null)
                     panel.descriptionText.text = recipe.description;
                 if (panel.durationText != null)
-                    panel.durationText.text = recipe.baseDuration.ToString();
+                    panel.durationText.text = $"Duration: {Mathf.Ceil(recipe.baseDuration)}";
                 if (panel.purchaseButton != null)
                 {
                     var r = recipe;
@@ -255,8 +250,7 @@ namespace TimelessEchoes.Buffs
             {
                 BuildCostSlots(pair.Value, pair.Key);
                 if (pair.Value.purchaseButton != null)
-                    pair.Value.purchaseButton.interactable =
-                        buffManager != null && buffManager.CanPurchase(pair.Key);
+                    pair.Value.purchaseButton.interactable = true;
             }
 
             RefreshSlots();


### PR DESCRIPTION
## Summary
- simplify `BuffManager.PurchaseBuff` to add duration without diminishing
- remove diminishing curve property from `BuffManager`
- make buff recipe buttons always interactable
- show buff duration directly instead of dynamic time remaining

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687087dd079c832e9f015a4a52c110f7