### PR TITLE
Add distance based buff handling

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -22,6 +22,10 @@ namespace TimelessEchoes.Buffs
         [Range(-100f, 100f)] public float damagePercent;
         [Range(-100f, 100f)] public float defensePercent;
         [Range(-100f, 100f)] public float attackSpeedPercent;
+        [Tooltip("Tasks complete instantly while active.")]
+        public bool instantTasks;
+        [Tooltip("Percent of longest run distance this buff remains active. 0 = no distance limit")]
+        [Range(0f,1f)] public float distancePercent;
         public List<ResourceRequirement> requirements = new();
 
         public string Title => string.IsNullOrEmpty(title) ? name : title;

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -153,7 +153,10 @@ namespace TimelessEchoes.Hero
             if (tracker == null)
                 TELogger.Log("GameplayStatTracker missing", TELogCategory.General, this);
             else
+            {
                 tracker.RecordHeroPosition(transform.position);
+                BuffManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
+            }
         }
 
         private void OnEnable()

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -49,6 +49,7 @@ namespace TimelessEchoes.Stats
         public float AverageRun => averageRun;
         public int CurrentRunKills => currentRunKills;
         public double CurrentRunBonusResources => currentRunBonusResources;
+        public float CurrentRunDistance => currentRunDistance;
 
         private Vector3 lastHeroPos;
         private static Dictionary<string, Resource> lookup;

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -1,5 +1,6 @@
 using TimelessEchoes.Hero;
 using TimelessEchoes.Skills;
+using TimelessEchoes.Buffs;
 using UnityEngine;
 
 namespace TimelessEchoes.Tasks
@@ -63,7 +64,9 @@ namespace TimelessEchoes.Tasks
         protected bool ShouldInstantComplete()
         {
             var controller = SkillController.Instance ?? FindFirstObjectByType<SkillController>();
-            return controller && controller.RollForEffect(associatedSkill, MilestoneType.InstantTask);
+            bool milestone = controller && controller.RollForEffect(associatedSkill, MilestoneType.InstantTask);
+            bool buff = TimelessEchoes.Buffs.BuffManager.Instance != null && TimelessEchoes.Buffs.BuffManager.Instance.InstantTaskBuffActive;
+            return milestone || buff;
         }
 
         protected float GrantCompletionXP()


### PR DESCRIPTION
## Summary
- extend buff recipes with instant-tasks and distance percent fields
- expose current run distance in `GameplayStatTracker`
- track active buff distance expiration in `BuffManager`
- check for instant task buff in `BaseTask`
- update hero to notify `BuffManager` of traveled distance

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68708a756240832eb0332b0c669e7d06