### PR TITLE
Update retreat text while in combat

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -146,6 +146,10 @@ namespace TimelessEchoes
                         var percent = kills * bonusPercentPerKill;
                         retreatBonusText.text = $"+{percent:0}% Resources";
                     }
+                    else if (hero != null && hero.InCombat)
+                    {
+                        retreatBonusText.text = "Queue Retreat";
+                    }
                     else
                     {
                         retreatBonusText.text = "+0% Resources";


### PR DESCRIPTION
## Summary
- show **Queue Retreat** on the retreat bonus text while the hero is in combat

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68771c8df274832eb653f6ac69beebe2