### PR TITLE
Align crop taskIDs with quest order

### DIFF
--- a/Assets/Resources/Tasks/Farming/Carrot.asset
+++ b/Assets/Resources/Tasks/Farming/Carrot.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Carrot
   m_EditorClassIdentifier: 
   taskName: Carrot
-  taskID: 28
+  taskID: 32
   taskIcon: {fileID: 4727212774405997460, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Chillie.asset
+++ b/Assets/Resources/Tasks/Farming/Chillie.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Chillie
   m_EditorClassIdentifier: 
   taskName: Chillie
-  taskID: 29
+  taskID: 41
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Corn.asset
+++ b/Assets/Resources/Tasks/Farming/Corn.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Corn
   m_EditorClassIdentifier: 
   taskName: Corn
-  taskID: 30
+  taskID: 29
   taskIcon: {fileID: -1010118597598872900, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Cucumber.asset
+++ b/Assets/Resources/Tasks/Farming/Cucumber.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Cucumber
   m_EditorClassIdentifier: 
   taskName: Cucumber
-  taskID: 31
+  taskID: 36
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Funion.asset
+++ b/Assets/Resources/Tasks/Farming/Funion.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Funion
   m_EditorClassIdentifier: 
   taskName: Funion
-  taskID: 32
+  taskID: 44
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Leek.asset
+++ b/Assets/Resources/Tasks/Farming/Leek.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Leek
   m_EditorClassIdentifier: 
   taskName: Leek
-  taskID: 33
+  taskID: 38
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Lettuce.asset
+++ b/Assets/Resources/Tasks/Farming/Lettuce.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Lettuce
   m_EditorClassIdentifier: 
   taskName: Lettuce
-  taskID: 34
+  taskID: 35
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Onion.asset
+++ b/Assets/Resources/Tasks/Farming/Onion.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Onion
   m_EditorClassIdentifier: 
   taskName: Onion
-  taskID: 35
+  taskID: 37
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Parsnip.asset
+++ b/Assets/Resources/Tasks/Farming/Parsnip.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Parsnip
   m_EditorClassIdentifier: 
   taskName: Parsnip
-  taskID: 36
+  taskID: 39
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Pepper.asset
+++ b/Assets/Resources/Tasks/Farming/Pepper.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Pepper
   m_EditorClassIdentifier: 
   taskName: Pepper
-  taskID: 37
+  taskID: 40
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Pumking.asset
+++ b/Assets/Resources/Tasks/Farming/Pumking.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Pumking
   m_EditorClassIdentifier: 
   taskName: Pumking
-  taskID: 38
+  taskID: 42
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Radish.asset
+++ b/Assets/Resources/Tasks/Farming/Radish.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Radish
   m_EditorClassIdentifier: 
   taskName: Radish
-  taskID: 39
+  taskID: 28
   taskIcon: {fileID: -1319403273844478748, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Spud.asset
+++ b/Assets/Resources/Tasks/Farming/Spud.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Spud
   m_EditorClassIdentifier: 
   taskName: Spud
-  taskID: 40
+  taskID: 33
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Strawberry.asset
+++ b/Assets/Resources/Tasks/Farming/Strawberry.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Strawberry
   m_EditorClassIdentifier: 
   taskName: Strawberry
-  taskID: 41
+  taskID: 43
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Tomato.asset
+++ b/Assets/Resources/Tasks/Farming/Tomato.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Tomato
   m_EditorClassIdentifier: 
   taskName: Tomato
-  taskID: 42
+  taskID: 34
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Turnip.asset
+++ b/Assets/Resources/Tasks/Farming/Turnip.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Turnip
   m_EditorClassIdentifier: 
   taskName: Turnip
-  taskID: 43
+  taskID: 45
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5

--- a/Assets/Resources/Tasks/Farming/Wartermelone.asset
+++ b/Assets/Resources/Tasks/Farming/Wartermelone.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Wartermelone
   m_EditorClassIdentifier: 
   taskName: Wartermelone
-  taskID: 44
+  taskID: 31
   taskIcon: {fileID: 9057977493438303337, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 12

--- a/Assets/Resources/Tasks/Farming/Wheat.asset
+++ b/Assets/Resources/Tasks/Farming/Wheat.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Wheat
   m_EditorClassIdentifier: 
   taskName: Wheat
-  taskID: 45
+  taskID: 30
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 8


### PR DESCRIPTION
## Summary
- reorder crop `taskID` fields so tasks unlock sequentially with Eva's quests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68758bbfffe4832e84dc1fff66c4fcc1