### PR TITLE
Fix damage display in Caleb UI

### DIFF
--- a/Assets/Scripts/UI/RunCalebUIManager.cs
+++ b/Assets/Scripts/UI/RunCalebUIManager.cs
@@ -120,7 +120,9 @@ namespace TimelessEchoes.UI
 
             if (uiReferences.leftText != null)
             {
-                string dmgLine = $"Damage: {baseDamage:0.##} (+{bonusDamage:0.##})";
+                string dmgLine = $"Damage: {baseDamage:0.##}";
+                if (bonusDamage > 0f)
+                    dmgLine += $" (+{bonusDamage:0.##})";
                 uiReferences.leftText.text =
                     dmgLine + "\n" +
                     $"Attack Rate: {attack:0.###} /s\n" +


### PR DESCRIPTION
## Summary
- adjust damage text in RunCalebUIManager so `(+x)` only shows when there is extra damage

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874af51b368832ea5413272afba9b75