### PR TITLE
Fix distance buff reset after death

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -232,6 +232,8 @@ namespace TimelessEchoes
 
             if (deathWindow != null)
                 deathWindow.SetActive(false);
+            BuffManager.Instance?.ClearActiveBuffs();
+            BuffManager.Instance?.UpdateDistance(0f);
             StartCoroutine(StartRunRoutine());
         }
 


### PR DESCRIPTION
## Summary
- clear active buffs when starting a run
- reset distance checks to ensure distance-based buffs are available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687962e9b068832ea806c1d5aaf2236b