### PR TITLE
Fix duplicate run record after death

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -356,7 +356,8 @@ namespace TimelessEchoes
                 runDropUI.ResetDrops();
             }
 
-            statTracker?.EndRun(false);
+            if (!runEndedByDeath)
+                statTracker?.EndRun(false);
             BuffManager.Instance?.ClearActiveBuffs();
             yield return StartCoroutine(CleanupMapRoutine());
             if (tavernCamera != null)


### PR DESCRIPTION
## Summary
- avoid calling `EndRun(false)` when the run already ended due to death

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68746f927160832ebff81d0cdbed5812