### PR TITLE
Resolve variable name conflicts in stats panels

### DIFF
--- a/Assets/Scripts/UI/ItemStatsPanelUI.cs
+++ b/Assets/Scripts/UI/ItemStatsPanelUI.cs
@@ -127,43 +127,43 @@ namespace TimelessEchoes.UI
 
             if (sortMode == SortMode.Default)
             {
-                var sortedKnown = known
+                var sortedKnownDefault = known
                     .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
                     .ThenBy(r => r.name)
                     .ToList();
-                var sortedUnknown = unknown
+                var sortedUnknownDefault = unknown
                     .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
                     .ThenBy(r => r.name)
                     .ToList();
-                var finalDefault = sortedKnown.Concat(sortedUnknown).ToList();
+                var finalDefault = sortedKnownDefault.Concat(sortedUnknownDefault).ToList();
                 ApplyOrder(finalDefault);
                 return;
             }
 
             if (sortMode == SortMode.Unknown)
             {
-                var sortedUnknown = unknown
+                var sortedUnknownUnknown = unknown
                     .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
                     .ThenBy(r => r.name)
                     .ToList();
-                var sortedKnown = known
+                var sortedKnownUnknown = known
                     .OrderBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
                     .ThenBy(r => r.name)
                     .ToList();
-                var finalUnknown = sortedUnknown.Concat(sortedKnown).ToList();
+                var finalUnknown = sortedUnknownUnknown.Concat(sortedKnownUnknown).ToList();
                 ApplyOrder(finalUnknown);
                 return;
             }
 
             int GetValue(Resource r) => sortMode == SortMode.Collected ? r.totalReceived : r.totalSpent;
 
-            var sortedKnown = known
+            var sortedKnownByValue = known
                 .OrderByDescending(GetValue)
                 .ThenBy(r => int.TryParse(r.resourceID.ToString(), out var id) ? id : 0)
                 .ThenBy(r => r.name)
                 .ToList();
 
-            var finalOrder = sortedKnown.Concat(unknown).ToList();
+            var finalOrder = sortedKnownByValue.Concat(unknown).ToList();
             ApplyOrder(finalOrder);
         }
 

--- a/Assets/Scripts/UI/TaskStatsPanelUI.cs
+++ b/Assets/Scripts/UI/TaskStatsPanelUI.cs
@@ -135,30 +135,30 @@ namespace TimelessEchoes.UI
 
             if (sortMode == SortMode.Default)
             {
-                var sortedKnown = known
+                var sortedKnownDefault = known
                     .OrderBy(t => t.taskID)
                     .ThenBy(t => t.taskName)
                     .ToList();
-                var sortedUnknown = unknown
+                var sortedUnknownDefault = unknown
                     .OrderBy(t => t.taskID)
                     .ThenBy(t => t.taskName)
                     .ToList();
-                var finalDefault = sortedKnown.Concat(sortedUnknown).ToList();
+                var finalDefault = sortedKnownDefault.Concat(sortedUnknownDefault).ToList();
                 ApplyOrder(finalDefault);
                 return;
             }
 
             if (sortMode == SortMode.Unknown)
             {
-                var sortedUnknown = unknown
+                var sortedUnknownUnknown = unknown
                     .OrderBy(t => t.taskID)
                     .ThenBy(t => t.taskName)
                     .ToList();
-                var sortedKnown = known
+                var sortedKnownUnknown = known
                     .OrderBy(t => t.taskID)
                     .ThenBy(t => t.taskName)
                     .ToList();
-                var finalUnknown = sortedUnknown.Concat(sortedKnown).ToList();
+                var finalUnknown = sortedUnknownUnknown.Concat(sortedKnownUnknown).ToList();
                 ApplyOrder(finalUnknown);
                 return;
             }
@@ -167,13 +167,13 @@ namespace TimelessEchoes.UI
                 ? statTracker?.GetTaskRecord(t)?.TotalCompleted ?? 0
                 : statTracker?.GetTaskRecord(t)?.TimeSpent ?? 0f;
 
-            var sortedKnown = known
+            var sortedKnownByValue = known
                 .OrderByDescending(GetValue)
                 .ThenBy(t => t.taskID)
                 .ThenBy(t => t.taskName)
                 .ToList();
 
-            var finalOrder = sortedKnown.Concat(unknown).ToList();
+            var finalOrder = sortedKnownByValue.Concat(unknown).ToList();
             ApplyOrder(finalOrder);
         }
 


### PR DESCRIPTION
## Summary
- fix CS0136 compile errors in ItemStatsPanelUI and TaskStatsPanelUI by renaming local variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68788204862c832e96fd4af1226851d7