### PR TITLE
Enable enemy health bar parent visibility

### DIFF
--- a/Assets/Scripts/Enemies/Health.cs
+++ b/Assets/Scripts/Enemies/Health.cs
@@ -8,10 +8,14 @@ namespace TimelessEchoes.Enemies
     /// </summary>
     public class Health : HealthBase
     {
+        [SerializeField] private GameObject healthBarParent;
+
         protected override void Awake()
         {
             base.Awake();
-            if (healthBar != null)
+            if (healthBarParent != null)
+                healthBarParent.SetActive(false);
+            else if (healthBar != null)
                 healthBar.gameObject.SetActive(false);
         }
 
@@ -34,8 +38,6 @@ namespace TimelessEchoes.Enemies
             float total = Mathf.Max(full - defense, full * 0.1f);
 
             CurrentHealth -= total;
-            if (healthBar != null && !healthBar.gameObject.activeSelf)
-                healthBar.gameObject.SetActive(true);
             UpdateBar();
             RaiseHealthChanged();
 
@@ -53,6 +55,14 @@ namespace TimelessEchoes.Enemies
 
             if (CurrentHealth <= 0f)
                 OnZeroHealth();
+        }
+
+        public void SetHealthBarVisible(bool visible)
+        {
+            if (healthBarParent != null)
+                healthBarParent.SetActive(visible);
+            else if (healthBar != null)
+                healthBar.gameObject.SetActive(visible);
         }
 
         protected override void OnZeroHealth()

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -39,6 +39,7 @@ namespace TimelessEchoes.Hero
         private readonly bool allowAttacks = true;
 
         private Transform currentEnemy;
+        private Health currentEnemyHealth;
 
         private AIPath ai;
         private float attackSpeedBonus;
@@ -358,13 +359,28 @@ namespace TimelessEchoes.Hero
                 var hp = currentEnemy.GetComponent<Health>();
                 var dist = Vector2.Distance(transform.position, currentEnemy.position);
                 if (hp == null || hp.CurrentHealth <= 0f || dist > stats.visionRange)
+                {
+                    currentEnemyHealth?.SetHealthBarVisible(false);
                     currentEnemy = null;
+                    currentEnemyHealth = null;
+                }
             }
 
             var nearest = currentEnemy != null ? currentEnemy : FindNearestEnemy();
             if (nearest != null)
             {
-                currentEnemy = nearest;
+                if (currentEnemy != nearest)
+                {
+                    currentEnemyHealth?.SetHealthBarVisible(false);
+                    currentEnemy = nearest;
+                    currentEnemyHealth = nearest.GetComponent<Health>();
+                    currentEnemyHealth?.SetHealthBarVisible(true);
+                }
+                else if (currentEnemyHealth == null)
+                {
+                    currentEnemyHealth = nearest.GetComponent<Health>();
+                    currentEnemyHealth?.SetHealthBarVisible(true);
+                }
                 if (state == State.PerformingTask && CurrentTask != null) CurrentTask.OnInterrupt(this);
                 HandleCombat(nearest);
                 return;
@@ -376,6 +392,8 @@ namespace TimelessEchoes.Hero
                 combatDamageMultiplier = 1f;
                 isRolling = false;
                 diceRoller?.ResetRoll();
+                currentEnemyHealth?.SetHealthBarVisible(false);
+                currentEnemyHealth = null;
                 state = State.Idle;
                 taskController?.SelectEarliestTask();
             }


### PR DESCRIPTION
## Summary
- control enemy health bar visibility using a HealthBarParent GameObject
- ensure hero toggles enemy health bar when targeting an enemy

## Testing
- `grep -R "NUnit" -n . | head`


------
https://chatgpt.com/codex/tasks/task_e_687472a0dc88832e9fe7ea98df6a1a5c