### PR TITLE
Load quests from Resources

### DIFF
--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -28,7 +28,7 @@ namespace TimelessEchoes.Quests
         private DiscipleGenerationManager generationManager;
         private QuestUIManager uiManager;
 
-        [FormerlySerializedAs("startingQuests")] [SerializeField]
+        [SerializeField] private string questResourcePath = "Quests";
         private List<QuestData> quests = new();
 
         private readonly Dictionary<string, QuestInstance> active = new();
@@ -43,6 +43,7 @@ namespace TimelessEchoes.Quests
 
         private void Awake()
         {
+            quests = new List<QuestData>(Resources.LoadAll<QuestData>(questResourcePath));
             resourceManager = ResourceManager.Instance;
             if (resourceManager == null)
                 Log("ResourceManager missing", TELogCategory.Resource, this);

--- a/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
+++ b/Assets/Scripts/Tests/Editor/QuestManagerTests.cs
@@ -51,7 +51,7 @@ namespace TimelessEchoes.Tests
         [Test]
         public void OnNpcMet_StartsQuest()
         {
-            typeof(QuestManager).GetField("startingQuests", BindingFlags.NonPublic | BindingFlags.Instance)
+            typeof(QuestManager).GetField("quests", BindingFlags.NonPublic | BindingFlags.Instance)
                 .SetValue(manager, new List<QuestData> { quest });
 
             StaticReferences.CompletedNpcTasks.Add("NPC1");
@@ -69,7 +69,7 @@ namespace TimelessEchoes.Tests
             next.questId = "Q2";
             next.requiredQuests.Add(quest);
 
-            typeof(QuestManager).GetField("startingQuests", BindingFlags.NonPublic | BindingFlags.Instance)
+            typeof(QuestManager).GetField("quests", BindingFlags.NonPublic | BindingFlags.Instance)
                 .SetValue(manager, new List<QuestData> { quest, next });
 
             oracle.saveData.Quests["Q1"] = new GameData.QuestRecord { Completed = true };


### PR DESCRIPTION
## Summary
- load quests from `Resources/Quests` when `QuestManager` initializes
- adjust tests to reference new field name

## Testing
- `nunit3-console --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad7676f64832ea92e79c0e794e9de