### PR TITLE
Fix cloud recycle logic

### DIFF
--- a/Assets/Scripts/MapGeneration/CloudSpawner.cs
+++ b/Assets/Scripts/MapGeneration/CloudSpawner.cs
@@ -15,6 +15,9 @@ public class CloudSpawner : MonoBehaviour
     [Header("Recycle Distances")] [SerializeField]
     private float aheadDistance = 18f; // recycle if too far in front of camera
 
+    [SerializeField] [Min(0f)]
+    private float recycleSpawnDistance = 6f; // how far ahead to place recycled clouds
+
     [SerializeField]
     private float behindDistance = 2f; // recycle if too far behind the camera
 
@@ -22,6 +25,15 @@ public class CloudSpawner : MonoBehaviour
     private float screenHalfWidth;
     private float screenHalfHeight;
     private Cloud[] clouds;
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        var maxSpawn = aheadDistance - 1f;
+        if (recycleSpawnDistance > maxSpawn)
+            recycleSpawnDistance = maxSpawn;
+    }
+#endif
 
     private void Awake()
     {
@@ -75,7 +87,17 @@ public class CloudSpawner : MonoBehaviour
     {
         UpdateScreenDimensions();
 
-        var x = cam.transform.position.x + Random.Range(-screenHalfWidth, screenHalfWidth);
+        float x;
+        if (spawnInView)
+        {
+            x = cam.transform.position.x + Random.Range(-screenHalfWidth, screenHalfWidth);
+        }
+        else
+        {
+            var maxSpawn = aheadDistance - 1f;
+            var offset = Mathf.Min(recycleSpawnDistance, maxSpawn);
+            x = cam.transform.position.x + screenHalfWidth + offset;
+        }
 
         var y = cam.transform.position.y + Random.Range(-screenHalfHeight, screenHalfHeight);
         c.Tr.position = new Vector3(x, y, 0f);


### PR DESCRIPTION
## Summary
- spawn recycled clouds in front of the camera
- allow configuring how far ahead recycled clouds spawn
- clamp spawn distance to one unit less than the recycle threshold

## Testing
- `echo "No tests to run" && true`

------
https://chatgpt.com/codex/tasks/task_e_6875f45e98b8832e8d4fe113d8d7e27b