### PR TITLE
Add steam_display to rich presence

### DIFF
--- a/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
+++ b/Assets/Scripts/Steamworks.NET/RichPresenceManager.cs
@@ -56,6 +56,7 @@ namespace TimelessEchoes
             if (!SteamManager.Initialized)
                 return;
             SteamFriends.SetRichPresence("status", "In Town");
+            SteamFriends.SetRichPresence("steam_display", "#Status_InTown");
         }
 
         /// <summary>
@@ -66,6 +67,7 @@ namespace TimelessEchoes
             if (!SteamManager.Initialized)
                 return;
             SteamFriends.SetRichPresence("status", "Exploring");
+            SteamFriends.SetRichPresence("steam_display", "#Status_InRun");
         }
 
         /// <summary>
@@ -77,6 +79,8 @@ namespace TimelessEchoes
                 return;
             int d = Mathf.FloorToInt(distance);
             SteamFriends.SetRichPresence("status", $"Distance: {d}");
+            SteamFriends.SetRichPresence("distance", d.ToString());
+            SteamFriends.SetRichPresence("steam_display", "#Status_Distance");
         }
 
         private void OnDestroy()

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Completing Mildred's quest unlocks the `Mildred` achievement.
 The `RichPresenceManager` component uses Steamworks.NET to update Steam Rich
 Presence. When in town, the status shows **In Town**. During a run it updates
 each frame with the hero's travelled distance.
+For the one-line rich presence shown under a friend's name, the script also
+sets the **steam_display** key with a localization token. Example tokens are
+`#Status_InTown`, `#Status_InRun` and `#Status_Distance`.
 
 ## Development Guidelines
 Refer to [Unity's official documentation](https://docs.unity3d.com) and ensure all changes work with **Unity 6000.1.6f1**.


### PR DESCRIPTION
## Summary
- set `steam_display` tokens when updating rich presence
- document `steam_display` usage in README

## Testing
- `npm test` *(fails: could not find package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874cbc3d060832e867d615cd3dadd06