### PR TITLE
Update defense floating text color

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -36,7 +36,7 @@ namespace TimelessEchoes.Enemies
                 if (bonusDamage != 0f)
                     text += $"<size=70%><color=#60C560>+{CalcUtils.FormatNumber(bonusDamage)}</color></size>";
                 if (defense != 0f)
-                    text += $"<size=70%><color=#C56260>-{CalcUtils.FormatNumber(defense)}</color></size>";
+                    text += $"<size=70%><color=#C69B60>-{CalcUtils.FormatNumber(defense)}</color></size>";
                 FloatingText.Spawn(text, transform.position + Vector3.up, GetFloatingTextColor(), GetFloatingTextSize());
             }
 


### PR DESCRIPTION
## Summary
- switch minus defense damage color to orange

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872fb3b67b0832e83d8d1ef118d982a