### PR TITLE
Remove unused index field in TalkToNpcTask

### DIFF
--- a/Assets/Scripts/Tasks/TalkToNpcTask.cs
+++ b/Assets/Scripts/Tasks/TalkToNpcTask.cs
@@ -22,7 +22,6 @@ namespace TimelessEchoes.Tasks
         [TextArea]
         [SerializeField] private List<string> lines = new();
 
-        private int index;
         private bool talked;
         private GameObject meetingInstance;
 
@@ -36,7 +35,6 @@ namespace TimelessEchoes.Tasks
         public override void StartTask()
         {
             talked = false;
-            index = 0;
             meetingInstance = null;
             if (!string.IsNullOrEmpty(npcId))
                 StaticReferences.ActiveNpcMeetings.Remove(npcId);


### PR DESCRIPTION
## Summary
- remove unused `index` field from `TalkToNpcTask`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878820a490c832e8ee8b8abc14cf920