### PR TITLE
Add kill stats to Steam

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -138,6 +138,7 @@ namespace Blindsided.SaveData
             public float DistanceTravelled;
             public float HighestDistance;
             public int TotalKills;
+            public int SlimesKilled;
             public int TasksCompleted;
             public int Deaths;
             public float DamageDealt;

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -233,7 +233,7 @@ namespace TimelessEchoes.Enemies
             if (statsTracker == null)
                 TELogger.Log("GameplayStatTracker missing", TELogCategory.Combat, this);
             else
-                statsTracker.AddKill();
+                statsTracker.AddKill(stats);
 
             GrantCombatExperience();
         }

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Blindsided.SaveData;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.Upgrades;
+using TimelessEchoes.Enemies;
 using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
@@ -29,6 +30,11 @@ namespace TimelessEchoes.Stats
         public float HighestDistance { get; private set; }
 
         public int TotalKills { get; private set; }
+
+        /// <summary>
+        /// Number of slime enemies defeated.
+        /// </summary>
+        public int SlimesKilled { get; private set; }
 
         public int TasksCompleted { get; private set; }
 
@@ -107,6 +113,7 @@ namespace TimelessEchoes.Stats
             g.DistanceTravelled = DistanceTravelled;
             g.HighestDistance = HighestDistance;
             g.TotalKills = TotalKills;
+            g.SlimesKilled = SlimesKilled;
             g.TasksCompleted = TasksCompleted;
             g.Deaths = Deaths;
             g.DamageDealt = DamageDealt;
@@ -139,6 +146,7 @@ namespace TimelessEchoes.Stats
             DistanceTravelled = g.DistanceTravelled;
             HighestDistance = g.HighestDistance;
             TotalKills = g.TotalKills;
+            SlimesKilled = g.SlimesKilled;
             TasksCompleted = g.TasksCompleted;
             Deaths = g.Deaths;
             DamageDealt = g.DamageDealt;
@@ -208,9 +216,11 @@ namespace TimelessEchoes.Stats
                 CurrentRunDistance = position.x;
         }
 
-        public void AddKill()
+        public void AddKill(EnemyStats enemy)
         {
             TotalKills++;
+            if (enemy != null && !string.IsNullOrEmpty(enemy.enemyName) && enemy.enemyName.ToLowerInvariant().Contains("slime"))
+                SlimesKilled++;
             CurrentRunKills++;
         }
 

--- a/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
@@ -115,6 +115,26 @@ namespace TimelessEchoes
                 }
             }
 
+            if (SteamUserStats.GetStat("TotalKills", out int storedKills))
+            {
+                int newKills = tracker.TotalKills;
+                if (newKills > storedKills)
+                {
+                    SteamUserStats.SetStat("TotalKills", newKills);
+                    changed = true;
+                }
+            }
+
+            if (SteamUserStats.GetStat("SlimesKilled", out int storedSlimes))
+            {
+                int newSlimes = tracker.SlimesKilled;
+                if (newSlimes > storedSlimes)
+                {
+                    SteamUserStats.SetStat("SlimesKilled", newSlimes);
+                    changed = true;
+                }
+            }
+
             if (changed)
                 SteamUserStats.StoreStats();
         }


### PR DESCRIPTION
## Summary
- extend GameData with SlimesKilled
- track SlimesKilled in GameplayStatTracker
- update Enemy to send stats to tracker
- sync TotalKills and SlimesKilled via SteamStatsUpdater

## Testing
- `npm test` *(fails: could not find package.json)*
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687abddeb9ec832eb5f8441c30f1eb2e