### PR TITLE
Fix clone combat event handling

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -557,6 +557,10 @@ namespace TimelessEchoes.Hero
             if (enemy == null)
                 return;
 
+            var setter = enemy.GetComponent<AIDestinationSetter>();
+            if (setter != null && setter.target != transform)
+                return;
+
             if (currentEnemy != null && currentEnemy != enemy.transform)
                 return;
 


### PR DESCRIPTION
## Summary
- avoid clones responding to enemy engage events meant for the main hero

## Testing
- `git show -U3 HEAD`

------
https://chatgpt.com/codex/tasks/task_e_687a2eab945c832eaccf1803de9cffaf