### PR TITLE
Add divider prefab support for quest list

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -274,6 +274,7 @@ namespace TimelessEchoes.Quests
                 UpdateProgress(inst);
             }
 
+            var hasCompleted = false;
             foreach (var quest in quests)
             {
                 if (quest == null) continue;
@@ -281,6 +282,11 @@ namespace TimelessEchoes.Quests
                     continue;
                 if (!oracle.saveData.Quests.TryGetValue(quest.questId, out var rec) || !rec.Completed)
                     continue;
+                if (!hasCompleted)
+                {
+                    uiManager.CreateDivider();
+                    hasCompleted = true;
+                }
                 uiManager.CreateEntry(quest, null, false, true);
             }
         }

--- a/Assets/Scripts/Quests/QuestUIManager.cs
+++ b/Assets/Scripts/Quests/QuestUIManager.cs
@@ -12,9 +12,11 @@ namespace TimelessEchoes.Quests
     {
         public static QuestUIManager Instance { get; private set; }
         [SerializeField] private QuestEntryUI questEntryPrefab;
+        [SerializeField] private GameObject dividerPrefab;
         [SerializeField] private Transform questParent;
 
         private readonly List<QuestEntryUI> entries = new();
+        private readonly List<GameObject> extras = new();
 
         private void Awake()
         {
@@ -37,12 +39,25 @@ namespace TimelessEchoes.Quests
             return ui;
         }
 
+        public GameObject CreateDivider()
+        {
+            if (dividerPrefab == null || questParent == null)
+                return null;
+            var obj = Instantiate(dividerPrefab, questParent);
+            extras.Add(obj);
+            return obj;
+        }
+
         public void Clear()
         {
             foreach (var entry in entries)
                 if (entry != null)
                     Destroy(entry.gameObject);
+            foreach (var extra in extras)
+                if (extra != null)
+                    Destroy(extra);
             entries.Clear();
+            extras.Clear();
         }
 
         public void RemoveEntry(QuestEntryUI entry)


### PR DESCRIPTION
## Summary
- add a `dividerPrefab` reference to `QuestUIManager`
- keep track of extra objects and destroy them on Clear
- insert a divider between active and completed quest entries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874723846d4832ea239022bd48f9dd4