### PR TITLE
Fix event invocation in Health

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -28,7 +28,7 @@ namespace TimelessEchoes.Enemies
 
             CurrentHealth -= total;
             UpdateBar();
-            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+            RaiseHealthChanged();
 
             if (Application.isPlaying)
             {

--- a/Assets/Scripts/HealthBase.cs
+++ b/Assets/Scripts/HealthBase.cs
@@ -66,6 +66,11 @@ namespace TimelessEchoes
         public event Action<float, float> OnHealthChanged;
         public event Action OnDeath;
 
+        protected void RaiseHealthChanged()
+        {
+            OnHealthChanged?.Invoke(CurrentHealth, MaxHealth);
+        }
+
         public SlicedFilledImage HealthBar
         {
             get => healthBar;


### PR DESCRIPTION
## Summary
- add a method in `HealthBase` to invoke `OnHealthChanged`
- use this method from `Health` to avoid direct event invocation

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b25a31b4832eb57f2a654eeb6de7