### PR TITLE
Fix hero combat engagement

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -541,6 +541,14 @@ namespace TimelessEchoes.Hero
                 currentEnemyHealth = hp;
                 currentEnemyHealth.SetHealthBarVisible(true);
             }
+
+            if (state == State.PerformingTask && CurrentTask != null)
+                CurrentTask.OnInterrupt(this);
+
+            state = State.Combat;
+            setter.target = enemy.transform;
+            ai?.SearchPath();
+            HandleCombat(enemy.transform);
         }
 
         private void Attack(Transform target)


### PR DESCRIPTION
## Summary
- ensure hero interrupts current task when an enemy engages
- immediately set combat state and attack target

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876df63c730832ea7959f1302f1eefd