### PR TITLE
Fix maxed stat display

### DIFF
--- a/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeUIManager.cs
@@ -274,7 +274,10 @@ namespace TimelessEchoes.Upgrades
                 float baseNext = upgrade.baseValue + (lvl + 1) * upgrade.statIncreasePerLevel + flat;
                 float next = baseNext * (1f + percent);
 
-                refs.statDisplayText.text = $"{current:0.###} -> {next:0.###}";
+                if (GetThreshold(upgrade) == null)
+                    refs.statDisplayText.text = $"{current:0.###}";
+                else
+                    refs.statDisplayText.text = $"{current:0.###} -> {next:0.###}";
             }
         }
     }


### PR DESCRIPTION
## Summary
- show only the current stat value once a stat upgrade is maxed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878804be3d8832ea4c2179ea27bf052