### PR TITLE
Display enemy defense in floating damage numbers

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Blindsided.Utilities;
 
 namespace TimelessEchoes.Enemies
 {
@@ -14,6 +15,36 @@ namespace TimelessEchoes.Enemies
         }
 
         protected override float GetFloatingTextSize() => 8f;
+
+        public override void TakeDamage(float amount, float bonusDamage = 0f)
+        {
+            if (CurrentHealth <= 0f) return;
+
+            var enemy = GetComponent<Enemy>();
+            var defense = enemy != null && enemy.Stats != null ? enemy.Stats.defense : 0f;
+
+            float full = amount + bonusDamage;
+            float total = Mathf.Max(full - defense, full * 0.1f);
+
+            CurrentHealth -= total;
+            UpdateBar();
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+
+            if (Application.isPlaying)
+            {
+                string text = CalcUtils.FormatNumber(total);
+                if (bonusDamage != 0f)
+                    text += $"<size=70%><color=#60C560>+{CalcUtils.FormatNumber(bonusDamage)}</color></size>";
+                if (defense != 0f)
+                    text += $"<size=70%><color=#C56260>-{CalcUtils.FormatNumber(defense)}</color></size>";
+                FloatingText.Spawn(text, transform.position + Vector3.up, GetFloatingTextColor(), GetFloatingTextSize());
+            }
+
+            AfterDamage(total);
+
+            if (CurrentHealth <= 0f)
+                OnZeroHealth();
+        }
 
         protected override void OnZeroHealth()
         {


### PR DESCRIPTION
## Summary
- show enemy defense as a red `-#` value alongside bonus damage
- reduce damage by enemy defense so the number shown matches actual damage dealt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871afdd1830832ea0d4d8ea067ba069