### PR TITLE
Fix NPC meeting task completion

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -11,6 +11,11 @@ namespace Blindsided.SaveData
         public static Dictionary<string, ResourceEntry> Resources => oracle.saveData.Resources;
         public static Dictionary<string, double> EnemyKills => oracle.saveData.EnemyKills;
         public static HashSet<string> CompletedNpcTasks => oracle.saveData.CompletedNpcTasks;
+        /// <summary>
+        ///     Runtime tracking of NPC meetings that are currently active.
+        ///     These are not persisted and are cleared when the game restarts.
+        /// </summary>
+        public static HashSet<string> ActiveNpcMeetings { get; } = new();
         public static Dictionary<string, double> FishDonations => oracle.saveData.FishDonations;
 
 

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -365,6 +365,8 @@ namespace TimelessEchoes.Tasks
                 if (npc.localX < localMinX || npc.localX >= localMaxX) continue;
                 if (npc.spawnOnlyOnce && Blindsided.SaveData.StaticReferences.CompletedNpcTasks.Contains(npc.id))
                     continue;
+                if (!string.IsNullOrEmpty(npc.id) && Blindsided.SaveData.StaticReferences.ActiveNpcMeetings.Contains(npc.id))
+                    continue;
 
                 Vector3 pos;
                 if (npc.spawnOnWater && TryGetWaterSpot(npc.localX, out pos)) { }

--- a/Assets/Scripts/Tasks/TalkToNpcTask.cs
+++ b/Assets/Scripts/Tasks/TalkToNpcTask.cs
@@ -37,16 +37,22 @@ namespace TimelessEchoes.Tasks
         {
             talked = false;
             index = 0;
+            meetingInstance = null;
+            if (!string.IsNullOrEmpty(npcId))
+                StaticReferences.ActiveNpcMeetings.Remove(npcId);
         }
 
         public override void OnArrival(HeroController hero)
         {
             SpawnMeetingUI();
+            talked = true;
+            if (!string.IsNullOrEmpty(npcId))
+                StaticReferences.ActiveNpcMeetings.Add(npcId);
         }
 
         private void SpawnMeetingUI()
         {
-            if (meetingPrefab == null) return;
+            if (meetingPrefab == null || meetingInstance != null) return;
             var parent = GameManager.Instance != null ? GameManager.Instance.MeetingParent : null;
             meetingInstance = Object.Instantiate(meetingPrefab, parent, false);
             var controller = meetingInstance.GetComponent<MeetingController>();
@@ -55,9 +61,9 @@ namespace TimelessEchoes.Tasks
 
         private void OnMeetingFinished()
         {
-            talked = true;
             if (!string.IsNullOrEmpty(npcId))
             {
+                StaticReferences.ActiveNpcMeetings.Remove(npcId);
                 StaticReferences.CompletedNpcTasks.Add(npcId);
                 var qm = Object.FindFirstObjectByType<QuestManager>();
                 qm?.OnNpcMet(npcId);


### PR DESCRIPTION
## Summary
- mark NPC meetings as completed as soon as the UI is spawned
- track active meetings in a runtime hashset
- prevent meeting NPCs from spawning again while their UI is open

## Testing
- `dotnet test` *(fails: MSBUILD error because no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68770a7c32a0832eb657ac2839e0578d