### PR TITLE
Hide enemy health bar until damage

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -8,6 +8,13 @@ namespace TimelessEchoes.Enemies
     /// </summary>
     public class Health : HealthBase
     {
+        protected override void Awake()
+        {
+            base.Awake();
+            if (healthBar != null)
+                healthBar.gameObject.SetActive(false);
+        }
+
         protected override Color GetFloatingTextColor()
         {
             ColorUtility.TryParseHtmlString("#C69B60", out var orange);
@@ -27,6 +34,8 @@ namespace TimelessEchoes.Enemies
             float total = Mathf.Max(full - defense, full * 0.1f);
 
             CurrentHealth -= total;
+            if (healthBar != null && !healthBar.gameObject.activeSelf)
+                healthBar.gameObject.SetActive(true);
             UpdateBar();
             RaiseHealthChanged();
 


### PR DESCRIPTION
## Summary
- keep enemy health bars hidden until they take damage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68746f1f6b38832eb09c207989dcfe03