### PR TITLE
Fix SteamCloud download skip logic

### DIFF
--- a/Assets/Scripts/Steamworks.NET/SteamCloudSync.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamCloudSync.cs
@@ -60,7 +60,13 @@ namespace TimelessEchoes
         /// </summary>
         public void Download()
         {
-            if (skipDownload) skipDownload = false;
+            if (skipDownload)
+            {
+                // The next download call was intentionally skipped, typically
+                // when wiping local data to avoid restoring from the cloud.
+                skipDownload = false;
+                return;
+            }
 
 #if !DISABLESTEAMWORKS
             if (!string.IsNullOrEmpty(fileName))


### PR DESCRIPTION
## Summary
- avoid redownloading wiped saves by returning early when a download is skipped

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878a1494cb0832e992b5b261b3912d4