### PR TITLE
Ensure save wipe clears runtime data

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -124,10 +124,11 @@ namespace Blindsided
             wipeInProgress = true;
             SteamCloudSync.Instance.SkipNextDownload();
             SteamCloudSync.Instance.QueueUploadAfterSceneLoad();
-            EventHandler.ResetData();
             var prefs = saveData.SavedPreferences;
             saveData = new GameData();
             saveData.SavedPreferences = prefs;
+            EventHandler.ResetData();
+            EventHandler.LoadData();
             SaveToFile(false);
             SceneManager.LoadScene(0);
         }
@@ -139,10 +140,11 @@ namespace Blindsided
             wipeInProgress = true;
             SteamCloudSync.Instance.SkipNextDownload();
             SteamCloudSync.Instance.QueueUploadAfterSceneLoad();
-            EventHandler.ResetData();
             var prefs = saveData.SavedPreferences;
             saveData = new GameData();
             saveData.SavedPreferences = prefs;
+            EventHandler.ResetData();
+            EventHandler.LoadData();
             SaveToFile(false);
             SceneManager.LoadScene(0);
         }


### PR DESCRIPTION
## Summary
- reorder `WipeAllData` and `WipeCloudData` steps so data resets before saving
- reload runtime data from the new blank save before writing the file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876f7931164832e8f9174e5b0ad14d6