### PR TITLE
Hero reacts to enemy aggro

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -219,6 +219,8 @@ namespace TimelessEchoes.Hero
             var skillController = SkillController.Instance;
             if (skillController != null)
                 skillController.OnMilestoneUnlocked += OnMilestoneUnlocked;
+
+            Enemy.OnEngage += OnEnemyEngage;
         }
 
         private void OnDisable()
@@ -228,6 +230,8 @@ namespace TimelessEchoes.Hero
             var skillController = SkillController.Instance;
             if (skillController != null)
                 skillController.OnMilestoneUnlocked -= OnMilestoneUnlocked;
+
+            Enemy.OnEngage -= OnEnemyEngage;
         }
 
         private void OnDestroy()
@@ -516,6 +520,27 @@ namespace TimelessEchoes.Hero
                 return false;
             oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
             return oracle.saveData.Quests.TryGetValue(questId, out var rec) && rec.Completed;
+        }
+
+        private void OnEnemyEngage(Enemy enemy)
+        {
+            if (enemy == null)
+                return;
+
+            if (currentEnemy != null && currentEnemy != enemy.transform)
+                return;
+
+            var hp = enemy.GetComponent<Health>();
+            if (hp == null || hp.CurrentHealth <= 0f)
+                return;
+
+            if (currentEnemy == null)
+            {
+                currentEnemyHealth?.SetHealthBarVisible(false);
+                currentEnemy = enemy.transform;
+                currentEnemyHealth = hp;
+                currentEnemyHealth.SetHealthBarVisible(true);
+            }
         }
 
         private void Attack(Transform target)


### PR DESCRIPTION
## Summary
- make `HeroController` handle enemy engagement events
- don't switch targets if the hero already has one
- reveal the healthbar of the engaged enemy

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876cfa01cf8832eb10ef13482c3a9a8