### PR TITLE
Wrap Steam code in build checks

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -17,6 +17,9 @@ using UnityEngine;
 using UnityEngine.UI;
 using static TimelessEchoes.TELogger;
 using static Blindsided.Oracle;
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
 
 namespace TimelessEchoes
 {
@@ -113,7 +116,9 @@ namespace TimelessEchoes
         {
             tavernUI?.SetActive(true);
             mapUI?.SetActive(false);
+#if !DISABLESTEAMWORKS
             RichPresenceManager.Instance?.SetInTown();
+#endif
             if (deathWindow != null)
                 deathWindow.SetActive(false);
             if (returnToTavernText != null)
@@ -213,7 +218,9 @@ namespace TimelessEchoes
                 returnOnDeathText.text = "Return On Death";
             if (returnToTavernText != null)
                 returnToTavernText.text = "Return To Town";
+#if !DISABLESTEAMWORKS
             RichPresenceManager.Instance?.SetInRun();
+#endif
             Log("Run starting", TELogCategory.Run, this);
             runEndedByDeath = false;
             if (deathWindowCoroutine != null)
@@ -461,7 +468,9 @@ namespace TimelessEchoes
             if (runCalebUI != null)
                 runCalebUI.gameObject.SetActive(false);
             npcObjectStateController?.UpdateObjectStates();
+#if !DISABLESTEAMWORKS
             RichPresenceManager.Instance?.SetInTown();
+#endif
             Log("Returned to tavern", TELogCategory.Run, this);
         }
 

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -14,6 +14,9 @@ using TimelessEchoes.Upgrades;
 using UnityEngine;
 using static TimelessEchoes.TELogger;
 using static Blindsided.Oracle;
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
 
 namespace TimelessEchoes.Hero
 {
@@ -174,7 +177,9 @@ namespace TimelessEchoes.Hero
             {
                 tracker.RecordHeroPosition(transform.position);
                 BuffManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
+#if !DISABLESTEAMWORKS
                 RichPresenceManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
+#endif
             }
         }
 

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -12,6 +12,9 @@ using UnityEngine.Serialization;
 using static Blindsided.Oracle;
 using static Blindsided.EventHandler;
 using static TimelessEchoes.TELogger;
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
 
 namespace TimelessEchoes.Quests
 {
@@ -223,8 +226,10 @@ namespace TimelessEchoes.Quests
         {
             if (string.IsNullOrEmpty(id)) return;
             StartAvailableQuests();
+#if !DISABLESTEAMWORKS
             var achievementManager = AchievementManager.Instance;
             achievementManager?.NotifyNpcMet(id);
+#endif
             RefreshNoticeboard();
         }
 

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -6,6 +6,9 @@ using TimelessEchoes.Tasks;
 using TimelessEchoes;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
 
 namespace TimelessEchoes.Stats
 {
@@ -173,7 +176,9 @@ namespace TimelessEchoes.Stats
             record.XpGained += xp;
             tasksCompleted++;
             currentRunTasks++;
+#if !DISABLESTEAMWORKS
             SteamStatsUpdater.Instance?.UpdateStats();
+#endif
         }
 
         public GameData.TaskRecord GetTaskRecord(TaskData data)
@@ -290,7 +295,9 @@ namespace TimelessEchoes.Stats
             currentRunDamageTaken = 0f;
             lastHeroPos = Vector3.zero;
             runStartTime = Time.time;
+#if !DISABLESTEAMWORKS
             SteamStatsUpdater.Instance?.UpdateStats();
+#endif
         }
     }
 }

--- a/Assets/Scripts/Steamworks.NET/SteamCloudSync.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamCloudSync.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
+#if !(UNITY_STANDALONE_WIN || UNITY_STANDALONE_LINUX || UNITY_STANDALONE_OSX || STEAMWORKS_WIN || STEAMWORKS_LIN_OSX)
+#define DISABLESTEAMWORKS
+#endif
 
 namespace TimelessEchoes
 {
@@ -64,7 +67,9 @@ namespace TimelessEchoes
             }
 
             if (!string.IsNullOrEmpty(fileName))
+#if !DISABLESTEAMWORKS
                 SteamCloudManager.DownloadFile(fileName);
+#endif
         }
 
         /// <summary>
@@ -73,7 +78,9 @@ namespace TimelessEchoes
         public void Upload()
         {
             if (!string.IsNullOrEmpty(fileName))
+#if !DISABLESTEAMWORKS
                 SteamCloudManager.UploadFile(fileName);
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- guard Steam-related calls in `QuestManager` against non-Steam builds
- protect Rich Presence updates in `HeroController` and `GameManager`
- wrap `SteamStatsUpdater` calls in `GameplayStatTracker`
- add Android-safe Steam sync in `SteamCloudSync`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687754e0d138832e83b9b35cd9d816bf