### PR TITLE
Add hero health base classes and singleton patterns

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -170,7 +170,7 @@ namespace TimelessEchoes
             if (hero != null)
             {
                 hero.gameObject.SetActive(true);
-                var hp = hero.GetComponent<Health>();
+                var hp = hero.GetComponent<Hero.HeroHealth>();
                 if (hp != null)
                 {
                     hp.Init((int)hp.MaxHealth);
@@ -221,7 +221,7 @@ namespace TimelessEchoes
         {
             if (hero != null)
             {
-                var hp = hero.GetComponent<Health>();
+                var hp = hero.GetComponent<Hero.HeroHealth>();
                 if (hp != null)
                     hp.OnDeath -= OnHeroDeath;
 

--- a/Assets/Scripts/HealthBase.cs
+++ b/Assets/Scripts/HealthBase.cs
@@ -1,0 +1,131 @@
+using System;
+using Blindsided.Utilities;
+using UnityEngine;
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Base component for objects that have health.
+    /// Handles health values, healing and floating text display.
+    /// </summary>
+    public abstract class HealthBase : MonoBehaviour, IDamageable, IHasHealth
+    {
+        [SerializeField] protected int maxHealth = 10;
+        [SerializeField] protected SlicedFilledImage healthBar;
+        [SerializeField, Range(0f, 1f)] protected float minFillPercent = 0.05f;
+        [SerializeField] protected HealthBarSpriteOption[] barSprites;
+
+        protected virtual void Awake()
+        {
+            CurrentHealth = maxHealth;
+            UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+        }
+
+        public virtual void TakeDamage(float amount, float bonusDamage = 0f)
+        {
+            if (CurrentHealth <= 0f) return;
+
+            float total = CalculateDamage(amount + bonusDamage);
+            CurrentHealth -= total;
+            UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+
+            if (Application.isPlaying)
+                ShowFloatingText(total, bonusDamage);
+
+            AfterDamage(total);
+
+            if (CurrentHealth <= 0f)
+                OnZeroHealth();
+        }
+
+        protected virtual float CalculateDamage(float fullDamage)
+        {
+            return fullDamage;
+        }
+
+        protected virtual void AfterDamage(float total) { }
+
+        protected virtual void OnZeroHealth()
+        {
+            OnDeath?.Invoke();
+        }
+
+        public virtual void Heal(float amount)
+        {
+            if (amount <= 0f || CurrentHealth >= MaxHealth) return;
+            CurrentHealth = Mathf.Min(CurrentHealth + amount, MaxHealth);
+            UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+        }
+
+        public float CurrentHealth { get; protected set; }
+        public float MaxHealth => maxHealth;
+
+        public event Action<float, float> OnHealthChanged;
+        public event Action OnDeath;
+
+        public SlicedFilledImage HealthBar
+        {
+            get => healthBar;
+            set
+            {
+                healthBar = value;
+                UpdateBar();
+            }
+        }
+
+        public virtual void Init(int hp)
+        {
+            maxHealth = hp;
+            CurrentHealth = hp;
+            UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+        }
+
+        protected virtual void UpdateBar()
+        {
+            if (healthBar == null) return;
+
+            var percent = MaxHealth > 0f ? CurrentHealth / MaxHealth : 0f;
+            healthBar.fillAmount = Mathf.Max(percent, minFillPercent);
+
+            if (barSprites != null && barSprites.Length > 0)
+            {
+                var chosen = healthBar.sprite;
+                var best = -1f;
+                foreach (var opt in barSprites)
+                {
+                    if (opt.sprite == null) continue;
+                    if (percent >= opt.minPercent && opt.minPercent > best)
+                    {
+                        chosen = opt.sprite;
+                        best = opt.minPercent;
+                    }
+                }
+
+                if (chosen != null)
+                    healthBar.sprite = chosen;
+            }
+        }
+
+        protected void ShowFloatingText(float total, float bonusDamage)
+        {
+            string text = CalcUtils.FormatNumber(total);
+            if (bonusDamage != 0f)
+                text += $"<size=70%><color=#60C560>+{CalcUtils.FormatNumber(bonusDamage)}</color></size>";
+            FloatingText.Spawn(text, transform.position + Vector3.up, GetFloatingTextColor(), GetFloatingTextSize());
+        }
+
+        protected abstract Color GetFloatingTextColor();
+        protected abstract float GetFloatingTextSize();
+
+        [Serializable]
+        public struct HealthBarSpriteOption
+        {
+            public Sprite sprite;
+            [Range(0f, 1f)] public float minPercent;
+        }
+    }
+}

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -20,9 +20,10 @@ namespace TimelessEchoes.Hero
     [RequireComponent(typeof(AIPath))]
     [RequireComponent(typeof(AIDestinationSetter))]
     [RequireComponent(typeof(RVOController))]
-    [RequireComponent(typeof(Health))]
+    [RequireComponent(typeof(HeroHealth))]
     public class HeroController : MonoBehaviour
     {
+        public static HeroController Instance { get; private set; }
         [SerializeField] private HeroStats stats;
         [SerializeField] private Animator animator;
         [SerializeField] private SpriteRenderer spriteRenderer;
@@ -53,7 +54,7 @@ namespace TimelessEchoes.Hero
         private float defenseBonus;
 
         private bool destinationOverride;
-        private Health health;
+        private HeroHealth health;
         private float healthBonus;
 
         private bool isRolling;
@@ -105,9 +106,16 @@ namespace TimelessEchoes.Hero
 
         private void Awake()
         {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+
             ai = GetComponent<AIPath>();
             setter = GetComponent<AIDestinationSetter>();
-            health = GetComponent<Health>();
+            health = GetComponent<HeroHealth>();
             if (buffController == null)
             {
                 buffController = BuffManager.Instance;
@@ -208,6 +216,12 @@ namespace TimelessEchoes.Hero
             var skillController = Skills.SkillController.Instance;
             if (skillController != null)
                 skillController.OnMilestoneUnlocked -= OnMilestoneUnlocked;
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
         }
 
         private void OnMilestoneUnlocked(Skill skill, MilestoneBonus milestone)

--- a/Assets/Scripts/Hero/HeroHealth.cs
+++ b/Assets/Scripts/Hero/HeroHealth.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+using TimelessEchoes.Stats;
+
+namespace TimelessEchoes.Hero
+{
+    /// <summary>
+    /// Health component specifically for the hero. Handles defense and stat tracking.
+    /// </summary>
+    [RequireComponent(typeof(HeroController))]
+    public class HeroHealth : HealthBase
+    {
+        public static HeroHealth Instance { get; private set; }
+        private HeroController controller;
+
+        protected override void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            controller = GetComponent<HeroController>();
+            base.Awake();
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+                Instance = null;
+        }
+
+        protected override float CalculateDamage(float fullDamage)
+        {
+            controller = controller != null ? controller : GetComponent<HeroController>();
+            if (controller != null)
+            {
+                float min = fullDamage * 0.1f;
+                return Mathf.Max(fullDamage - controller.Defense, min);
+            }
+            return fullDamage;
+        }
+
+        protected override void AfterDamage(float total)
+        {
+            var tracker = GameplayStatTracker.Instance ??
+                           FindFirstObjectByType<GameplayStatTracker>();
+            tracker?.AddDamageTaken(total);
+        }
+
+        protected override Color GetFloatingTextColor()
+        {
+            ColorUtility.TryParseHtmlString("#C56260", out var red);
+            return red;
+        }
+
+        protected override float GetFloatingTextSize() => 6f;
+    }
+}

--- a/Assets/Scripts/Hero/HeroRegen.cs
+++ b/Assets/Scripts/Hero/HeroRegen.cs
@@ -7,15 +7,15 @@ namespace TimelessEchoes.Hero
     /// <summary>
     /// Applies health regeneration to the hero based on donations handled by <see cref="RegenManager"/>.
     /// </summary>
-    [RequireComponent(typeof(Health))]
+    [RequireComponent(typeof(HeroHealth))]
     public class HeroRegen : MonoBehaviour
     {
-        private Health health;
+        private HeroHealth health;
         private RegenManager regenManager;
 
         private void Awake()
         {
-            health = GetComponent<Health>();
+            health = GetComponent<HeroHealth>();
             if (regenManager == null)
                 regenManager = FindFirstObjectByType<RegenManager>();
         }

--- a/Assets/Scripts/NPC/MildredMovementController.cs
+++ b/Assets/Scripts/NPC/MildredMovementController.cs
@@ -18,7 +18,7 @@ namespace TimelessEchoes.NPC
         {
             ai = GetComponent<AIPath>();
             if (hero == null)
-                hero = FindFirstObjectByType<HeroController>();
+                hero = HeroController.Instance ?? FindFirstObjectByType<HeroController>();
         }
 
         private void Update()

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -106,8 +106,9 @@ namespace TimelessEchoes
                     tracker?.AddDamageDealt(dmgAmount);
                     var buffManager = TimelessEchoes.Buffs.BuffManager.Instance ??
                                       FindFirstObjectByType<TimelessEchoes.Buffs.BuffManager>();
-                    var hero = FindFirstObjectByType<TimelessEchoes.Hero.HeroController>();
-                    var heroHealth = hero != null ? hero.GetComponent<TimelessEchoes.Enemies.Health>() : null;
+                    var hero = TimelessEchoes.Hero.HeroController.Instance ??
+                                FindFirstObjectByType<TimelessEchoes.Hero.HeroController>();
+                    var heroHealth = hero != null ? hero.GetComponent<TimelessEchoes.Hero.HeroHealth>() : null;
                     if (buffManager != null && heroHealth != null)
                     {
                         float ls = buffManager.LifestealPercent;

--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -25,7 +25,7 @@ namespace TimelessEchoes.Regen
 
         private readonly Dictionary<Resource, double> donations = new();
         private readonly List<RegenEntryUIReferences> entries = new();
-        private Health heroHealth;
+        private Hero.HeroHealth heroHealth;
 
         private void Awake()
         {
@@ -44,7 +44,8 @@ namespace TimelessEchoes.Regen
                     Log("ResourceInventoryUI missing", TELogCategory.Resource, this);
             }
 
-            heroHealth = FindFirstObjectByType<HeroController>()?.GetComponent<Health>();
+            heroHealth = Hero.HeroHealth.Instance ??
+                         FindFirstObjectByType<Hero.HeroHealth>();
 
             LoadState();
             BuildEntries();

--- a/Assets/Scripts/Tests/Editor/HealthTests.cs
+++ b/Assets/Scripts/Tests/Editor/HealthTests.cs
@@ -1,6 +1,8 @@
 using NUnit.Framework;
 using UnityEngine;
 using TimelessEchoes.Enemies;
+using TimelessEchoes.Hero;
+using TimelessEchoes;
 using Blindsided.Utilities;
 using System.Reflection;
 
@@ -44,9 +46,9 @@ namespace TimelessEchoes.Tests
         {
             var barObj = new GameObject();
             var bar = barObj.AddComponent<SlicedFilledImage>();
-            var barField = typeof(Health).GetField("healthBar", BindingFlags.NonPublic | BindingFlags.Instance);
+            var barField = typeof(HealthBase).GetField("healthBar", BindingFlags.NonPublic | BindingFlags.Instance);
             barField.SetValue(health, bar);
-            var minField = typeof(Health).GetField("minFillPercent", BindingFlags.NonPublic | BindingFlags.Instance);
+            var minField = typeof(HealthBase).GetField("minFillPercent", BindingFlags.NonPublic | BindingFlags.Instance);
             minField.SetValue(health, 0.2f);
 
             health.TakeDamage(10f);
@@ -60,16 +62,16 @@ namespace TimelessEchoes.Tests
         {
             var barObj = new GameObject();
             var bar = barObj.AddComponent<SlicedFilledImage>();
-            var barField = typeof(Health).GetField("healthBar", BindingFlags.NonPublic | BindingFlags.Instance);
+            var barField = typeof(HealthBase).GetField("healthBar", BindingFlags.NonPublic | BindingFlags.Instance);
             barField.SetValue(health, bar);
 
             var sprite1 = Sprite.Create(Texture2D.whiteTexture, new Rect(0, 0, 1, 1), Vector2.zero);
             var sprite2 = Sprite.Create(Texture2D.blackTexture, new Rect(0, 0, 1, 1), Vector2.zero);
 
-            var options = new Health.HealthBarSpriteOption[2];
-            options[0] = new Health.HealthBarSpriteOption { sprite = sprite1, minPercent = 0.25f };
-            options[1] = new Health.HealthBarSpriteOption { sprite = sprite2, minPercent = 0f };
-            var optField = typeof(Health).GetField("barSprites", BindingFlags.NonPublic | BindingFlags.Instance);
+            var options = new HealthBase.HealthBarSpriteOption[2];
+            options[0] = new HealthBase.HealthBarSpriteOption { sprite = sprite1, minPercent = 0.25f };
+            options[1] = new HealthBase.HealthBarSpriteOption { sprite = sprite2, minPercent = 0f };
+            var optField = typeof(HealthBase).GetField("barSprites", BindingFlags.NonPublic | BindingFlags.Instance);
             optField.SetValue(health, options);
 
             health.TakeDamage(0f); // update bar
@@ -83,25 +85,27 @@ namespace TimelessEchoes.Tests
         [Test]
         public void DefenseReducesDamage()
         {
-            var hero = obj.AddComponent<Hero.HeroController>();
-            var field = typeof(Hero.HeroController).GetField("baseDefense", BindingFlags.NonPublic | BindingFlags.Instance);
+            var hero = obj.AddComponent<HeroController>();
+            var heroHealth = obj.AddComponent<HeroHealth>();
+            var field = typeof(HeroController).GetField("baseDefense", BindingFlags.NonPublic | BindingFlags.Instance);
             field.SetValue(hero, 2f);
 
-            health.TakeDamage(5f);
+            heroHealth.TakeDamage(5f);
 
-            Assert.AreEqual(7f, health.CurrentHealth);
+            Assert.AreEqual(7f, heroHealth.CurrentHealth);
         }
 
         [Test]
         public void DamageHasMinimumValue()
         {
-            var hero = obj.AddComponent<Hero.HeroController>();
-            var field = typeof(Hero.HeroController).GetField("baseDefense", BindingFlags.NonPublic | BindingFlags.Instance);
+            var hero = obj.AddComponent<HeroController>();
+            var heroHealth = obj.AddComponent<HeroHealth>();
+            var field = typeof(HeroController).GetField("baseDefense", BindingFlags.NonPublic | BindingFlags.Instance);
             field.SetValue(hero, 100f);
 
-            health.TakeDamage(10f);
+            heroHealth.TakeDamage(10f);
 
-            Assert.AreEqual(9f, health.CurrentHealth);
+            Assert.AreEqual(9f, heroHealth.CurrentHealth);
         }
     }
 }

--- a/Assets/Scripts/UI/RunCalebUIManager.cs
+++ b/Assets/Scripts/UI/RunCalebUIManager.cs
@@ -18,7 +18,7 @@ namespace TimelessEchoes.UI
         [SerializeField] private RegenManager regenManager;
 
         private HeroController hero;
-        private Health heroHealth;
+        private HeroHealth heroHealth;
 
         private float lastDamage;
         private float lastAttack;
@@ -48,8 +48,8 @@ namespace TimelessEchoes.UI
 
         private void OnEnable()
         {
-            hero = FindFirstObjectByType<HeroController>();
-            heroHealth = hero ? hero.GetComponent<Health>() : null;
+            hero = HeroController.Instance ?? FindFirstObjectByType<HeroController>();
+            heroHealth = hero ? hero.GetComponent<HeroHealth>() : null;
             if (heroHealth != null)
             {
                 heroHealth.OnHealthChanged += OnHealthChanged;


### PR DESCRIPTION
## Summary
- introduce `HealthBase` abstract class and split out enemy `Health`
- add `HeroHealth` derived from `HealthBase`
- convert `HeroController` and `HeroHealth` into singletons
- update hero-related scripts to reference new classes and singleton instances
- adjust unit tests for refactored health classes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b51c12b0832e8d4db4b10f2a80d1