### PR TITLE
Fix preference save when wiping data

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -126,6 +126,7 @@ namespace Blindsided
             var prefs = saveData.SavedPreferences;
             saveData = new GameData();
             saveData.SavedPreferences = prefs;
+            SaveToCache();
             FlushToDisk();
             SceneManager.LoadScene(0);
         }
@@ -141,6 +142,8 @@ namespace Blindsided
             saveData.SavedPreferences = prefs;
             ES3.DeleteFile(_settings); // clear cached copy
             SteamCloudManager.DeleteFile(_fileName);
+            SaveToCache();
+            FlushToDisk();
             SceneManager.LoadScene(0);
         }
 


### PR DESCRIPTION
## Summary
- ensure `WipeAllData` and `WipeCloudData` cache the new save data before flushing it to disk

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875dd22f7d4832e9ad2c0328f106acf