### PR TITLE
Add Disciple scriptable object

### DIFF
--- a/Assets/Scripts/NpcGeneration/Disciple.cs
+++ b/Assets/Scripts/NpcGeneration/Disciple.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Blindsided.Utilities;
+using TimelessEchoes.Quests;
+using UnityEngine;
+
+namespace TimelessEchoes.NpcGeneration
+{
+    [ManageableData]
+    [CreateAssetMenu(fileName = "Disciple", menuName = "SO/Disciple")]
+    public class Disciple : ScriptableObject
+    {
+        public List<DiscipleGenerator.ResourceEntry> resources = new();
+        public QuestData requiredQuest;
+        [Min(0f)] public float generationInterval = 5f;
+    }
+}

--- a/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
@@ -1,5 +1,10 @@
+using System.Collections;
 using System.Collections.Generic;
+using Blindsided.SaveData;
+using TimelessEchoes.Quests;
 using UnityEngine;
+using static Blindsided.EventHandler;
+using static Blindsided.Oracle;
 
 namespace TimelessEchoes.NpcGeneration
 {
@@ -10,19 +15,76 @@ namespace TimelessEchoes.NpcGeneration
     public class DiscipleGenerationManager : MonoBehaviour
     {
         public static DiscipleGenerationManager Instance { get; private set; }
-        [SerializeField] private List<DiscipleGenerator> generators = new();
+        [SerializeField] private List<Disciple> disciples = new();
+        [SerializeField] private DiscipleGenerator generatorPrefab;
+        [SerializeField] private Transform generatorParent;
+
+        private readonly List<DiscipleGenerator> generators = new();
 
         public IReadOnlyList<DiscipleGenerator> Generators => generators;
 
         private void Awake()
         {
             Instance = this;
+            OnLoadData += OnLoadDataHandler;
+            OnQuestHandin += OnQuestHandinHandler;
         }
 
         private void OnDestroy()
         {
+            OnLoadData -= OnLoadDataHandler;
+            OnQuestHandin -= OnQuestHandinHandler;
             if (Instance == this)
                 Instance = null;
+        }
+
+        private void OnLoadDataHandler()
+        {
+            StartCoroutine(DeferredBuild());
+        }
+
+        private void OnQuestHandinHandler(string questId)
+        {
+            StartCoroutine(DeferredBuild());
+        }
+
+        private IEnumerator DeferredBuild()
+        {
+            yield return null;
+            BuildGenerators();
+        }
+
+        private void BuildGenerators()
+        {
+            foreach (var gen in generators)
+                if (gen != null)
+                    Destroy(gen.gameObject);
+            generators.Clear();
+
+            if (generatorPrefab == null || generatorParent == null)
+                return;
+
+            foreach (var d in disciples)
+            {
+                if (d == null) continue;
+                if (!QuestCompleted(d.requiredQuest))
+                    continue;
+
+                var gen = Instantiate(generatorPrefab, generatorParent);
+                gen.name = d.name;
+                gen.SetData(d);
+                generators.Add(gen);
+            }
+        }
+
+        private static bool QuestCompleted(QuestData quest)
+        {
+            if (quest == null)
+                return true;
+            if (oracle == null)
+                return false;
+            oracle.saveData.Quests ??= new Dictionary<string, GameData.QuestRecord>();
+            return oracle.saveData.Quests.TryGetValue(quest.questId, out var rec) && rec.Completed;
         }
 
 

--- a/Assets/Scripts/NpcGeneration/DiscipleGenerator.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerator.cs
@@ -22,9 +22,31 @@ namespace TimelessEchoes.NpcGeneration
             public double amount = 1;
         }
 
+        [SerializeField] private Disciple data;
         [SerializeField] private List<ResourceEntry> resources = new();
         [SerializeField] private QuestData requiredQuest;
         [SerializeField] private float generationInterval = 5f;
+
+        public void SetData(Disciple d)
+        {
+            data = d;
+            ApplyData();
+        }
+
+        private void ApplyData()
+        {
+            if (data == null)
+                return;
+            generationInterval = data.generationInterval;
+            requiredQuest = data.requiredQuest;
+            resources = new List<ResourceEntry>();
+            foreach (var entry in data.resources)
+            {
+                if (entry == null) continue;
+                var copy = new ResourceEntry { resource = entry.resource, amount = entry.amount };
+                resources.Add(copy);
+            }
+        }
 
         private readonly Dictionary<Resource, double> stored = new();
         private readonly Dictionary<Resource, double> collectedTotals = new();
@@ -63,6 +85,7 @@ namespace TimelessEchoes.NpcGeneration
             OnSaveData += SaveState;
             OnLoadData += LoadState;
             OnQuestHandin += OnQuestHandinEvent;
+            ApplyData();
         }
 
         private void OnEnable()


### PR DESCRIPTION
## Summary
- create new `Disciple` ScriptableObject asset
- allow `DiscipleGenerator` to load data from a `Disciple`
- update `DiscipleGenerationManager` to spawn generators from `Disciple` assets

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687abf3e9c10832e81ba5907d4769a0c