### PR TITLE
Implement configurable priority bonus for backtracking

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -21,6 +21,8 @@ namespace TimelessEchoes.Tasks
 
         [SerializeField] public HeroController hero;
         [SerializeField] public float maxBacktrackDistance = -1f;
+        // Positive values give tasks located behind the hero a priority bonus
+        [SerializeField] public float backtrackingAdditionalWeight = 0f;
         [SerializeField] private CinemachineCamera mapCamera;
         [SerializeField] private string currentTaskName;
         [SerializeField] private MonoBehaviour currentTaskObject;
@@ -408,6 +410,8 @@ namespace TimelessEchoes.Tasks
                         continue;
 
                     float d = Vector3.Distance(currentPos, p);
+                    if (deltaX > 0f && backtrackingAdditionalWeight > 0f)
+                        d -= deltaX * backtrackingAdditionalWeight;
                     if (d < bestDist)
                     {
                         bestDist = d;
@@ -419,7 +423,11 @@ namespace TimelessEchoes.Tasks
                 {
                     for (int i = 0; i < pairs.Count; i++)
                     {
-                        float d = Vector3.Distance(currentPos, pairs[i].pos);
+                        var (p, _, _) = pairs[i];
+                        float deltaX = currentPos.x - p.x;
+                        float d = Vector3.Distance(currentPos, p);
+                        if (deltaX > 0f && backtrackingAdditionalWeight > 0f)
+                            d -= deltaX * backtrackingAdditionalWeight;
                         if (d < bestDist)
                         {
                             bestDist = d;

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Procedural tasks are ordered by their world X position so the hero progresses
 from left to right. Mining and fishing tasks award resources on completion,
 allowing you to upgrade your hero.
 
+`TaskController` also exposes a **backtrackingAdditionalWeight** setting. When
+positive, tasks located behind the hero receive a priority bonus proportional
+to how far back they are. Increase this value to force backtracking when the
+player advances too far forward.
+
 Water based tasks ignore blocking colliders and can spawn even when a tile on
 the `Blocking` layer is present.
 Grass tasks use a dedicated list and only appear on grass tiles. A toggle on the


### PR DESCRIPTION
## Summary
- document backtrackingAdditionalWeight in README
- give backtracking tasks a priority bonus by subtracting weighted distance

## Testing
- `dotnet test` *(fails: command not found)*
- `unity -batchmode -runTests -projectPath `pwd` -testResults results.xml -logFile -` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68746f0bb280832e92c65763148f6a49