### PR TITLE
Fix quest icons refreshing after discovery

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -182,6 +182,7 @@ namespace TimelessEchoes.Quests
                 progress /= count;
 
             inst.ui?.SetProgress(progress);
+            inst.ui?.UpdateRequirementIcons();
         }
 
         private void CompleteQuest(QuestInstance inst)


### PR DESCRIPTION
## Summary
- store cost slots for quest entries and refresh them
- update quest entry icons whenever quest progress updates

## Testing
- `dotnet test` *(fails: command not found)*
- `unity-editor -batchmode -quit -runTests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b6c21de4832ea8284958843718f3