### PR TITLE
Update cloud spawning logic

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -218,7 +218,7 @@ namespace TimelessEchoes
             if (mapCamera != null)
             {
                 mapCamera.gameObject.SetActive(true);
-                cloudSpawner?.ResetClouds();
+                cloudSpawner?.ResetClouds(false);
             }
 
             tavernUI?.SetActive(false);
@@ -371,7 +371,7 @@ namespace TimelessEchoes
             if (tavernCamera != null)
             {
                 tavernCamera.gameObject.SetActive(true);
-                cloudSpawner?.ResetClouds();
+                cloudSpawner?.ResetClouds(true);
             }
             tavernUI?.SetActive(true);
             mapUI?.SetActive(false);


### PR DESCRIPTION
## Summary
- double the number of clouds in town compared to runs
- ensure recycled clouds respawn across the screen
- update GameManager to pass whether we're in town or on a run

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875f7b85c20832e8213b5dacfba28fc