### PR TITLE
Use CalcUtils time format for buff UI

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -87,7 +87,9 @@ namespace TimelessEchoes.Buffs
                 if (ui.durationText != null)
                 {
                     var remain = recipe ? buffManager.GetRemaining(recipe) : 0f;
-                    ui.durationText.text = remain > 0f ? Mathf.Ceil(remain).ToString() : string.Empty;
+                    ui.durationText.text = remain > 0f
+                        ? FormatTime(remain, shortForm: true)
+                        : string.Empty;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- use `CalcUtils.FormatTime` to show remaining buff durations in short form

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68717f55f2b0832e8c54e078e8141436