### PR TITLE
Add max blend shader for clouds

### DIFF
--- a/Assets/Materials/CloudMaterial.mat
+++ b/Assets/Materials/CloudMaterial.mat
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CloudMaterial
+  m_Shader: {fileID: 4800000, guid: fadc2b1739c6447288e59619b1964507, type: 3}
+  m_ShaderKeywords: ""
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - first:
+        name: _MainTex
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - first:
+        name: PixelSnap
+      second: 0
+    m_Colors:
+    - first:
+        name: _Color
+      second: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Materials/CloudMaterial.mat.meta
+++ b/Assets/Materials/CloudMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b2e6b387d30b4d0198c71e9eafbea3f1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/MapGeneration/CloudSpawner.cs
+++ b/Assets/Scripts/MapGeneration/CloudSpawner.cs
@@ -9,6 +9,8 @@ public class CloudSpawner : MonoBehaviour
     public static CloudSpawner Instance { get; private set; }
     [Header("Setup")] [SerializeField] private Sprite[] frames; // 4 cloud images
     [SerializeField] private int runCloudCount = 3; // number of clouds during runs
+
+    [Header("Rendering")] [SerializeField] private Material cloudMaterial;
     private int TownCloudCount => runCloudCount * 2;
 
     [Header("Parallax")] [SerializeField] private float baseSpeed = 0.2f; // world units / sec
@@ -79,9 +81,13 @@ public class CloudSpawner : MonoBehaviour
     {
         var go = new GameObject("Cloud", typeof(SpriteRenderer));
         var sr = go.GetComponent<SpriteRenderer>();
+
+        if (cloudMaterial != null)
+            sr.sharedMaterial = cloudMaterial;
+
         sr.sprite = frames[Random.Range(0, frames.Length)];
         sr.sortingLayerName = "Background";
-        sr.material.enableInstancing = true;
+        sr.enableInstancing = true;
 
         var cloud = new Cloud { Tr = go.transform };
         Recycle(cloud, spawnInView);

--- a/Assets/Shaders/SpriteMaxBlend.shader
+++ b/Assets/Shaders/SpriteMaxBlend.shader
@@ -1,0 +1,65 @@
+Shader "Custom/SpriteMaxBlend"
+{
+    Properties
+    {
+        [PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "Queue"="Transparent"
+            "IgnoreProjector"="True"
+            "RenderType"="Transparent"
+            "PreviewType"="Sprite"
+            "CanUseSpriteAtlas"="True"
+        }
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend One OneMinusSrcAlpha
+        BlendOp Max
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float4 color : COLOR;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                fixed4 color : COLOR;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            fixed4 _Color;
+            sampler2D _MainTex;
+
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = v.texcoord;
+                o.color = v.color * _Color;
+                return o;
+            }
+
+            fixed4 frag(v2f i) : SV_Target
+            {
+                fixed4 c = tex2D(_MainTex, i.texcoord) * i.color;
+                return c;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/SpriteMaxBlend.shader.meta
+++ b/Assets/Shaders/SpriteMaxBlend.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: fadc2b1739c6447288e59619b1964507
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add new SpriteMaxBlend shader using `BlendOp Max`
- create CloudMaterial using the max blend shader
- expose cloudMaterial field in `CloudSpawner`
- apply shared material and enable instancing when clouds spawn

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687600d60e44832eb4fa1657abfa2960