### PR TITLE
Initialize town UI windows as closed

### DIFF
--- a/Assets/Scripts/UI/TownWindowManager.cs
+++ b/Assets/Scripts/UI/TownWindowManager.cs
@@ -58,6 +58,11 @@ namespace TimelessEchoes.UI
                 startRunButton.onClick.AddListener(CloseAllWindows);
         }
 
+        private void Start()
+        {
+            CloseAllWindows();
+        }
+
         private void OnDestroy()
         {
             if (upgrades.button != null)


### PR DESCRIPTION
## Summary
- close all town windows when the `TownWindowManager` starts

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dd1ed614832eb8732acea47e88dc