### PR TITLE
Add player death sound

### DIFF
--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -36,6 +36,9 @@ namespace TimelessEchoes.Audio
         [Header("Chest Clips")] [SerializeField]
         private AudioClip[] chestOpenClips;
 
+        [Header("Hero Clips")] [SerializeField]
+        private AudioClip heroDeathClip;
+
         public enum TaskType
         {
             Woodcutting,
@@ -149,6 +152,11 @@ namespace TimelessEchoes.Audio
         public void PlayFishCatchClip()
         {
             PlaySfx(fishCatchClip);
+        }
+
+        public void PlayHeroDeathClip()
+        {
+            PlaySfx(heroDeathClip);
         }
 
         private void PlaySfx(AudioClip clip)

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -14,6 +14,7 @@ using TimelessEchoes.NPC;
 using TimelessEchoes.Stats;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.Audio;
 using TMPro;
 using Unity.Cinemachine;
 using UnityEngine;
@@ -337,6 +338,8 @@ namespace TimelessEchoes
                             currentMap.transform);
                 }
             }
+
+            AudioManager.Instance?.PlayHeroDeathClip();
 
             Log("Hero death", TELogCategory.Hero, this);
 

--- a/Assets/Scripts/Hero/HeroAudio.cs
+++ b/Assets/Scripts/Hero/HeroAudio.cs
@@ -51,5 +51,10 @@ namespace TimelessEchoes.Hero
         {
             Audio?.PlayFishCatchClip();
         }
+
+        public void PlayDeath()
+        {
+            Audio?.PlayHeroDeathClip();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add hero death sound to audio manager
- trigger hero death clip in game manager
- expose play method in hero audio

## Testing
- `dotnet test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68796255a008832eaaf915f8e31f2960