### PR TITLE
Fix delayed run end stats update

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -223,6 +223,10 @@ namespace TimelessEchoes
 #if !DISABLESTEAMWORKS
             RichPresenceManager.Instance?.SetInRun();
 #endif
+            if (runEndedByDeath && statTracker != null)
+            {
+                statTracker.EndRun(true);
+            }
             Log("Run starting", TELogCategory.Run, this);
             runEndedByDeath = false;
             if (deathWindowCoroutine != null)
@@ -355,7 +359,6 @@ namespace TimelessEchoes
             if (statTracker != null)
             {
                 statTracker.AddDeath();
-                statTracker.EndRun(true);
             }
 
             BuffManager.Instance?.ClearActiveBuffs();
@@ -460,8 +463,13 @@ namespace TimelessEchoes
                 runDropUI.ResetDrops();
             }
 
-            if (!runEndedByDeath)
-                statTracker?.EndRun(false);
+            if (statTracker != null)
+            {
+                if (runEndedByDeath)
+                    statTracker.EndRun(true);
+                else
+                    statTracker.EndRun(false);
+            }
             BuffManager.Instance?.ClearActiveBuffs();
             yield return StartCoroutine(CleanupMapRoutine());
             if (tavernCamera != null)


### PR DESCRIPTION
## Summary
- move `EndRun` call from OnHeroDeath so stats and distance aren't reset until a restart or return
- finalize a death run when starting a new run or returning to tavern

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687977ec648c832e9858a4959bb0ff53