### PR TITLE
Update UI upgrade button behavior

### DIFF
--- a/Assets/Prefabs/UI/Upgrades/Upgrade.prefab
+++ b/Assets/Prefabs/UI/Upgrades/Upgrade.prefab
@@ -66,6 +66,7 @@ MonoBehaviour:
   countText: {fileID: 1841410465884961785}
   selectionImage: {fileID: 0}
   upgradeButton: {fileID: 1258390322170696258}
+  upgradeButtonText: {fileID: 2312384945028776293}
   nameText: {fileID: 9155395266114017365}
   statDisplayText: {fileID: 8844084338998089394}
   descriptionText: {fileID: 6162470923925629372}

--- a/Assets/Scripts/References/UI/StatUIReferences.cs
+++ b/Assets/Scripts/References/UI/StatUIReferences.cs
@@ -10,6 +10,7 @@ namespace References.UI
         public TMP_Text countText;
         public Image selectionImage;
         public Button upgradeButton;
+        public TMP_Text upgradeButtonText;
         public TMP_Text nameText;
         public TMP_Text statDisplayText;
         public TMP_Text descriptionText;

--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -191,7 +191,21 @@ namespace TimelessEchoes.Upgrades
             {
                 var refs = statReferences[i];
                 if (refs != null && refs.upgradeButton != null)
-                    refs.upgradeButton.interactable = controller != null && controller.CanUpgrade(upgrades[i]);
+                {
+                    var threshold = GetThreshold(upgrades[i]);
+                    if (threshold == null)
+                    {
+                        refs.upgradeButton.interactable = false;
+                        if (refs.upgradeButtonText != null)
+                            refs.upgradeButtonText.text = "Maxed";
+                    }
+                    else
+                    {
+                        refs.upgradeButton.interactable = controller != null && controller.CanUpgrade(upgrades[i]);
+                        if (refs.upgradeButtonText != null)
+                            refs.upgradeButtonText.text = "Upgrade";
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add upgrade button text reference to `StatUIReferences`
- update `StatUpgradeUIManager` to disable and label an upgrade button as "Maxed" when an upgrade reaches its highest level
- add the new reference in `Upgrade.prefab`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68787ce0a3d4832e8e9029171cbb0685