### PR TITLE
Fix SaveToFile invocation

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -173,7 +173,12 @@ namespace Blindsided
 
         #region Core save / load
 
-        private void SaveToFile(bool allowUpload = true)
+        private void SaveToFile()
+        {
+            SaveToFile(true);
+        }
+
+        private void SaveToFile(bool allowUpload)
         {
             EventHandler.SaveData();
             saveData.DateQuitString = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Summary
- make `SaveToFile` overload without parameters so `InvokeRepeating` works

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878293d07ec832e80576a4680ce8226