### PR TITLE
Add stats window management

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -27,6 +27,7 @@ namespace TimelessEchoes.UI
         [SerializeField] private WindowReference credits = new();
         [SerializeField] private WindowReference regen = new();
         [SerializeField] private WindowReference disciples = new();
+        [SerializeField] private WindowReference stats = new();
         [SerializeField] private WindowReference inventory = new();
         [SerializeField] private WindowReference options = new();
 
@@ -47,6 +48,8 @@ namespace TimelessEchoes.UI
                 regen.button.onClick.AddListener(OpenRegen);
             if (disciples.button != null)
                 disciples.button.onClick.AddListener(OpenDisciples);
+            if (stats.button != null)
+                stats.button.onClick.AddListener(OpenStats);
             if (options.button != null)
                 options.button.onClick.AddListener(OpenOptions);
             if (inventory.button != null)
@@ -69,6 +72,8 @@ namespace TimelessEchoes.UI
                 regen.button.onClick.RemoveListener(OpenRegen);
             if (disciples.button != null)
                 disciples.button.onClick.RemoveListener(OpenDisciples);
+            if (stats.button != null)
+                stats.button.onClick.RemoveListener(OpenStats);
             if (options.button != null)
                 options.button.onClick.RemoveListener(OpenOptions);
             if (inventory.button != null)
@@ -89,6 +94,7 @@ namespace TimelessEchoes.UI
         private void OpenCredits() => OpenWindow(credits.window);
         private void OpenRegen() => OpenWindow(regen.window);
         private void OpenDisciples() => OpenWindow(disciples.window);
+        private void OpenStats() => OpenWindow(stats.window);
         private void OpenOptions() => OpenWindow(options.window);
         private void ToggleInventory()
         {
@@ -117,6 +123,8 @@ namespace TimelessEchoes.UI
                 regen.window.SetActive(false);
             if (disciples.window != null)
                 disciples.window.SetActive(false);
+            if (stats.window != null)
+                stats.window.SetActive(false);
             if (options.window != null)
                 options.window.SetActive(false);
         }
@@ -135,6 +143,8 @@ namespace TimelessEchoes.UI
                 regen.window.SetActive(false);
             if (disciples.window != null)
                 disciples.window.SetActive(false);
+            if (stats.window != null)
+                stats.window.SetActive(false);
             if (options.window != null)
                 options.window.SetActive(false);
             if (inventory.window != null)


### PR DESCRIPTION
## Summary
- expand `TownWindowManager` with a `stats` entry
- hook stats button events
- ensure all windows close the stats window when toggled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872d5d1e410832e844ae88d9685c455