### PR TITLE
Improve default task/item sorting

### DIFF
--- a/Assets/Scripts/UI/ItemStatsPanelUI.cs
+++ b/Assets/Scripts/UI/ItemStatsPanelUI.cs
@@ -121,14 +121,23 @@ namespace TimelessEchoes.UI
             if (entries.Count == 0)
                 return;
 
-            if (sortMode == SortMode.Default)
-            {
-                ApplyOrder(defaultOrder);
-                return;
-            }
-
             IEnumerable<Resource> known = defaultOrder.Where(r => r.totalReceived > 0);
             IEnumerable<Resource> unknown = defaultOrder.Where(r => r.totalReceived <= 0);
+
+            if (sortMode == SortMode.Default)
+            {
+                var sortedKnown = known
+                    .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
+                    .ThenBy(r => r.name)
+                    .ToList();
+                var sortedUnknown = unknown
+                    .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
+                    .ThenBy(r => r.name)
+                    .ToList();
+                var finalDefault = sortedKnown.Concat(sortedUnknown).ToList();
+                ApplyOrder(finalDefault);
+                return;
+            }
 
             int GetValue(Resource r) => sortMode == SortMode.Collected ? r.totalReceived : r.totalSpent;
 

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -124,18 +124,27 @@ namespace TimelessEchoes.UI
             if (entries.Count == 0)
                 return;
 
-            if (sortMode == SortMode.Default)
-            {
-                ApplyOrder(defaultOrder);
-                return;
-            }
-
             IEnumerable<TaskData> known = defaultOrder;
             IEnumerable<TaskData> unknown = Enumerable.Empty<TaskData>();
             if (statTracker != null)
             {
                 known = defaultOrder.Where(t => (statTracker.GetTaskRecord(t)?.TotalCompleted ?? 0) > 0);
                 unknown = defaultOrder.Where(t => (statTracker.GetTaskRecord(t)?.TotalCompleted ?? 0) == 0);
+            }
+
+            if (sortMode == SortMode.Default)
+            {
+                var sortedKnown = known
+                    .OrderBy(t => t.taskID)
+                    .ThenBy(t => t.taskName)
+                    .ToList();
+                var sortedUnknown = unknown
+                    .OrderBy(t => t.taskID)
+                    .ThenBy(t => t.taskName)
+                    .ToList();
+                var finalDefault = sortedKnown.Concat(sortedUnknown).ToList();
+                ApplyOrder(finalDefault);
+                return;
             }
 
             float GetValue(TaskData t) => sortMode == SortMode.Completions


### PR DESCRIPTION
## Summary
- prioritize known tasks when sorting tasks by default
- prioritize known items when sorting items by default

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68787f82c3d4832e8cb5764bd524f3f2