### PR TITLE
Display 'Too Far' for distance-restricted buffs

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -103,9 +103,16 @@ namespace TimelessEchoes.Buffs
                     else
                     {
                         var remain = recipe ? buffManager.GetRemaining(recipe) : 0f;
-                        ui.durationText.text = remain > 0f
-                            ? FormatTime(remain, shortForm: true)
-                            : string.Empty;
+                        if (!distanceOk)
+                        {
+                            ui.durationText.text = "Too Far";
+                        }
+                        else
+                        {
+                            ui.durationText.text = remain > 0f
+                                ? FormatTime(remain, shortForm: true)
+                                : string.Empty;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- show "Too Far" on distance locked buffs

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879a12d5574832e81c1beb88420ebd8