### PR TITLE
Add quest turn-in button indicator

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -38,6 +38,7 @@ namespace TimelessEchoes.Quests
             public QuestData data;
             public QuestEntryUI ui;
             public readonly Dictionary<EnemyStats, double> killCounts = new();
+            public bool ReadyForTurnIn;
         }
 
         private void Awake()
@@ -183,6 +184,7 @@ namespace TimelessEchoes.Quests
 
             inst.ui?.SetProgress(progress);
             inst.ui?.UpdateRequirementIcons();
+            inst.ReadyForTurnIn = progress >= 1f;
         }
 
         private void CompleteQuest(QuestInstance inst)
@@ -232,6 +234,19 @@ namespace TimelessEchoes.Quests
             achievementManager?.NotifyNpcMet(id);
 #endif
             RefreshNoticeboard();
+        }
+
+        /// <summary>
+        /// Returns true if any active quest can be turned in.
+        /// </summary>
+        public bool HasQuestsReadyForTurnIn()
+        {
+            foreach (var inst in active.Values)
+            {
+                if (inst != null && inst.ReadyForTurnIn)
+                    return true;
+            }
+            return false;
         }
 
         private void TryStartQuest(QuestData quest)

--- a/Assets/Scripts/UI/QuestButtonIndicator.cs
+++ b/Assets/Scripts/UI/QuestButtonIndicator.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using TimelessEchoes.Quests;
+using Blindsided;
+
+namespace TimelessEchoes.UI
+{
+    /// <summary>
+    /// Highlights the quest button when quests can be turned in.
+    /// </summary>
+    public class QuestButtonIndicator : MonoBehaviour
+    {
+        [SerializeField] private GameObject indicatorImage;
+        [SerializeField] private QuestManager questManager;
+
+        private void Awake()
+        {
+            if (questManager == null)
+                questManager = Object.FindFirstObjectByType<QuestManager>();
+        }
+
+        private void Update()
+        {
+            UpdateIndicator();
+        }
+
+        private void OnEnable()
+        {
+            EventHandler.OnQuestHandin += OnQuestHandin;
+            EventHandler.OnLoadData += OnLoadData;
+            UpdateIndicator();
+        }
+
+        private void OnDisable()
+        {
+            EventHandler.OnQuestHandin -= OnQuestHandin;
+            EventHandler.OnLoadData -= OnLoadData;
+        }
+
+        private void OnQuestHandin(string _)
+        {
+            UpdateIndicator();
+        }
+
+        private void OnLoadData()
+        {
+            UpdateIndicator();
+        }
+
+        private void UpdateIndicator()
+        {
+            if (indicatorImage == null || questManager == null)
+                return;
+            indicatorImage.SetActive(questManager.HasQuestsReadyForTurnIn());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `QuestButtonIndicator` to display an indicator on the quests button
- track quest completion progress in `QuestManager`
- expose `HasQuestsReadyForTurnIn` to check for turn-ins

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878bf6110f4832e8cac6be206df4f25