### PR TITLE
Display completed quests

### DIFF
--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -17,16 +17,19 @@ namespace TimelessEchoes.Quests
         public TMP_Text rewardText;
         public Button turnInButton;
         public SlicedFilledImage progressImage;
+        public GameObject progressBar;
         public CostResourceUIReferences costSlotPrefab;
         public Transform costParent;
 
         private Action onTurnIn;
 
-        public void Setup(QuestData data, Action turnIn)
+        public void Setup(QuestData data, Action turnIn, bool showRequirements = true, bool completed = false)
         {
             onTurnIn = turnIn;
             if (nameText != null)
-                nameText.text = data != null ? data.questName : string.Empty;
+                nameText.text = data != null
+                    ? data.questName + (completed ? " | Completed" : string.Empty)
+                    : string.Empty;
             if (descriptionText != null)
                 descriptionText.text = data != null ? data.description : string.Empty;
             if (rewardText != null)
@@ -35,15 +38,21 @@ namespace TimelessEchoes.Quests
             if (turnInButton != null)
             {
                 turnInButton.onClick.RemoveAllListeners();
-                if (onTurnIn != null)
+                if (onTurnIn != null && !completed)
+                {
                     turnInButton.onClick.AddListener(() => onTurnIn());
+                }
+                turnInButton.gameObject.SetActive(onTurnIn != null && !completed);
             }
+
+            if (progressBar != null)
+                progressBar.SetActive(!completed);
 
             if (costParent != null)
             {
                 foreach (Transform child in costParent)
                     Destroy(child.gameObject);
-                if (data != null && costSlotPrefab != null)
+                if (data != null && costSlotPrefab != null && showRequirements)
                     foreach (var req in data.requirements)
                     {
                         var slot = Instantiate(costSlotPrefab, costParent);

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -273,6 +273,16 @@ namespace TimelessEchoes.Quests
                 inst.ui = uiManager.CreateEntry(inst.data, () => CompleteQuest(inst));
                 UpdateProgress(inst);
             }
+
+            foreach (var quest in quests)
+            {
+                if (quest == null) continue;
+                if (active.ContainsKey(quest.questId))
+                    continue;
+                if (!oracle.saveData.Quests.TryGetValue(quest.questId, out var rec) || !rec.Completed)
+                    continue;
+                uiManager.CreateEntry(quest, null, false, true);
+            }
         }
 
 

--- a/Assets/Scripts/Quests/QuestUIManager.cs
+++ b/Assets/Scripts/Quests/QuestUIManager.cs
@@ -27,12 +27,12 @@ namespace TimelessEchoes.Quests
                 Instance = null;
         }
 
-        public QuestEntryUI CreateEntry(QuestData quest, Action onTurnIn)
+        public QuestEntryUI CreateEntry(QuestData quest, Action onTurnIn, bool showRequirements = true, bool completed = false)
         {
             if (questEntryPrefab == null || questParent == null)
                 return null;
             var ui = Instantiate(questEntryPrefab, questParent);
-            ui.Setup(quest, onTurnIn);
+            ui.Setup(quest, onTurnIn, showRequirements, completed);
             entries.Add(ui);
             return ui;
         }


### PR DESCRIPTION
## Summary
- show completed quests after current quests
- support disabling quest turn-in button and hiding requirements
- add progress bar GameObject field on QuestEntryUI to hide when completed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872d5aa2eac832e8cd08962a6782ce8