### PR TITLE
Refactor resource inventory UI

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -28,7 +28,6 @@ namespace TimelessEchoes.Buffs
 
         [Header("Tooltip References")] [SerializeField]
         private RunBuffTooltipUIReferences runSlotTooltip;
-        [SerializeField] private Sprite unknownResourceSprite;
 
         [SerializeField] private Vector2 tooltipOffset = Vector2.zero;
 
@@ -251,27 +250,20 @@ namespace TimelessEchoes.Buffs
                 var slot = Instantiate(panel.costSlotPrefab, panel.costGridLayoutParent.transform);
                 slot.resource = req.resource;
 
-                if (slot.selectButton != null)
+                slot.PointerClick += (_, button) =>
                 {
-                    var res = req.resource;
-                    slot.selectButton.onClick.AddListener(() => resourceInventoryUI?.HighlightResource(res));
-                    slot.selectButton.interactable = true;
-                }
+                    if (button == UnityEngine.EventSystems.PointerEventData.InputButton.Left)
+                        resourceInventoryUI?.HighlightResource(req.resource);
+                };
 
                 var unlocked = resourceManager && resourceManager.IsUnlocked(req.resource);
 
                 if (slot.iconImage != null)
                 {
-                    slot.iconImage.sprite = req.resource ? req.resource.icon : null;
-                    slot.iconImage.enabled = unlocked;
-                }
-
-                if (slot.questionMarkImage != null)
-                {
-                    slot.questionMarkImage.enabled = !unlocked;
-                    slot.questionMarkImage.color = !unlocked
-                        ? new Color(0x74 / 255f, 0x3E / 255f, 0x38 / 255f)
-                        : Color.white;
+                    var unknownSprite = resourceInventoryUI ? resourceInventoryUI.UnknownSprite : null;
+                    slot.iconImage.sprite = unlocked ? req.resource?.icon : unknownSprite;
+                    slot.iconImage.color = unlocked ? Color.white : new Color(0x74 / 255f, 0x3E / 255f, 0x38 / 255f);
+                    slot.iconImage.enabled = true;
                 }
 
                 if (slot.countText != null)
@@ -376,7 +368,11 @@ namespace TimelessEchoes.Buffs
                 var slotRef = Instantiate(runSlotTooltip.tooltipCostPrefab, runSlotTooltip.tooltipCostParent);
                 bool unlockedRes = resourceManager && resourceManager.IsUnlocked(req.resource);
                 if (slotRef.resourceIcon != null)
-                    slotRef.resourceIcon.sprite = unlockedRes && req.resource ? req.resource.icon : unknownResourceSprite;
+                {
+                    var unknownSprite = resourceInventoryUI ? resourceInventoryUI.UnknownSprite : null;
+                    slotRef.resourceIcon.sprite = unlockedRes && req.resource ? req.resource.icon : unknownSprite;
+                    slotRef.resourceIcon.color = unlockedRes ? Color.white : new Color(0x74 / 255f, 0x3E / 255f, 0x38 / 255f);
+                }
                 if (slotRef.resourceCostText != null)
                     slotRef.resourceCostText.text = $"Cost: {FormatNumber(req.amount, true)}";
 

--- a/Assets/Scripts/References/UI/CostResourceUIReferences.cs
+++ b/Assets/Scripts/References/UI/CostResourceUIReferences.cs
@@ -3,33 +3,36 @@ using TimelessEchoes.Upgrades;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 
 namespace References.UI
 {
-    public class CostResourceUIReferences : MonoBehaviour
+    public class CostResourceUIReferences : MonoBehaviour, IPointerClickHandler
     {
         private static readonly List<CostResourceUIReferences> instances = new();
         public Resource resource;
-        public Image questionMarkImage;
         public Image iconImage;
         public TMP_Text countText;
         public Image selectionImage;
-        public Button selectButton;
+
+        public event System.Action<CostResourceUIReferences, PointerEventData.InputButton> PointerClick;
 
         private void Awake()
         {
             instances.Add(this);
-            if (selectButton != null)
-                selectButton.onClick.AddListener(OnSelect);
         }
 
         private void OnDestroy()
         {
             instances.Remove(this);
-            if (selectButton != null)
-                selectButton.onClick.RemoveListener(OnSelect);
         }
 
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            PointerClick?.Invoke(this, eventData.button);
+            if (eventData.button == PointerEventData.InputButton.Left)
+                OnSelect();
+        }
         private void OnSelect()
         {
             foreach (var inst in instances)

--- a/Assets/Scripts/References/UI/ResourceUIReferences.cs
+++ b/Assets/Scripts/References/UI/ResourceUIReferences.cs
@@ -10,30 +10,26 @@ namespace References.UI
     public class ResourceUIReferences : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerClickHandler
     {
         private static readonly List<ResourceUIReferences> instances = new();
-        public Image questionMarkImage;
-        public Image highlightImage;
         public Image iconImage;
         public TMP_Text countText;
         public Image selectionImage;
-        public Button selectButton;
 
         private void Awake()
         {
             instances.Add(this);
-            if (selectButton != null)
-                selectButton.onClick.AddListener(OnSelect);
+            // existing selection images are controlled globally
         }
 
         private void OnDestroy()
         {
             instances.Remove(this);
-            if (selectButton != null)
-                selectButton.onClick.RemoveListener(OnSelect);
         }
 
         public void OnPointerClick(PointerEventData eventData)
         {
             PointerClick?.Invoke(this, eventData.button);
+            if (eventData.button == PointerEventData.InputButton.Left)
+                OnSelect();
         }
 
         public void OnPointerEnter(PointerEventData eventData)

--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -89,13 +89,11 @@ namespace TimelessEchoes.Regen
                 if (res == null) continue;
                 var entry = Instantiate(entryPrefab, entryParent);
                 entry.costResourceUIReferences.resource = res;
-                if (entry.costResourceUIReferences.selectButton != null)
+                entry.costResourceUIReferences.PointerClick += (_, button) =>
                 {
-                    var r = res;
-                    entry.costResourceUIReferences.selectButton.onClick.RemoveAllListeners();
-                    entry.costResourceUIReferences.selectButton.onClick.AddListener(() =>
-                        inventoryUI?.HighlightResource(r));
-                }
+                    if (button == UnityEngine.EventSystems.PointerEventData.InputButton.Left)
+                        inventoryUI?.HighlightResource(res);
+                };
 
                 if (entry.donate10PercentButton != null)
                 {
@@ -134,14 +132,13 @@ namespace TimelessEchoes.Regen
             var donated = donations.TryGetValue(res, out var val) ? val : 0;
 
             var costRefs = entry.costResourceUIReferences;
+            var unknownColor = new Color(0x74 / 255f, 0x3E / 255f, 0x38 / 255f);
             if (costRefs.iconImage != null)
             {
-                costRefs.iconImage.sprite = res.icon;
-                costRefs.iconImage.enabled = unlocked;
+                costRefs.iconImage.sprite = unlocked ? res.icon : inventoryUI?.UnknownSprite;
+                costRefs.iconImage.color = unlocked ? Color.white : unknownColor;
+                costRefs.iconImage.enabled = true;
             }
-
-            if (costRefs.questionMarkImage != null)
-                costRefs.questionMarkImage.enabled = !unlocked;
             if (costRefs.countText != null)
                 costRefs.countText.text = unlocked ? Mathf.FloorToInt((float)playerAmt).ToString() : string.Empty;
 

--- a/Assets/Scripts/Upgrades/RunDropUI.cs
+++ b/Assets/Scripts/Upgrades/RunDropUI.cs
@@ -168,24 +168,17 @@ namespace TimelessEchoes.Upgrades
                 slot.transform.SetSiblingIndex(0);
                 newSlot = true;
 
-                if (slot != null && slot.selectButton != null)
-                    slot.selectButton.onClick.AddListener(() => SelectSlot(slots.IndexOf(slot)));
-
                 if (slot != null)
                 {
                     slot.PointerClick += (_, button) =>
                     {
                         if (button == PointerEventData.InputButton.Right && tooltip != null)
                             tooltip.gameObject.SetActive(false);
-                        if (slot.highlightImage != null)
-                            slot.highlightImage.enabled = false;
                     };
                     slot.PointerEnter += _ =>
                     {
                         if (showTooltipOnHover)
                             ShowTooltip(slots.IndexOf(slot));
-                        if (slot.highlightImage != null)
-                            slot.highlightImage.enabled = false;
                     };
                     slot.PointerExit += _ =>
                     {
@@ -206,8 +199,6 @@ namespace TimelessEchoes.Upgrades
                 }
             }
 
-            if (slot != null && slot.highlightImage != null)
-                slot.highlightImage.enabled = true;
 
             if (displayObject != null)
                 displayObject.SetActive(true);
@@ -242,8 +233,6 @@ namespace TimelessEchoes.Upgrades
                 slot.iconImage.enabled = true;
             }
 
-            if (slot.questionMarkImage)
-                slot.questionMarkImage.enabled = false;
             if (slot.countText)
                 slot.countText.gameObject.SetActive(false);
             if (slot.selectionImage)

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -125,12 +125,11 @@ namespace TimelessEchoes.Upgrades
                         {
                             var slot = Instantiate(prefab, parent.transform);
                             slot.resource = req.resource;
-                            if (slot.selectButton != null)
+                            slot.PointerClick += (_, button) =>
                             {
-                                var res = req.resource;
-                                slot.selectButton.onClick.RemoveAllListeners();
-                                slot.selectButton.onClick.AddListener(() => resourceInventoryUI?.HighlightResource(res));
-                            }
+                                if (button == UnityEngine.EventSystems.PointerEventData.InputButton.Left)
+                                    resourceInventoryUI?.HighlightResource(req.resource);
+                            };
                             list.Add(slot);
                         }
                     }
@@ -165,13 +164,13 @@ namespace TimelessEchoes.Upgrades
                 int cost = req.amount + Mathf.Max(0, lvl - threshold.minLevel) * req.amountIncreasePerLevel;
 
                 bool unlocked = resourceManager && resourceManager.IsUnlocked(req.resource);
-                if (slot.questionMarkImage)
-                    slot.questionMarkImage.enabled = !unlocked;
 
                 if (slot.iconImage)
                 {
-                    slot.iconImage.sprite = req.resource ? req.resource.icon : null;
-                    slot.iconImage.enabled = unlocked;
+                    var unknownSprite = resourceInventoryUI ? resourceInventoryUI.UnknownSprite : null;
+                    slot.iconImage.sprite = unlocked ? req.resource?.icon : unknownSprite;
+                    slot.iconImage.color = unlocked ? Color.white : new Color(0x74 / 255f, 0x3E / 255f, 0x38 / 255f);
+                    slot.iconImage.enabled = true;
                 }
 
                 if (slot.countText)
@@ -184,8 +183,6 @@ namespace TimelessEchoes.Upgrades
 
                 if (slot.selectionImage)
                     slot.selectionImage.enabled = false;
-                if (slot.selectButton)
-                    slot.selectButton.interactable = true;
             }
         }
 


### PR DESCRIPTION
## Summary
- simplify `ResourceUIReferences` and `CostResourceUIReferences`
- update `RunDropUI`, `RegenManager`, `BuffUIManager` and `StatUpgradeUIManager` to new APIs
- overhaul `ResourceInventoryUI` to instantiate slots, show unknown sprite and auto-deselect

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687870304cf0832e8403f15a1771df61