### PR TITLE
Improve retreat queued messaging

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -146,6 +146,12 @@ namespace TimelessEchoes
                         var percent = kills * bonusPercentPerKill;
                         retreatBonusText.text = $"+{percent:0}% Resources";
                     }
+                    else if (retreatQueued && hero != null && hero.InCombat)
+                    {
+                        var kills = statTracker != null ? statTracker.CurrentRunKills : 0;
+                        var percent = kills * bonusPercentPerKill;
+                        retreatBonusText.text = $"Retreat Queued +{percent:0}%";
+                    }
                     else if (hero != null && hero.InCombat)
                     {
                         retreatBonusText.text = "Queue Retreat";
@@ -178,6 +184,12 @@ namespace TimelessEchoes
                 retreatQueued = true;
                 if (returnToTavernText != null)
                     returnToTavernText.text = "Retreating...";
+                if (retreatBonusText != null)
+                {
+                    var kills = statTracker != null ? statTracker.CurrentRunKills : 0;
+                    var percent = kills * bonusPercentPerKill;
+                    retreatBonusText.text = $"Retreat Queued +{percent:0}%";
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- update GameManager to show `Retreat Queued +x%` when retreating
- refresh UI immediately when queuing retreat

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68772c7f9220832e9548222d125e83b8