### PR TITLE
Fix mirror hero spawn freeze

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -247,11 +247,11 @@ namespace TimelessEchoes.Buffs
             {
                 var mirrorObj = new GameObject("MirrorHero");
                 mirrorObj.transform.SetParent(mainController.transform, false);
-                var heroClone = Instantiate(mainHero.gameObject, mainHero.transform.position, Quaternion.identity, mirrorObj.transform);
+                var tc = mirrorObj.AddComponent<Tasks.TaskController>();
+                var heroClone = Instantiate(mainHero.gameObject, mainHero.transform.position,
+                    Quaternion.identity, mirrorObj.transform);
                 var heroComp = heroClone.GetComponent<Hero.HeroController>();
                 heroComp?.MarkAsMirror();
-
-                var tc = mirrorObj.AddComponent<Tasks.TaskController>();
                 tc.hero = heroComp;
                 tc.maxBacktrackDistance = mainController.maxBacktrackDistance;
                 tc.backtrackingAdditionalWeight = mainController.backtrackingAdditionalWeight;

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -195,7 +195,7 @@ namespace TimelessEchoes.Hero
         private void OnEnable()
         {
             if (taskController == null)
-                taskController = GetComponent<TaskController>();
+                taskController = GetComponentInParent<TaskController>();
 
             if (buffController == null)
             {


### PR DESCRIPTION
## Summary
- spawn TaskController before hero clone so Awake can link correctly
- find TaskController using `GetComponentInParent` during `OnEnable`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a19d17e4c832e9f2da83ced7c539d