### PR TITLE
Fix enemy stat labels

### DIFF
--- a/Assets/Prefabs/UI/Stats/EnemyEntry.prefab
+++ b/Assets/Prefabs/UI/Stats/EnemyEntry.prefab
@@ -636,7 +636,7 @@ GameObject:
   - component: {fileID: 1205721544206614959}
   - component: {fileID: 5620335432057288960}
   m_Layer: 5
-  m_Name: Hitpoints/Damage_Text
+  m_Name: Health/Damage_Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -689,7 +689,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Hitpoints: ???
+  m_text: 'Health: ???
 
     Damage: ???'
   m_isRightToLeft: 0
@@ -1106,7 +1106,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Damage: ???, Attack Rate: ???, Movement: ???, Hitpoints: ???
+  m_text: 'Damage: ???, Attack Rate: ???, Movement: ???, Health: ???
 
     Kills:
     4, Next Reveal: 10'

--- a/Assets/Prefabs/UI/Stats/ItemEntry.prefab
+++ b/Assets/Prefabs/UI/Stats/ItemEntry.prefab
@@ -1151,7 +1151,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Damage: ???, Attack Rate: ???, Movement: ???, Hitpoints: ???
+  m_text: 'Damage: ???, Attack Rate: ???, Movement: ???, Health: ???
 
     Kills:
     4, Next Reveal: 10'
@@ -1612,7 +1612,7 @@ GameObject:
   - component: {fileID: 7030418403088289328}
   - component: {fileID: 1902343818136865111}
   m_Layer: 5
-  m_Name: Hitpoints/Damage_Text
+  m_Name: Health/Damage_Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Prefabs/UI/Stats/TaskEntry.prefab
+++ b/Assets/Prefabs/UI/Stats/TaskEntry.prefab
@@ -287,7 +287,7 @@ GameObject:
   - component: {fileID: 5754463171746830193}
   - component: {fileID: 3455198727293779481}
   m_Layer: 5
-  m_Name: Hitpoints/Damage_Text
+  m_Name: Health/Damage_Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1240,7 +1240,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Damage: ???, Attack Rate: ???, Movement: ???, Hitpoints: ???
+  m_text: 'Damage: ???, Attack Rate: ???, Movement: ???, Health: ???
 
     Kills:
     4, Next Reveal: 10'

--- a/Assets/Scriptables/StatUpgrades/Attack Speed.asset
+++ b/Assets/Scriptables/StatUpgrades/Attack Speed.asset
@@ -10,7 +10,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 79fdaab072066594bad454607db52b83, type: 3}
-  m_Name: Attack Speed
+  m_Name: Attack Rate
   m_EditorClassIdentifier: 
   baseValue: 1
   description: Swing more often.

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -283,7 +283,7 @@ namespace TimelessEchoes.Hero
                         baseDamage = baseVal;
                         damageBonus = increase;
                         break;
-                    case "Attack Speed":
+                    case "Attack Rate":
                         baseAttackSpeed = baseVal;
                         attackSpeedBonus = increase;
                         break;

--- a/Assets/Scripts/UI/EnemyStatsPanelUI.cs
+++ b/Assets/Scripts/UI/EnemyStatsPanelUI.cs
@@ -22,7 +22,7 @@ namespace TimelessEchoes.UI
             Default,
             Damage,
             Health,
-            AttackSpeed,
+            AttackRate,
             MoveSpeed
         }
 
@@ -118,7 +118,7 @@ namespace TimelessEchoes.UI
 
             string hp = reveal >= 2 ? CalcUtils.FormatNumber(stats.maxHealth, true, 400f, false) : "???";
             string dmg = reveal >= 1 ? CalcUtils.FormatNumber(stats.damage, true, 400f, false) : "???";
-            ui.hitpointsAndDamageText.text = $"Hitpoints: {hp}\nDamage: {dmg}";
+            ui.hitpointsAndDamageText.text = $"Health: {hp}\nDamage: {dmg}";
 
             string move = reveal >= 3 ? CalcUtils.FormatNumber(stats.moveSpeed, true, 400f, false) : "???";
             string atk = reveal >= 4 ? CalcUtils.FormatNumber(stats.attackSpeed, true, 400f, false) : "???";
@@ -162,7 +162,7 @@ namespace TimelessEchoes.UI
                 SortMode.Damage => 1,
                 SortMode.Health => 2,
                 SortMode.MoveSpeed => 3,
-                SortMode.AttackSpeed => 4,
+                SortMode.AttackRate => 4,
                 _ => 0
             };
 
@@ -171,7 +171,7 @@ namespace TimelessEchoes.UI
                 SortMode.Damage => s.damage,
                 SortMode.Health => s.maxHealth,
                 SortMode.MoveSpeed => s.moveSpeed,
-                SortMode.AttackSpeed => s.attackSpeed,
+                SortMode.AttackRate => s.attackSpeed,
                 _ => 0
             };
 

--- a/Assets/Scripts/UI/RunCalebUIManager.cs
+++ b/Assets/Scripts/UI/RunCalebUIManager.cs
@@ -116,7 +116,7 @@ namespace TimelessEchoes.UI
             if (uiReferences.leftText != null)
                 uiReferences.leftText.text =
                     $"Damage: {damage:0.##}\n" +
-                    $"Attack Speed: {attack:0.###} /s\n" +
+                    $"Attack Rate: {attack:0.###} /s\n" +
                     $"Movement Speed {move:0.##}";
 
             if (uiReferences.rightText != null)


### PR DESCRIPTION
## Summary
- rename UI stat sorting label to `Attack Rate`
- rename `Hitpoints` references to `Health`
- show hero `Attack Rate` instead of `Attack Speed`
- update asset names accordingly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870beb511b8832ea1e0b05c911f2f79