### PR TITLE
Rename npc generation save data to disciples

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -31,7 +31,7 @@ namespace Blindsided.SaveData
 
         [HideReferenceObjectPicker] public HashSet<string> CompletedNpcTasks = new();
 
-        [HideReferenceObjectPicker] public Dictionary<string, NpcGenerationRecord> NpcGeneration = new();
+        [HideReferenceObjectPicker] public Dictionary<string, DiscipleGenerationRecord> Disciples = new();
 
         [HideReferenceObjectPicker] public Dictionary<string, QuestRecord> Quests = new();
 
@@ -101,7 +101,7 @@ namespace Blindsided.SaveData
         }
 
         [HideReferenceObjectPicker]
-        public class NpcGenerationRecord
+        public class DiscipleGenerationRecord
         {
             public Dictionary<string, double> StoredResources = new();
             public Dictionary<string, double> TotalCollected = new();

--- a/Assets/Scripts/NpcGeneration/Disciple.cs
+++ b/Assets/Scripts/NpcGeneration/Disciple.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Blindsided.Utilities;
 using TimelessEchoes.Quests;
@@ -9,7 +10,14 @@ namespace TimelessEchoes.NpcGeneration
     [CreateAssetMenu(fileName = "Disciple", menuName = "SO/Disciple")]
     public class Disciple : ScriptableObject
     {
-        public List<DiscipleGenerator.ResourceEntry> resources = new();
+        [Serializable]
+        public class ResourceEntry
+        {
+            public Resource resource;
+            public double amount = 1;
+        }
+
+        public List<ResourceEntry> resources = new();
         public QuestData requiredQuest;
         [Min(0f)] public float generationInterval = 5f;
     }

--- a/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerationManager.cs
@@ -17,7 +17,6 @@ namespace TimelessEchoes.NpcGeneration
         public static DiscipleGenerationManager Instance { get; private set; }
         [SerializeField] private List<Disciple> disciples = new();
         [SerializeField] private DiscipleGenerator generatorPrefab;
-        [SerializeField] private Transform generatorParent;
 
         private readonly List<DiscipleGenerator> generators = new();
 
@@ -61,7 +60,7 @@ namespace TimelessEchoes.NpcGeneration
                     Destroy(gen.gameObject);
             generators.Clear();
 
-            if (generatorPrefab == null || generatorParent == null)
+            if (generatorPrefab == null)
                 return;
 
             foreach (var d in disciples)
@@ -70,7 +69,7 @@ namespace TimelessEchoes.NpcGeneration
                 if (!QuestCompleted(d.requiredQuest))
                     continue;
 
-                var gen = Instantiate(generatorPrefab, generatorParent);
+                var gen = Instantiate(generatorPrefab, transform);
                 gen.name = d.name;
                 gen.SetData(d);
                 generators.Add(gen);

--- a/Assets/Scripts/Tools/ConsoleCommands.cs
+++ b/Assets/Scripts/Tools/ConsoleCommands.cs
@@ -134,7 +134,7 @@ namespace TimelessEchoes
             var oracle = Blindsided.Oracle.oracle;
             if (oracle == null) return;
             oracle.saveData.CompletedNpcTasks = new HashSet<string>();
-            oracle.saveData.NpcGeneration = new Dictionary<string, GameData.NpcGenerationRecord>();
+            oracle.saveData.Disciples = new Dictionary<string, GameData.DiscipleGenerationRecord>();
             Blindsided.EventHandler.LoadData();
             NpcObjectStateController.Instance?.UpdateObjectStates();
         }


### PR DESCRIPTION
## Summary
- rename `NpcGenerationRecord` to `DiscipleGenerationRecord`
- store disciple generation data in `Disciples` dictionary
- adjust `DiscipleGenerator` to rely on `Disciple` data and use scriptable name as key
- simplify `DiscipleGenerationManager` to use its own transform as parent
- fix console command to wipe disciple data
- move `ResourceEntry` type into `Disciple`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ac7568168832eb5c167c5a315139d