### PR TITLE
Round kilometers stat before Steam submit

### DIFF
--- a/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
@@ -87,6 +87,7 @@ namespace TimelessEchoes
             if (SteamUserStats.GetStat("TotalKilometers", out float storedKm))
             {
                 float newKm = tracker.DistanceTravelled / 1000f;
+                newKm = Mathf.Round(newKm * 10000f) / 10000f;
                 if (newKm > storedKm)
                 {
                     SteamUserStats.SetStat("TotalKilometers", newKm);


### PR DESCRIPTION
## Summary
- round total kilometers float to four decimals in Steam stats

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a0fd2e154832e8371f37a62cb2947