### PR TITLE
Implement hero cloning buff

### DIFF
--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -18,6 +18,7 @@ namespace TimelessEchoes.Buffs
 
         public Sprite buffIcon;
         [Min(0f)] public float baseDuration = 30f;
+        [Min(0)] public int cloneCount;
         [Range(-100f, 100f)] public float moveSpeedPercent;
         [Range(-100f, 100f)] public float damagePercent;
         [Range(-100f, 100f)] public float defensePercent;

--- a/Assets/Scripts/Hero/HeroHealth.cs
+++ b/Assets/Scripts/Hero/HeroHealth.cs
@@ -11,19 +11,26 @@ namespace TimelessEchoes.Hero
     {
         public static HeroHealth Instance { get; private set; }
         private HeroController controller;
+        public bool Immortal { get; set; }
 
         protected override void Awake()
         {
-            if (Instance != null && Instance != this) Destroy(Instance.gameObject);
-            Instance = this;
             controller = GetComponent<HeroController>();
+            if (!controller || !controller.IsClone)
+            {
+                if (Instance != null && Instance != this) Destroy(Instance.gameObject);
+                Instance = this;
+            }
             base.Awake();
         }
 
         private void OnDestroy()
         {
-            if (Instance == this)
-                Instance = null;
+            if (!controller || !controller.IsClone)
+            {
+                if (Instance == this)
+                    Instance = null;
+            }
         }
 
         protected override float CalculateDamage(float fullDamage)
@@ -54,6 +61,12 @@ namespace TimelessEchoes.Hero
         protected override float GetFloatingTextSize()
         {
             return 6f;
+        }
+
+        public override void TakeDamage(float amount, float bonusDamage = 0f)
+        {
+            if (Immortal) return;
+            base.TakeDamage(amount, bonusDamage);
         }
     }
 }

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -18,6 +18,32 @@ namespace TimelessEchoes.Tasks
 
         public float LastGrantedXp => lastGrantedXp;
 
+        private HeroController claimedBy;
+        public HeroController ClaimedBy => claimedBy;
+
+        public bool Claim(HeroController hero)
+        {
+            if (hero == null) return false;
+            if (claimedBy == null || claimedBy == hero)
+            {
+                claimedBy = hero;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void ReleaseClaim(HeroController hero)
+        {
+            if (claimedBy == hero || hero == null)
+                claimedBy = null;
+        }
+
+        public void ClearClaim()
+        {
+            claimedBy = null;
+        }
+
         /// <summary>
         ///     A property to indicate if this task should prevent the hero from moving.
         /// </summary>


### PR DESCRIPTION
## Summary
- let buffs spawn temporary hero clones that work on tasks
- track clone instances so they expire with the buff
- allow tasks to be claimed by a specific hero
- adjust TaskController and HeroController to support multiple heroes
- keep clone health immortal and reduce sprite opacity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a284ecf28832e80f983480166970a