### PR TITLE
Add Unknown sort mode

### DIFF
--- a/Assets/Scripts/UI/ItemStatsPanelUI.cs
+++ b/Assets/Scripts/UI/ItemStatsPanelUI.cs
@@ -20,7 +20,8 @@ namespace TimelessEchoes.UI
         {
             Default,
             Collected,
-            Spent
+            Spent,
+            Unknown
         }
 
         [SerializeField] private SortMode sortMode = SortMode.Default;
@@ -136,6 +137,21 @@ namespace TimelessEchoes.UI
                     .ToList();
                 var finalDefault = sortedKnown.Concat(sortedUnknown).ToList();
                 ApplyOrder(finalDefault);
+                return;
+            }
+
+            if (sortMode == SortMode.Unknown)
+            {
+                var sortedUnknown = unknown
+                    .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
+                    .ThenBy(r => r.name)
+                    .ToList();
+                var sortedKnown = known
+                    .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
+                    .ThenBy(r => r.name)
+                    .ToList();
+                var finalUnknown = sortedUnknown.Concat(sortedKnown).ToList();
+                ApplyOrder(finalUnknown);
                 return;
             }
 

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -21,7 +21,8 @@ namespace TimelessEchoes.UI
         {
             Default,
             Completions,
-            TaskTime
+            TaskTime,
+            Unknown
         }
 
         [SerializeField] private SortMode sortMode = SortMode.Default;
@@ -144,6 +145,21 @@ namespace TimelessEchoes.UI
                     .ToList();
                 var finalDefault = sortedKnown.Concat(sortedUnknown).ToList();
                 ApplyOrder(finalDefault);
+                return;
+            }
+
+            if (sortMode == SortMode.Unknown)
+            {
+                var sortedUnknown = unknown
+                    .OrderBy(t => t.taskID)
+                    .ThenBy(t => t.taskName)
+                    .ToList();
+                var sortedKnown = known
+                    .OrderBy(t => t.taskID)
+                    .ThenBy(t => t.taskName)
+                    .ToList();
+                var finalUnknown = sortedUnknown.Concat(sortedKnown).ToList();
+                ApplyOrder(finalUnknown);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- add `Unknown` sort mode to ItemStatsPanelUI and TaskStatsPanelUI
- support sorting to show unknown items or tasks first

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687880e0a39c832eb37f65e53bfb1908