### PR TITLE
Align TaskData spawn ranges

### DIFF
--- a/Assets/Resources/Tasks/Farming/Carrot.asset
+++ b/Assets/Resources/Tasks/Farming/Carrot.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 4727212774405997460, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 125
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 31c43e7b43e9407791103b070abe9e42, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Chillie.asset
+++ b/Assets/Resources/Tasks/Farming/Chillie.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -9046296309055213395, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 350
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 4ca1d6c5bf8245df82a7a75168d51f02, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Corn.asset
+++ b/Assets/Resources/Tasks/Farming/Corn.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -1010118597598872900, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 50
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: c83b4b0590bf39a498aef150278941ac, type: 2}
   taskDuration: 3
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Cucumber.asset
+++ b/Assets/Resources/Tasks/Farming/Cucumber.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -7998690685759499793, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 225
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: c3c28a1d79264acb8fe05e6880426a43, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Funion.asset
+++ b/Assets/Resources/Tasks/Farming/Funion.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -3967237929857205426, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 425
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 72c197707d4c4c529d67db6a7e711132, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Leek.asset
+++ b/Assets/Resources/Tasks/Farming/Leek.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -4179824020582981186, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 275
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 959a94840c214b3dae27c81ab2473463, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Lettuce.asset
+++ b/Assets/Resources/Tasks/Farming/Lettuce.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 2799499457651537543, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 200
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 35982548c6994ba5a00d881db3dac34e, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Onion.asset
+++ b/Assets/Resources/Tasks/Farming/Onion.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -87930393345229523, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 250
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 2395628c18784e2bab0b7af0b4bbc721, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Parsnip.asset
+++ b/Assets/Resources/Tasks/Farming/Parsnip.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 1524892664962734932, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 300
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 00568cbce0574f7680580a71be54f90a, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Pepper.asset
+++ b/Assets/Resources/Tasks/Farming/Pepper.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -7950665004155765343, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 325
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 28ae2ed17b1546c8a3d5f43e52c3cdb7, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Pumking.asset
+++ b/Assets/Resources/Tasks/Farming/Pumking.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -2584793599262434737, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 375
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 78e6cf2e15964b41b5fcd5833f00d44a, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Radish.asset
+++ b/Assets/Resources/Tasks/Farming/Radish.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -1319403273844478748, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Spud.asset
+++ b/Assets/Resources/Tasks/Farming/Spud.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 166006926289291715, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 150
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: ba841e2bed264c8bb9226481219ced25, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Strawberry.asset
+++ b/Assets/Resources/Tasks/Farming/Strawberry.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -8228112601785353111, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 400
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 212e527a951e485c8bc8c31cb639f88a, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Tomato.asset
+++ b/Assets/Resources/Tasks/Farming/Tomato.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 8954413170907878631, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 175
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: a01bc0adc87a48bab23d3700a16800e6, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Turnip.asset
+++ b/Assets/Resources/Tasks/Farming/Turnip.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 4227562727828232050, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 5
+  minX: 450
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 907a527d8f6a4a3f8ff78ba58fd4a59f, type: 2}
   taskDuration: 2
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Wartermelone.asset
+++ b/Assets/Resources/Tasks/Farming/Wartermelone.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 9057977493438303337, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 12
+  minX: 100
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: e7b996d2be115c74aae9b52d0808a89f, type: 2}
   taskDuration: 6
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Farming/Wheat.asset
+++ b/Assets/Resources/Tasks/Farming/Wheat.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -1041579510, guid: 9cb02e74c571af045af4e6f90876850b, type: 3}
   associatedSkill: {fileID: 11400000, guid: f3b9fce6557e44d4ac8a2a064e3b0b9b, type: 2}
   xpForCompletion: 8
+  minX: 75
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: ac7e31f0151eed24397bcddbdb709b85, type: 2}
   taskDuration: 4
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Fishing/Bloopicus Maximus.asset
+++ b/Assets/Resources/Tasks/Fishing/Bloopicus Maximus.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 8589306949512994324, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 50
+  minX: 2500
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 25
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Fishing/Flippy Floppy.asset
+++ b/Assets/Resources/Tasks/Fishing/Flippy Floppy.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -5709444697936806870, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 2
+  minX: 0
+  maxX: 250
   taskDuration: 2
   resourceDrops:
   - resource: {fileID: 11400000, guid: 691350e69adc08a4082225a8015d2955, type: 2}

--- a/Assets/Resources/Tasks/Fishing/Flipzoid.asset
+++ b/Assets/Resources/Tasks/Fishing/Flipzoid.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -7136742806779194532, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 15
+  minX: 500
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 10
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Fishing/Muddy Muck Muncher.asset
+++ b/Assets/Resources/Tasks/Fishing/Muddy Muck Muncher.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -575027357971916658, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 3
+  minX: 75
+  maxX: 500
   requiredQuest: {fileID: 0}
   taskDuration: 3
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Fishing/Niblet the Bold.asset
+++ b/Assets/Resources/Tasks/Fishing/Niblet the Bold.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -3352606046829665213, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 25
+  minX: 1000
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 15
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Fishing/Sir Splashford III.asset
+++ b/Assets/Resources/Tasks/Fishing/Sir Splashford III.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -6599523220579283235, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 5
+  minX: 200
+  maxX: 1000
   requiredQuest: {fileID: 0}
   taskDuration: 4
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Fishing/Snapjaw Jr..asset
+++ b/Assets/Resources/Tasks/Fishing/Snapjaw Jr..asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 7134718345356409942, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 10
+  minX: 400
+  maxX: 10000
   requiredQuest: {fileID: 0}
   taskDuration: 7
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Fishing/Wigglelittle.asset
+++ b/Assets/Resources/Tasks/Fishing/Wigglelittle.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 3646522454361906472, guid: 1dc8e874f9facc24fa08bd9484c90178, type: 3}
   associatedSkill: {fileID: 11400000, guid: 211bb19c6f906e141893064edf3e6f8b, type: 2}
   xpForCompletion: 7
+  minX: 300
+  maxX: 2500
   requiredQuest: {fileID: 0}
   taskDuration: 5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Looting/Copium Chest.asset
+++ b/Assets/Resources/Tasks/Looting/Copium Chest.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 776162574, guid: 6a1eba8e86be0ce4884405f559395edb, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 20
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 0.5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Looting/Crystal Chest.asset
+++ b/Assets/Resources/Tasks/Looting/Crystal Chest.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 752469611, guid: 6a1eba8e86be0ce4884405f559395edb, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 10
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 0.5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Looting/Golden Chest.asset
+++ b/Assets/Resources/Tasks/Looting/Golden Chest.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -2238842246251146030, guid: 337426889e46c764cb0e793986b7ef37, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 7
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 0.5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Looting/Idle Chest.asset
+++ b/Assets/Resources/Tasks/Looting/Idle Chest.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -6654411221075461266, guid: 6a1eba8e86be0ce4884405f559395edb, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 25
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 0.5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Looting/Lirium Chest.asset
+++ b/Assets/Resources/Tasks/Looting/Lirium Chest.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 931018621, guid: 6a1eba8e86be0ce4884405f559395edb, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 15
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 0.5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Looting/MetalChest.asset
+++ b/Assets/Resources/Tasks/Looting/MetalChest.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -987686138164254292, guid: 151f0f2575d0eb14f8357b530959f372, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 5
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 0.5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Looting/Vastium Chest.asset
+++ b/Assets/Resources/Tasks/Looting/Vastium Chest.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 1740307149, guid: 6a1eba8e86be0ce4884405f559395edb, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 50
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 0.5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Looting/Wooden Chest.asset
+++ b/Assets/Resources/Tasks/Looting/Wooden Chest.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -7070875390197807606, guid: 1ec0b90faf4188545ba0f1bd405b6df3, type: 3}
   associatedSkill: {fileID: 11400000, guid: 762e694a868a7534ea079da462fc5c73, type: 2}
   xpForCompletion: 2
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 0.5
   sfxInterval: 0

--- a/Assets/Resources/Tasks/Mining/Copium Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Copium Ore.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -4797693821990039991, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3
+  minX: 500
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 21c838e0a781dcb4c96d7cb663953ff5, type: 2}
   taskDuration: 10
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Mining/Dlog Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Dlog Ore.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -3476202021705219157, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3
+  minX: 150
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 74ed306672b0a214685903da2dbf07c8, type: 2}
   taskDuration: 4
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Mining/Erif Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Erif Ore.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -623644546430554401, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3
+  minX: 200
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 8881bebf2bb94df4a91353c851ca2b6f, type: 2}
   taskDuration: 5
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Mining/Eznorb Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Eznorb Ore.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 5050492222661095950, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3
+  minX: 40
+  maxX: Infinity
   taskDuration: 2
   sfxInterval: 0.7
   resourceDrops:

--- a/Assets/Resources/Tasks/Mining/Idle Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Idle Ore.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 7054577682481060284, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3
+  minX: 1000
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 63ff8ec529640974ab5843c76a2009bf, type: 2}
   taskDuration: 15
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Mining/Lirium Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Lirium Ore.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 7473302359189358601, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3
+  minX: 300
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: 8c7a0f27f3d9da0419dab5a969401442, type: 2}
   taskDuration: 7
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Mining/Nori Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Nori Ore.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -6760471406004971263, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3
+  minX: 100
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 3
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Mining/Vastium Ore.asset
+++ b/Assets/Resources/Tasks/Mining/Vastium Ore.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -1370118117, guid: 513dea0f987e3824db48aa939832f2f7, type: 3}
   associatedSkill: {fileID: 11400000, guid: 26be2150ef7e8b143b109ad88581e2ed, type: 2}
   xpForCompletion: 3
+  minX: 2500
+  maxX: Infinity
   requiredQuest: {fileID: 11400000, guid: f646904b6b4c43541883f9a6e7ebb312, type: 2}
   taskDuration: 25
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Large Birch Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Large Birch Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 2630977764869979562, guid: 53248977f321e9648bbbe8718c39a315, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 25
+  minX: 500
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 7
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Large Fruit Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Large Fruit Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 621266246945384593, guid: b45d02bebb0bae34490e63de2e1440b9, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 7
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 3
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Large Oak Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Large Oak Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -6043950617988251759, guid: c79f924a676f900408ab47fe98ae9935, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 10
+  minX: 100
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 6
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Large Spruce Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Large Spruce Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -2161423198996946198, guid: 6dcc684ee8a4e9a428482ed2a78beb66, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 50
+  minX: 2500
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 10
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Medium Birch Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Medium Birch Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -2044317885256534180, guid: ff597bf836f9fb24a9d6b5c4190007a7, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 8
+  minX: 500
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 3
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Medium Fruit Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Medium Fruit Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -6213476910104009479, guid: 25ec107e317209041985b70a5dc05d93, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 3
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 2
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Medium Oak Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Medium Oak Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 6013379132409528037, guid: 974fe87578622624abd01a4856b266ef, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 5
+  minX: 100
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 3
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Medium Spruce Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Medium Spruce Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -3194247907673141736, guid: 70c5d1de0a66bab45bd496acee38f43e, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 15
+  minX: 2500
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 4
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Small Birch Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Small Birch Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -1772785241186216535, guid: 66726431582e2244ba5aeef3a3b96ae9, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 3
+  minX: 500
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 2.5
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Small Fruit Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Small Fruit Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -799831649384477707, guid: c0379aa4fd42660418cc76d22a3de2e1, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 1
+  minX: 0
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 1
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Small Oak Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Small Oak Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: 1701996483059660236, guid: e144c0eae8cb318449644c1524511be5, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 2
+  minX: 100
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 1.5
   sfxInterval: 0.7

--- a/Assets/Resources/Tasks/Woodcutting/Small Spruce Tree.asset
+++ b/Assets/Resources/Tasks/Woodcutting/Small Spruce Tree.asset
@@ -17,6 +17,8 @@ MonoBehaviour:
   taskIcon: {fileID: -4892141724536017943, guid: cbc5d9c181eaf0943969b1c5cb93ba50, type: 3}
   associatedSkill: {fileID: 11400000, guid: c2b68db9a9d75f441a4fc9e8e179640d, type: 2}
   xpForCompletion: 6
+  minX: 2500
+  maxX: Infinity
   requiredQuest: {fileID: 0}
   taskDuration: 3
   sfxInterval: 0.7


### PR DESCRIPTION
## Summary
- set `minX` and `maxX` on all `TaskData` scriptable objects based on `TASKS_SUMMARY`

## Testing
- `git diff --cached --name-only`

------
https://chatgpt.com/codex/tasks/task_e_687973c6db9c832ebd0f2811f2e5773d