### PR TITLE
Fix hero pursuit logic

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -367,8 +367,7 @@ namespace TimelessEchoes.Hero
             if (currentEnemy != null)
             {
                 var hp = currentEnemy.GetComponent<Health>();
-                var dist = Vector2.Distance(transform.position, currentEnemy.position);
-                if (hp == null || hp.CurrentHealth <= 0f || dist > stats.visionRange)
+                if (hp == null || hp.CurrentHealth <= 0f)
                 {
                     currentEnemyHealth?.SetHealthBarVisible(false);
                     currentEnemy = null;


### PR DESCRIPTION
## Summary
- ensure hero keeps target after being engaged from outside vision range

## Testing
- `dotnet test` *(fails: command not found)*
- `unity-editor -runTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876e935ba34832eaee52a8e2b72f441