### PR TITLE
Display run duration in formatted time

### DIFF
--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -236,10 +236,18 @@ namespace TimelessEchoes.UI
             }
 
             if (longestRunText != null)
-                longestRunText.text = CalcUtils.FormatNumber(longest, true);
+            {
+                longestRunText.text = graphMode == GraphMode.Duration
+                    ? CalcUtils.FormatTime(longest)
+                    : CalcUtils.FormatNumber(longest, true);
+            }
 
             if (averageRunText != null)
-                averageRunText.text = CalcUtils.FormatNumber(average, true);
+            {
+                averageRunText.text = graphMode == GraphMode.Duration
+                    ? CalcUtils.FormatTime(average)
+                    : CalcUtils.FormatNumber(average, true);
+            }
 
             if (averageRunSlider != null)
             {


### PR DESCRIPTION
## Summary
- use `CalcUtils.FormatTime` when showing longest and average run stats for Duration graphs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871821770c4832e8e445c08cd3768b8