### PR TITLE
Use CalcUtils formatting for fish donation count

### DIFF
--- a/Assets/Scripts/Regen/RegenManager.cs
+++ b/Assets/Scripts/Regen/RegenManager.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
 using static TimelessEchoes.TELogger;
+using static Blindsided.Utilities.CalcUtils;
 
 namespace TimelessEchoes.Regen
 {
@@ -146,7 +147,7 @@ namespace TimelessEchoes.Regen
                 entry.fishNameText.text = unlocked ? res.name : "???";
 
             if (entry.amountDonatedText != null)
-                entry.amountDonatedText.text = Mathf.FloorToInt((float)donated).ToString();
+                entry.amountDonatedText.text = FormatNumber(donated, true);
 
             if (entry.regenText != null)
                 entry.regenText.text = $"Granting {GetRegenFor(res):0.###} Regen";


### PR DESCRIPTION
## Summary
- display regen fish donations using `FormatNumber`

## Testing
- `git diff HEAD~1`

------
https://chatgpt.com/codex/tasks/task_e_6878779df6b0832eb3cf79bb32c2b01d