### PR TITLE
Add ReaperManager for instant kills

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -28,6 +28,7 @@ namespace TimelessEchoes
         public static GameManager Instance { get; private set; }
         [Header("Prefabs")] [SerializeField] private GameObject mapPrefab;
         [SerializeField] private GameObject gravestonePrefab;
+        [SerializeField] private GameObject reaperPrefab;
 
         [Header("UI References")] [SerializeField]
         private Button startRunButton;
@@ -46,6 +47,8 @@ namespace TimelessEchoes
         [SerializeField] private SlicedFilledImage deathTimerImage;
         [SerializeField] private float deathWindowDuration = 20f;
         [SerializeField] public string mildredQuestId;
+
+        public GameObject ReaperPrefab => reaperPrefab;
 
         [Header("Cameras")] [SerializeField] private CinemachineCamera tavernCamera;
 
@@ -225,14 +228,28 @@ namespace TimelessEchoes
                 if (hp != null)
                     hp.OnDeath -= OnHeroDeath;
 
-                // Disable hero so it stops moving during the death window
                 var ai = hero.GetComponent<AIPath>();
                 if (ai != null)
                     ai.enabled = false;
-                hero.gameObject.SetActive(false);
-                if (gravestonePrefab != null && currentMap != null)
-                    Instantiate(gravestonePrefab, hero.transform.position, Quaternion.identity,
-                        currentMap.transform);
+
+                if (reaperPrefab != null && currentMap != null)
+                {
+                    Enemies.ReaperManager.Spawn(reaperPrefab, hero.gameObject, currentMap.transform, false,
+                        () =>
+                        {
+                            hero.gameObject.SetActive(false);
+                            if (gravestonePrefab != null)
+                                Instantiate(gravestonePrefab, hero.transform.position, Quaternion.identity,
+                                    currentMap.transform);
+                        });
+                }
+                else
+                {
+                    hero.gameObject.SetActive(false);
+                    if (gravestonePrefab != null && currentMap != null)
+                        Instantiate(gravestonePrefab, hero.transform.position, Quaternion.identity,
+                            currentMap.transform);
+                }
             }
 
             Log("Hero death", TELogCategory.Hero, this);

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -90,6 +90,16 @@ namespace TimelessEchoes
                                      FindFirstObjectByType<TimelessEchoes.Skills.SkillController>();
                     if (controller != null && controller.RollForEffect(combatSkill, TimelessEchoes.Skills.MilestoneType.InstantKill))
                     {
+                        var prefab = TimelessEchoes.GameManager.Instance != null ?
+                                     TimelessEchoes.GameManager.Instance.ReaperPrefab : null;
+                        if (Enemies.ReaperManager.Spawn(prefab, target.gameObject, null, true) != null)
+                        {
+                            var sfx2 = GetComponent<ProjectileHitSfx>();
+                            sfx2?.PlayHit();
+                            SpawnEffect();
+                            Destroy(gameObject);
+                            return;
+                        }
                         var hp = target.GetComponent<IHasHealth>();
                         if (hp != null)
                             dmgAmount = Mathf.Max(dmgAmount, hp.CurrentHealth);


### PR DESCRIPTION
## Summary
- add `ReaperManager` for reaping animation and timed kills
- allow `GameManager` to spawn a reaper on hero death
- spawn reaper when projectile instant-kills an enemy

## Testing
- `echo "No programmatic tests configured."`

------
https://chatgpt.com/codex/tasks/task_e_6872f1ea048c832e9a81ceda8cdcb97a