### PR TITLE
Add Steam rich presence support

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -100,6 +100,7 @@ namespace TimelessEchoes
         {
             tavernUI?.SetActive(true);
             mapUI?.SetActive(false);
+            RichPresenceManager.Instance?.SetInTown();
             if (deathWindow != null)
                 deathWindow.SetActive(false);
             if (returnToTavernText != null)
@@ -141,6 +142,7 @@ namespace TimelessEchoes
         private void StartRun()
         {
             HideTooltip();
+            RichPresenceManager.Instance?.SetInRun();
             Log("Run starting", TELogCategory.Run, this);
             runEndedByDeath = false;
             if (deathWindowCoroutine != null)
@@ -367,6 +369,7 @@ namespace TimelessEchoes
             if (runCalebUI != null)
                 runCalebUI.gameObject.SetActive(false);
             npcObjectStateController?.UpdateObjectStates();
+            RichPresenceManager.Instance?.SetInTown();
             Log("Returned to tavern", TELogCategory.Run, this);
         }
 

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -174,6 +174,7 @@ namespace TimelessEchoes.Hero
             {
                 tracker.RecordHeroPosition(transform.position);
                 BuffManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
+                RichPresenceManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
             }
         }
 

--- a/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
+++ b/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
+#if !DISABLESTEAMWORKS
+using Steamworks;
+#endif
+
+namespace TimelessEchoes
+{
+    /// <summary>
+    /// Handles Steam rich presence status updates.
+    /// Shows whether the player is in town or in a run and
+    /// displays the current distance when in a run.
+    /// </summary>
+    public class RichPresenceManager : MonoBehaviour
+    {
+#if !DISABLESTEAMWORKS
+        private static RichPresenceManager instance;
+        /// <summary>
+        /// Singleton instance accessor.
+        /// </summary>
+        public static RichPresenceManager Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = FindFirstObjectByType<RichPresenceManager>();
+                    if (instance == null)
+                        instance = new GameObject("RichPresenceManager").AddComponent<RichPresenceManager>();
+                }
+
+                return instance;
+            }
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+            SetInTown();
+        }
+
+        /// <summary>
+        /// Sets rich presence to indicate the player is in town.
+        /// </summary>
+        public void SetInTown()
+        {
+            if (!SteamManager.Initialized)
+                return;
+            SteamFriends.SetRichPresence("status", "In Town");
+        }
+
+        /// <summary>
+        /// Sets rich presence to indicate the player has started a run.
+        /// </summary>
+        public void SetInRun()
+        {
+            if (!SteamManager.Initialized)
+                return;
+            SteamFriends.SetRichPresence("status", "Exploring");
+        }
+
+        /// <summary>
+        /// Updates the distance value while in a run.
+        /// </summary>
+        public void UpdateDistance(float distance)
+        {
+            if (!SteamManager.Initialized)
+                return;
+            int d = Mathf.FloorToInt(distance);
+            SteamFriends.SetRichPresence("status", $"Distance: {d}");
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+                instance = null;
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs.meta
+++ b/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3cb94c0d00a54dfdb52df8e9df6aed04

--- a/README.md
+++ b/README.md
@@ -67,5 +67,10 @@ achievement.
 Engaging five slimes at once unlocks the `SlimeSwarm` achievement.
 Completing Mildred's quest unlocks the `Mildred` achievement.
 
+## Steam Rich Presence
+The `RichPresenceManager` component uses Steamworks.NET to update Steam Rich
+Presence. When in town, the status shows **In Town**. During a run it updates
+each frame with the hero's travelled distance.
+
 ## Development Guidelines
 Refer to [Unity's official documentation](https://docs.unity3d.com) and ensure all changes work with **Unity 6000.1.6f1**.


### PR DESCRIPTION
## Summary
- add `RichPresenceManager` to keep Steam rich presence up to date
- update `GameManager` and `HeroController` to report run state and distance
- document rich presence in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874c84fb3fc832e983ee8a448c30d8e