### PR TITLE
Add quest chain for all farming tasks

### DIFF
--- a/Assets/Resources/Quests/Eva/Berry Sweet.asset
+++ b/Assets/Resources/Quests/Eva/Berry Sweet.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Berry Sweet
+  m_EditorClassIdentifier:
+  questId: Strawberry
+  questName: Berry Sweet
+  description: Bring 30 Pumkings to satisfy Eva's cravings.
+  rewardDescription: 'Unlock the Strawberry crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 78e6cf2e15964b41b5fcd5833f00d44a, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: c11abbf84f4141844b21de6f7af929ea, type: 2}
+    amount: 30
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Berry Sweet.asset.meta
+++ b/Assets/Resources/Quests/Eva/Berry Sweet.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 212e527a951e485c8bc8c31cb639f88a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Carrot Craze.asset
+++ b/Assets/Resources/Quests/Eva/Carrot Craze.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Carrot Craze
+  m_EditorClassIdentifier:
+  questId: Carrot
+  questName: Carrot Craze
+  description: Harvest 10 Wartermelone for Eva to unlock carrot seeds.
+  rewardDescription: 'Unlock the Carrot crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: e7b996d2be115c74aae9b52d0808a89f, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: ae1b523394ff9eb49866f20982e4c68d, type: 2}
+    amount: 10
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Carrot Craze.asset.meta
+++ b/Assets/Resources/Quests/Eva/Carrot Craze.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31c43e7b43e9407791103b070abe9e42
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Chili Challenge.asset
+++ b/Assets/Resources/Quests/Eva/Chili Challenge.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Chili Challenge
+  m_EditorClassIdentifier:
+  questId: Chillie
+  questName: Chili Challenge
+  description: Offer 15 Peppers to test some fiery magic.
+  rewardDescription: 'Unlock the Chillie crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 28ae2ed17b1546c8a3d5f43e52c3cdb7, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: db783fe988c6728428405a8c18c3f5d8, type: 2}
+    amount: 15
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Chili Challenge.asset.meta
+++ b/Assets/Resources/Quests/Eva/Chili Challenge.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4ca1d6c5bf8245df82a7a75168d51f02
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Cool Cucumber.asset
+++ b/Assets/Resources/Quests/Eva/Cool Cucumber.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Cool Cucumber
+  m_EditorClassIdentifier:
+  questId: Cucumber
+  questName: Cool Cucumber
+  description: Hand over 20 Lettuce for a refreshing crop upgrade.
+  rewardDescription: 'Unlock the Cucumber crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 35982548c6994ba5a00d881db3dac34e, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 49595052db28a8e48a4eb1fa7d04b7f6, type: 2}
+    amount: 20
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Cool Cucumber.asset.meta
+++ b/Assets/Resources/Quests/Eva/Cool Cucumber.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3c28a1d79264acb8fe05e6880426a43
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Funky Funion.asset
+++ b/Assets/Resources/Quests/Eva/Funky Funion.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Funky Funion
+  m_EditorClassIdentifier:
+  questId: Funion
+  questName: Funky Funion
+  description: Donate 20 Strawberries for Eva's new stew.
+  rewardDescription: 'Unlock the Funion crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 212e527a951e485c8bc8c31cb639f88a, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: dcd8ad1628b899a48847deb1cb2b3739, type: 2}
+    amount: 20
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Funky Funion.asset.meta
+++ b/Assets/Resources/Quests/Eva/Funky Funion.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 72c197707d4c4c529d67db6a7e711132
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Leek Leak.asset
+++ b/Assets/Resources/Quests/Eva/Leek Leak.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Leek Leak
+  m_EditorClassIdentifier:
+  questId: Leek
+  questName: Leek Leak
+  description: Share 20 Onions so Eva can grow hearty leeks.
+  rewardDescription: 'Unlock the Leek crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 2395628c18784e2bab0b7af0b4bbc721, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: b5b12e283249229419b1a300192d8601, type: 2}
+    amount: 20
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Leek Leak.asset.meta
+++ b/Assets/Resources/Quests/Eva/Leek Leak.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 959a94840c214b3dae27c81ab2473463
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Lettuce Feast.asset
+++ b/Assets/Resources/Quests/Eva/Lettuce Feast.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Lettuce Feast
+  m_EditorClassIdentifier:
+  questId: Lettuce
+  questName: Lettuce Feast
+  description: Supply 20 Tomatoes so Eva can craft a healthy salad.
+  rewardDescription: 'Unlock the Lettuce crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: a01bc0adc87a48bab23d3700a16800e6, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: e8e8a19bb4573f540a00a6d78dddd0db, type: 2}
+    amount: 20
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Lettuce Feast.asset.meta
+++ b/Assets/Resources/Quests/Eva/Lettuce Feast.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35982548c6994ba5a00d881db3dac34e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Onion Odyssey.asset
+++ b/Assets/Resources/Quests/Eva/Onion Odyssey.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Onion Odyssey
+  m_EditorClassIdentifier:
+  questId: Onion
+  questName: Onion Odyssey
+  description: Deliver 20 Cucumbers for a tearful experiment.
+  rewardDescription: 'Unlock the Onion crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: c3c28a1d79264acb8fe05e6880426a43, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 5eaebeeea7cd85948922c1bcab927ca6, type: 2}
+    amount: 20
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Onion Odyssey.asset.meta
+++ b/Assets/Resources/Quests/Eva/Onion Odyssey.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2395628c18784e2bab0b7af0b4bbc721
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Parsnip Plan.asset
+++ b/Assets/Resources/Quests/Eva/Parsnip Plan.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Parsnip Plan
+  m_EditorClassIdentifier:
+  questId: Parsnip
+  questName: Parsnip Plan
+  description: Provide 20 Leeks to expand the root cellar.
+  rewardDescription: 'Unlock the Parsnip crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 959a94840c214b3dae27c81ab2473463, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 92206defd8abd854c835604fc2ebfc33, type: 2}
+    amount: 20
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Parsnip Plan.asset.meta
+++ b/Assets/Resources/Quests/Eva/Parsnip Plan.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 00568cbce0574f7680580a71be54f90a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Pepper Pursuit.asset
+++ b/Assets/Resources/Quests/Eva/Pepper Pursuit.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Pepper Pursuit
+  m_EditorClassIdentifier:
+  questId: Pepper
+  questName: Pepper Pursuit
+  description: Gather 20 Parsnips to spice up the fields.
+  rewardDescription: 'Unlock the Pepper crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 00568cbce0574f7680580a71be54f90a, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: fb12ddb33d729bf48a519c61510dca6a, type: 2}
+    amount: 20
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Pepper Pursuit.asset.meta
+++ b/Assets/Resources/Quests/Eva/Pepper Pursuit.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 28ae2ed17b1546c8a3d5f43e52c3cdb7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Pumking Party.asset
+++ b/Assets/Resources/Quests/Eva/Pumking Party.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Pumking Party
+  m_EditorClassIdentifier:
+  questId: Pumking
+  questName: Pumking Party
+  description: Trade 25 Chillies for seeds fit for a king.
+  rewardDescription: 'Unlock the Pumking crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 4ca1d6c5bf8245df82a7a75168d51f02, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 52b45ffed04e559418584d82175340a6, type: 2}
+    amount: 25
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Pumking Party.asset.meta
+++ b/Assets/Resources/Quests/Eva/Pumking Party.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78e6cf2e15964b41b5fcd5833f00d44a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Spud Bud.asset
+++ b/Assets/Resources/Quests/Eva/Spud Bud.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Spud Bud
+  m_EditorClassIdentifier:
+  questId: Spud
+  questName: Spud Bud
+  description: Bring 15 Carrots so Eva can perfect potato farming.
+  rewardDescription: 'Unlock the Spud crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 31c43e7b43e9407791103b070abe9e42, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 9e342e09a47b4014ab320cc6d06a2a3d, type: 2}
+    amount: 15
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Spud Bud.asset.meta
+++ b/Assets/Resources/Quests/Eva/Spud Bud.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ba841e2bed264c8bb9226481219ced25
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Tomato Triumph.asset
+++ b/Assets/Resources/Quests/Eva/Tomato Triumph.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Tomato Triumph
+  m_EditorClassIdentifier:
+  questId: Tomato
+  questName: Tomato Triumph
+  description: Deliver 20 Spuds for Evas secret sauce recipe.
+  rewardDescription: 'Unlock the Tomato crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: ba841e2bed264c8bb9226481219ced25, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: fd0a53a91094b2b4da64fec1b7c7bace, type: 2}
+    amount: 20
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Tomato Triumph.asset.meta
+++ b/Assets/Resources/Quests/Eva/Tomato Triumph.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a01bc0adc87a48bab23d3700a16800e6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/Eva/Turnip Time.asset
+++ b/Assets/Resources/Quests/Eva/Turnip Time.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Turnip Time
+  m_EditorClassIdentifier:
+  questId: Turnip
+  questName: Turnip Time
+  description: Deliver 30 Funions to master the final crop.
+  rewardDescription: 'Unlock the Turnip crop'
+  npcId: Witch1
+  requiredQuests:
+  - {fileID: 11400000, guid: 72c197707d4c4c529d67db6a7e711132, type: 2}
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: b4981418ea008e74f8918c87bac15573, type: 2}
+    amount: 30
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/Eva/Turnip Time.asset.meta
+++ b/Assets/Resources/Quests/Eva/Turnip Time.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 907a527d8f6a4a3f8ff78ba58fd4a59f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Tasks/Farming/Carrot.asset
+++ b/Assets/Resources/Tasks/Farming/Carrot.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: 4727212774405997460, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
-  requiredQuest: {fileID: 0}
+  requiredQuest: {fileID: 11400000, guid: 31c43e7b43e9407791103b070abe9e42, type: 2}
   taskDuration: 2
   sfxInterval: 0
   resourceDrops:

--- a/Assets/Resources/Tasks/Farming/Chillie.asset
+++ b/Assets/Resources/Tasks/Farming/Chillie.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 4ca1d6c5bf8245df82a7a75168d51f02, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 52b45ffed04e559418584d82175340a6, type: 2}

--- a/Assets/Resources/Tasks/Farming/Cucumber.asset
+++ b/Assets/Resources/Tasks/Farming/Cucumber.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: c3c28a1d79264acb8fe05e6880426a43, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 5eaebeeea7cd85948922c1bcab927ca6, type: 2}

--- a/Assets/Resources/Tasks/Farming/Funion.asset
+++ b/Assets/Resources/Tasks/Farming/Funion.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 72c197707d4c4c529d67db6a7e711132, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: b4981418ea008e74f8918c87bac15573, type: 2}

--- a/Assets/Resources/Tasks/Farming/Leek.asset
+++ b/Assets/Resources/Tasks/Farming/Leek.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 959a94840c214b3dae27c81ab2473463, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 92206defd8abd854c835604fc2ebfc33, type: 2}

--- a/Assets/Resources/Tasks/Farming/Lettuce.asset
+++ b/Assets/Resources/Tasks/Farming/Lettuce.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 35982548c6994ba5a00d881db3dac34e, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 49595052db28a8e48a4eb1fa7d04b7f6, type: 2}

--- a/Assets/Resources/Tasks/Farming/Onion.asset
+++ b/Assets/Resources/Tasks/Farming/Onion.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 2395628c18784e2bab0b7af0b4bbc721, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: b5b12e283249229419b1a300192d8601, type: 2}

--- a/Assets/Resources/Tasks/Farming/Parsnip.asset
+++ b/Assets/Resources/Tasks/Farming/Parsnip.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 00568cbce0574f7680580a71be54f90a, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: fb12ddb33d729bf48a519c61510dca6a, type: 2}

--- a/Assets/Resources/Tasks/Farming/Pepper.asset
+++ b/Assets/Resources/Tasks/Farming/Pepper.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 28ae2ed17b1546c8a3d5f43e52c3cdb7, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: db783fe988c6728428405a8c18c3f5d8, type: 2}

--- a/Assets/Resources/Tasks/Farming/Pumking.asset
+++ b/Assets/Resources/Tasks/Farming/Pumking.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 78e6cf2e15964b41b5fcd5833f00d44a, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: c11abbf84f4141844b21de6f7af929ea, type: 2}

--- a/Assets/Resources/Tasks/Farming/Spud.asset
+++ b/Assets/Resources/Tasks/Farming/Spud.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: ba841e2bed264c8bb9226481219ced25, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: fd0a53a91094b2b4da64fec1b7c7bace, type: 2}

--- a/Assets/Resources/Tasks/Farming/Strawberry.asset
+++ b/Assets/Resources/Tasks/Farming/Strawberry.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 212e527a951e485c8bc8c31cb639f88a, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: dcd8ad1628b899a48847deb1cb2b3739, type: 2}

--- a/Assets/Resources/Tasks/Farming/Tomato.asset
+++ b/Assets/Resources/Tasks/Farming/Tomato.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: a01bc0adc87a48bab23d3700a16800e6, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: e8e8a19bb4573f540a00a6d78dddd0db, type: 2}

--- a/Assets/Resources/Tasks/Farming/Turnip.asset
+++ b/Assets/Resources/Tasks/Farming/Turnip.asset
@@ -17,6 +17,7 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  requiredQuest: {fileID: 11400000, guid: 907a527d8f6a4a3f8ff78ba58fd4a59f, type: 2}
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 420847cbb07e26640a57575ee30d5120, type: 2}


### PR DESCRIPTION
## Summary
- create quest assets in `Assets/Resources/Quests/Eva` for each remaining crop
- link new quests in farming task assets via `requiredQuest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875857362ec832ea7e3e6595ee8f339