### PR TITLE
Change enemy defense to float

### DIFF
--- a/Assets/Scripts/Enemies/EnemyStats.cs
+++ b/Assets/Scripts/Enemies/EnemyStats.cs
@@ -12,7 +12,7 @@ namespace TimelessEchoes.Enemies
         public Sprite icon;
         public int maxHealth = 10;
         public int experience = 10;
-        public int defense = 0;
+        public float defense = 0f;
         public int damage = 1;
         public float moveSpeed = 3f;
         public float attackSpeed = 1f;


### PR DESCRIPTION
## Summary
- switch EnemyStats.defense from int to float
- reference new float defense in enemy health calculations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b3ef09a4832eae82e7a11f9670b8