### PR TITLE
Fix reaper kill logic

### DIFF
--- a/Assets/Scripts/Enemies/ReaperManager.cs
+++ b/Assets/Scripts/Enemies/ReaperManager.cs
@@ -39,6 +39,9 @@ namespace TimelessEchoes.Enemies
             if (hp != null && dmg != null && hp.CurrentHealth > 0f)
             {
                 float amount = hp.CurrentHealth;
+                var enemy = target.GetComponent<Enemy>();
+                if (enemy != null && enemy.Stats != null)
+                    amount += enemy.Stats.defense + 1f;
                 dmg.TakeDamage(amount);
                 if (fromHero)
                 {
@@ -73,10 +76,12 @@ namespace TimelessEchoes.Enemies
         /// <summary>
         /// Spawns a new reaper targeting the given object.
         /// </summary>
-        public static ReaperManager Spawn(GameObject prefab, GameObject target, Transform parent = null, bool fromHero = false, Action onKill = null)
+        public static ReaperManager Spawn(GameObject prefab, GameObject target, Transform parent = null,
+            bool fromHero = false, Action onKill = null, Vector3? positionOffset = null)
         {
             if (prefab == null || target == null) return null;
-            var obj = Instantiate(prefab, target.transform.position, Quaternion.identity, parent);
+            var offset = positionOffset ?? Vector3.zero;
+            var obj = Instantiate(prefab, target.transform.position + offset, Quaternion.identity, parent);
             var mgr = obj.GetComponent<ReaperManager>();
             if (mgr != null)
                 mgr.Init(target, fromHero, onKill);

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -29,6 +29,7 @@ namespace TimelessEchoes
         [Header("Prefabs")] [SerializeField] private GameObject mapPrefab;
         [SerializeField] private GameObject gravestonePrefab;
         [SerializeField] private GameObject reaperPrefab;
+        [SerializeField] private Vector3 reaperSpawnOffset = Vector3.zero;
 
         [Header("UI References")] [SerializeField]
         private Button startRunButton;
@@ -49,6 +50,7 @@ namespace TimelessEchoes
         [SerializeField] public string mildredQuestId;
 
         public GameObject ReaperPrefab => reaperPrefab;
+        public Vector3 ReaperSpawnOffset => reaperSpawnOffset;
 
         [Header("Cameras")] [SerializeField] private CinemachineCamera tavernCamera;
 
@@ -241,7 +243,7 @@ namespace TimelessEchoes
                             if (gravestonePrefab != null)
                                 Instantiate(gravestonePrefab, hero.transform.position, Quaternion.identity,
                                     currentMap.transform);
-                        });
+                        }, reaperSpawnOffset);
                 }
                 else
                 {

--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -92,7 +92,9 @@ namespace TimelessEchoes
                     {
                         var prefab = TimelessEchoes.GameManager.Instance != null ?
                                      TimelessEchoes.GameManager.Instance.ReaperPrefab : null;
-                        if (Enemies.ReaperManager.Spawn(prefab, target.gameObject, null, true) != null)
+                        var offset = TimelessEchoes.GameManager.Instance != null ?
+                                     (Vector3?)TimelessEchoes.GameManager.Instance.ReaperSpawnOffset : null;
+                        if (Enemies.ReaperManager.Spawn(prefab, target.gameObject, null, true, null, offset) != null)
                         {
                             var sfx2 = GetComponent<ProjectileHitSfx>();
                             sfx2?.PlayHit();


### PR DESCRIPTION
## Summary
- ensure Reaper kill bypasses enemy defense
- add optional position offset when spawning a Reaper
- expose Reaper spawn offset in GameManager

## Testing
- `dotnet test --list-tests` *(fails: no project file)*

------
https://chatgpt.com/codex/tasks/task_e_6872f60b8aa4832e9034e747dbc1a742