### PR TITLE
Fix invalid cast in BetterRuleTiles importer

### DIFF
--- a/Assets/BetterRuleTiles/Editor/EditorSubClasses/EditorGridBase.cs
+++ b/Assets/BetterRuleTiles/Editor/EditorSubClasses/EditorGridBase.cs
@@ -517,7 +517,8 @@ namespace VinToolsEditor.BetterRuleTiles
 
         public void FixMissingTexture(Texture2D tex)
         {
-            TextureImporter importer = (TextureImporter)TextureImporter.GetAtPath(AssetDatabase.GetAssetPath(tex));
+            var importer = AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(tex)) as TextureImporter;
+            if (importer == null) return;
 
             importer.isReadable = true;
 


### PR DESCRIPTION
## Summary
- prevent `InvalidCastException` when retrieving `TextureImporter`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874a754a0a0832ea1a938597d6219e7