### PR TITLE
Assign unique task IDs

### DIFF
--- a/Assets/Resources/Tasks/Chests/Wooden Chest.asset
+++ b/Assets/Resources/Tasks/Chests/Wooden Chest.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Wooden Chest
   m_EditorClassIdentifier: 
   taskName: Wooden Chest
-  taskID: 5
+  taskID: 10
   taskIcon: {fileID: -7070875390197807606, guid: 1ec0b90faf4188545ba0f1bd405b6df3, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Carrot.asset
+++ b/Assets/Resources/Tasks/Farming/Carrot.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Carrot
   m_EditorClassIdentifier: 
   taskName: Carrot
-  taskID: 4
+  taskID: 23
   taskIcon: {fileID: 4727212774405997460, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Chillie.asset
+++ b/Assets/Resources/Tasks/Farming/Chillie.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Chillie
   m_EditorClassIdentifier: 
   taskName: Chillie
-  taskID: 4
+  taskID: 24
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Corn.asset
+++ b/Assets/Resources/Tasks/Farming/Corn.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Corn
   m_EditorClassIdentifier: 
   taskName: Corn
-  taskID: 4
+  taskID: 25
   taskIcon: {fileID: -1010118597598872900, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Cucumber.asset
+++ b/Assets/Resources/Tasks/Farming/Cucumber.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Cucumber
   m_EditorClassIdentifier: 
   taskName: Cucumber
-  taskID: 4
+  taskID: 26
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Funion.asset
+++ b/Assets/Resources/Tasks/Farming/Funion.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Funion
   m_EditorClassIdentifier: 
   taskName: Funion
-  taskID: 4
+  taskID: 27
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Leek.asset
+++ b/Assets/Resources/Tasks/Farming/Leek.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Leek
   m_EditorClassIdentifier: 
   taskName: Leek
-  taskID: 4
+  taskID: 28
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Lettuce.asset
+++ b/Assets/Resources/Tasks/Farming/Lettuce.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Lettuce
   m_EditorClassIdentifier: 
   taskName: Lettuce
-  taskID: 4
+  taskID: 29
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Onion.asset
+++ b/Assets/Resources/Tasks/Farming/Onion.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Onion
   m_EditorClassIdentifier: 
   taskName: Onion
-  taskID: 4
+  taskID: 30
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Parsnip.asset
+++ b/Assets/Resources/Tasks/Farming/Parsnip.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Parsnip
   m_EditorClassIdentifier: 
   taskName: Parsnip
-  taskID: 4
+  taskID: 31
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Pepper.asset
+++ b/Assets/Resources/Tasks/Farming/Pepper.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Pepper
   m_EditorClassIdentifier: 
   taskName: Pepper
-  taskID: 4
+  taskID: 32
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Pumking.asset
+++ b/Assets/Resources/Tasks/Farming/Pumking.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Pumking
   m_EditorClassIdentifier: 
   taskName: Pumking
-  taskID: 4
+  taskID: 33
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Radish.asset
+++ b/Assets/Resources/Tasks/Farming/Radish.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Radish
   m_EditorClassIdentifier: 
   taskName: Radish
-  taskID: 4
+  taskID: 34
   taskIcon: {fileID: -1319403273844478748, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Spud.asset
+++ b/Assets/Resources/Tasks/Farming/Spud.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Spud
   m_EditorClassIdentifier: 
   taskName: Spud
-  taskID: 4
+  taskID: 35
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Strawberry.asset
+++ b/Assets/Resources/Tasks/Farming/Strawberry.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Strawberry
   m_EditorClassIdentifier: 
   taskName: Strawberry
-  taskID: 4
+  taskID: 36
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Tomato.asset
+++ b/Assets/Resources/Tasks/Farming/Tomato.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Tomato
   m_EditorClassIdentifier: 
   taskName: Tomato
-  taskID: 4
+  taskID: 37
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Turnip.asset
+++ b/Assets/Resources/Tasks/Farming/Turnip.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Turnip
   m_EditorClassIdentifier: 
   taskName: Turnip
-  taskID: 4
+  taskID: 38
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Wartermelone.asset
+++ b/Assets/Resources/Tasks/Farming/Wartermelone.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Wartermelone
   m_EditorClassIdentifier: 
   taskName: Wartermelone
-  taskID: 4
+  taskID: 39
   taskIcon: {fileID: 9057977493438303337, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 12

--- a/Assets/Resources/Tasks/Farming/Wheat.asset
+++ b/Assets/Resources/Tasks/Farming/Wheat.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Wheat
   m_EditorClassIdentifier: 
   taskName: Wheat
-  taskID: 4
+  taskID: 40
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 8

--- a/Assets/Resources/Tasks/Fishing/Fish.asset
+++ b/Assets/Resources/Tasks/Fishing/Fish.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Fish
   m_EditorClassIdentifier: 
   taskName: Flippy Floppy
-  taskID: 3
+  taskID: 9
   taskIcon: {fileID: -5709444697936806870, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 2

--- a/Assets/Resources/Tasks/Mining/Copium Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Copium Ore.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Copium Ore
   m_EditorClassIdentifier: 
   taskName: Copium Ore
-  taskID: 1
+  taskID: 6
   taskIcon: {fileID: -4797693821990039991, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Mining/Dlog Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Dlog Ore.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Dlog Ore
   m_EditorClassIdentifier: 
   taskName: Dlog Ore
-  taskID: 1
+  taskID: 3
   taskIcon: {fileID: -3476202021705219157, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Mining/Erif Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Erif Ore.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Erif Ore
   m_EditorClassIdentifier: 
   taskName: Erif Ore
-  taskID: 1
+  taskID: 4
   taskIcon: {fileID: -623644546430554401, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Mining/Idle Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Idle Ore.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Idle Ore
   m_EditorClassIdentifier: 
   taskName: Idle Ore
-  taskID: 1
+  taskID: 7
   taskIcon: {fileID: 7054577682481060284, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Mining/Lirium Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Lirium Ore.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Lirium Ore
   m_EditorClassIdentifier: 
   taskName: Lirium Ore
-  taskID: 1
+  taskID: 5
   taskIcon: {fileID: 7473302359189358601, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Mining/Nori Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Nori Ore.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Nori Ore
   m_EditorClassIdentifier: 
   taskName: Nori Ore
-  taskID: 1
+  taskID: 2
   taskIcon: {fileID: -6760471406004971263, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Mining/Vastium Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Vastium Ore.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Vastium Ore
   m_EditorClassIdentifier: 
   taskName: Vastium Ore
-  taskID: 1
+  taskID: 8
   taskIcon: {fileID: -1370118117, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Woodcutting/Large Birch Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Large Birch Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Large Birch Tree
   m_EditorClassIdentifier: 
   taskName: Large Birch Tree
-  taskID: 14
+  taskID: 19
   taskIcon: {fileID: 2630977764869979562, guid: 53248977f321e9648bbbe8718c39a315, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 25

--- a/Assets/Resources/Tasks/Woodcutting/Large Fruit Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Large Fruit Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Large Fruit Tree
   m_EditorClassIdentifier: 
   taskName: Large Fruit Tree
-  taskID: 8
+  taskID: 13
   taskIcon: {fileID: 621266246945384593, guid: b45d02bebb0bae34490e63de2e1440b9, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 7

--- a/Assets/Resources/Tasks/Woodcutting/Large Oak Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Large Oak Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Large Oak Tree
   m_EditorClassIdentifier: 
   taskName: Large Oak Tree
-  taskID: 11
+  taskID: 16
   taskIcon: {fileID: -6043950617988251759, guid: c79f924a676f900408ab47fe98ae9935, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 10

--- a/Assets/Resources/Tasks/Woodcutting/Large Spruce Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Large Spruce Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Large Spruce Tree
   m_EditorClassIdentifier: 
   taskName: Large Spruce Tree
-  taskID: 17
+  taskID: 22
   taskIcon: {fileID: -2161423198996946198, guid: 6dcc684ee8a4e9a428482ed2a78beb66, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 50

--- a/Assets/Resources/Tasks/Woodcutting/Medium Birch Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Medium Birch Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Medium Birch Tree
   m_EditorClassIdentifier: 
   taskName: Medium Birch Tree
-  taskID: 13
+  taskID: 18
   taskIcon: {fileID: -2044317885256534180, guid: ff597bf836f9fb24a9d6b5c4190007a7, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 8

--- a/Assets/Resources/Tasks/Woodcutting/Medium Fruit Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Medium Fruit Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Medium Fruit Tree
   m_EditorClassIdentifier: 
   taskName: Medium Fruit Tree
-  taskID: 7
+  taskID: 12
   taskIcon: {fileID: -6213476910104009479, guid: 25ec107e317209041985b70a5dc05d93, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Woodcutting/Medium Oak Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Medium Oak Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Medium Oak Tree
   m_EditorClassIdentifier: 
   taskName: Medium Oak Tree
-  taskID: 10
+  taskID: 15
   taskIcon: {fileID: 6013379132409528037, guid: 974fe87578622624abd01a4856b266ef, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Woodcutting/Medium Spruce Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Medium Spruce Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Medium Spruce Tree
   m_EditorClassIdentifier: 
   taskName: Medium Spruce Tree
-  taskID: 16
+  taskID: 21
   taskIcon: {fileID: -3194247907673141736, guid: 70c5d1de0a66bab45bd496acee38f43e, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 15

--- a/Assets/Resources/Tasks/Woodcutting/Small Birch Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Small Birch Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Small Birch Tree
   m_EditorClassIdentifier: 
   taskName: Small Birch Tree
-  taskID: 12
+  taskID: 17
   taskIcon: {fileID: -1772785241186216535, guid: 66726431582e2244ba5aeef3a3b96ae9, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 3

--- a/Assets/Resources/Tasks/Woodcutting/Small Fruit Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Small Fruit Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Small Fruit Tree
   m_EditorClassIdentifier: 
   taskName: Small Fruit Tree
-  taskID: 6
+  taskID: 11
   taskIcon: {fileID: -799831649384477707, guid: c0379aa4fd42660418cc76d22a3de2e1, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 1

--- a/Assets/Resources/Tasks/Woodcutting/Small Oak Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Small Oak Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Small Oak Tree
   m_EditorClassIdentifier: 
   taskName: Small Oak Tree
-  taskID: 9
+  taskID: 14
   taskIcon: {fileID: 1701996483059660236, guid: e144c0eae8cb318449644c1524511be5, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 2

--- a/Assets/Resources/Tasks/Woodcutting/Small Spruce Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Small Spruce Tree.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Small Spruce Tree
   m_EditorClassIdentifier: 
   taskName: Small Spruce Tree
-  taskID: 15
+  taskID: 20
   taskIcon: {fileID: -4892141724536017943, guid: cbc5d9c181eaf0943969b1c5cb93ba50, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 6


### PR DESCRIPTION
## Summary
- ensure every TaskData asset has a unique taskID
- reorder mining tasks (ores) according to design order
- shift woodcutting IDs and assign IDs for farming, fishing and chest tasks

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687485ca29bc832e8bbe47d77d3e1a64