### PR TITLE
Add hold-to-upgrade feature

### DIFF
--- a/Assets/Scripts/Blindsided/Utilities/RepeatButtonClick.cs
+++ b/Assets/Scripts/Blindsided/Utilities/RepeatButtonClick.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Blindsided.Utilities
+{
+    /// <summary>
+    /// Invokes the attached button's onClick event repeatedly while held.
+    /// </summary>
+    [RequireComponent(typeof(Button))]
+    public class RepeatButtonClick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, IPointerExitHandler
+    {
+        [SerializeField] public Button button;
+        [SerializeField] public float holdDelay = 0.5f;
+        [SerializeField] public float repeatInterval = 0.1f;
+
+        private bool held;
+        private float nextTime;
+
+        private void Awake()
+        {
+            if (button == null)
+                button = GetComponent<Button>();
+        }
+
+        private void OnDisable()
+        {
+            held = false;
+        }
+
+        private void Update()
+        {
+            if (!held || button == null || !button.interactable)
+                return;
+
+            if (Time.unscaledTime >= nextTime)
+            {
+                button.onClick.Invoke();
+                nextTime = Time.unscaledTime + repeatInterval;
+            }
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            if (button == null || !button.interactable)
+                return;
+            held = true;
+            nextTime = Time.unscaledTime + holdDelay;
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            held = false;
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            held = false;
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using References.UI;
+using Blindsided.Utilities;
 using TimelessEchoes.Skills;
 using UnityEngine;
 using static Blindsided.SaveData.StaticReferences;
@@ -56,7 +57,11 @@ namespace TimelessEchoes.Upgrades
                 int index = i;
                 var refs = statReferences[i];
                 if (refs != null && refs.upgradeButton != null)
+                {
                     refs.upgradeButton.onClick.AddListener(() => ApplyUpgrade(index));
+                    var repeat = refs.upgradeButton.gameObject.AddComponent<RepeatButtonClick>();
+                    repeat.button = refs.upgradeButton;
+                }
             }
 
             BuildAllCostSlots();


### PR DESCRIPTION
## Summary
- add `RepeatButtonClick` helper to invoke a button repeatedly while held
- enable hold-to-upgrade for each stat upgrade button

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e3052ccc832ea7e4679a9c41b6cd