### PR TITLE
Refactor BuffManager to load recipes from Resources

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -19,7 +19,7 @@ namespace TimelessEchoes.Buffs
 
         private ResourceManager resourceManager;
 
-        [SerializeField] private List<BuffRecipe> allRecipes = new();
+        private BuffRecipe[] cachedRecipes;
 
         private readonly List<ActiveBuff> activeBuffs = new();
         private readonly List<BuffRecipe> slotAssignments = new(new BuffRecipe[5]);
@@ -76,8 +76,15 @@ namespace TimelessEchoes.Buffs
                 return false;
             }
         }
-        public IEnumerable<BuffRecipe> Recipes =>
-            allRecipes?.Count > 0 ? allRecipes : Resources.LoadAll<BuffRecipe>("");
+        public IEnumerable<BuffRecipe> Recipes
+        {
+            get
+            {
+                if (cachedRecipes == null || cachedRecipes.Length == 0)
+                    cachedRecipes = Resources.LoadAll<BuffRecipe>("Buffs");
+                return cachedRecipes;
+            }
+        }
 
         private void Awake()
         {


### PR DESCRIPTION
## Summary
- remove serialized `allRecipes` list
- load recipes from Resources `Buffs` folder at runtime

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687ad7beb488832e9425dfcf37dc66d6