### PR TITLE
Fix disciple wipe

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -177,7 +177,8 @@ namespace Blindsided
 
         private void SaveToFile(bool allowUpload)
         {
-            EventHandler.SaveData();
+            if (!wipeInProgress)
+                EventHandler.SaveData();
             saveData.DateQuitString = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
 
             ES3.Save(_dataName, saveData, _settings); // direct file write


### PR DESCRIPTION
## Summary
- ensure wiping keeps disciple data empty by skipping SaveData events during a wipe

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687ace440974832e88971a594c912cf4