### PR TITLE
Add quest data for new NPCs

### DIFF
--- a/Assets/Resources/Quests/FARMINGNPC.meta
+++ b/Assets/Resources/Quests/FARMINGNPC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 94d1bf9ed99646579c69b8fecce6df7f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Carrot Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Carrot Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Carrot Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Carrot
+  questName: Carrot Harvest Hope
+  description: Harvest and present 100 Carrots to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Carrot
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 9e342e09a47b4014ab320cc6d06a2a3d, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Carrot Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Carrot Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 299dd56fdf6c4f46a2ba0c9ce54134b3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Chillie Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Chillie Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Chillie Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Chillie
+  questName: Chillie Harvest Hope
+  description: Harvest and present 100 Chillies to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Chillie
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 52b45ffed04e559418584d82175340a6, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Chillie Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Chillie Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b42f62b9f4cc4bc4b2a511adf4b80b47
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Corn Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Corn Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Corn Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Corn
+  questName: Corn Harvest Hope
+  description: Harvest and present 100 Corn to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Corn
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 1fd4ff0f627126a4a8ca50ea71793823, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Corn Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Corn Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e4539a46ec54a6d90649879059b2af0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Cucumber Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Cucumber Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Cucumber Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Cucumber
+  questName: Cucumber Harvest Hope
+  description: Harvest and present 100 Cucumbers to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Cucumber
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 5eaebeeea7cd85948922c1bcab927ca6, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Cucumber Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Cucumber Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63132c136be84bcb8e37cb2c7beaa70b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Funion Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Funion Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Funion Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Funion
+  questName: Funion Harvest Hope
+  description: Harvest and present 100 Funions to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Funion
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: b4981418ea008e74f8918c87bac15573, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Funion Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Funion Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8da9a6e1d21d4e9c996c570e171386dd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Leek Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Leek Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Leek Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Leek
+  questName: Leek Harvest Hope
+  description: Harvest and present 100 Leeks to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Leek
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 92206defd8abd854c835604fc2ebfc33, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Leek Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Leek Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eeb83a9d24684f268c13f0f594b4f6b6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Lettuce Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Lettuce Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Lettuce Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Lettuce
+  questName: Lettuce Harvest Hope
+  description: Harvest and present 100 Lettuce to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Lettuce
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 49595052db28a8e48a4eb1fa7d04b7f6, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Lettuce Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Lettuce Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d127e8e24879479db87e9c6e51a90a9b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Onion Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Onion Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Onion Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Onion
+  questName: Onion Harvest Hope
+  description: Harvest and present 100 Onions to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Onion
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: b5b12e283249229419b1a300192d8601, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Onion Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Onion Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87abd56902144b1dadb888cbe0725f6e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Parsnip Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Parsnip Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Parsnip Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Parsnip
+  questName: Parsnip Harvest Hope
+  description: Harvest and present 100 Parsnips to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Parsnip
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: fb12ddb33d729bf48a519c61510dca6a, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Parsnip Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Parsnip Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 55788ebec3e1482b84b4a3b78dcf71c4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Pepper Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Pepper Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Pepper Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Pepper
+  questName: Pepper Harvest Hope
+  description: Harvest and present 100 Peppers to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Pepper
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: db783fe988c6728428405a8c18c3f5d8, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Pepper Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Pepper Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe2ce9e6ea8a418281ecbe6848e2a57b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Pumking Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Pumking Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Pumking Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Pumking
+  questName: Pumking Harvest Hope
+  description: Harvest and present 100 Pumkings to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Pumking
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: c11abbf84f4141844b21de6f7af929ea, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Pumking Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Pumking Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 859bb4c70e524cb0a25939c862d10120
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Spud Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Spud Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Spud Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Spud
+  questName: Spud Harvest Hope
+  description: Harvest and present 100 Spuds to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Spud
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: fd0a53a91094b2b4da64fec1b7c7bace, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Spud Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Spud Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a289dbcc84c4cf9a655456d6f0ec3a9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Strawberry Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Strawberry Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Strawberry Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Strawberry
+  questName: Strawberry Harvest Hope
+  description: Harvest and present 100 Strawberries to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Strawberry
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: dcd8ad1628b899a48847deb1cb2b3739, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Strawberry Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Strawberry Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f9201696220a43f3894f210eb3b4e416
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Tomato Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Tomato Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Tomato Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Tomato
+  questName: Tomato Harvest Hope
+  description: Harvest and present 100 Tomatoes to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Tomato
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: e8e8a19bb4573f540a00a6d78dddd0db, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Tomato Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Tomato Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a8deab080374f1db840b6c30e777ade
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Turnip Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Turnip Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Turnip Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Turnip
+  questName: Turnip Harvest Hope
+  description: Harvest and present 100 Turnips to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Turnip
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 420847cbb07e26640a57575ee30d5120, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Turnip Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Turnip Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6780ea978db14e2382604414b9809001
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Wartermelone Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Wartermelone Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Wartermelone Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Wartermelone
+  questName: Wartermelone Harvest Hope
+  description: Harvest and present 100 Wartermelone to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Wartermelone
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: ae1b523394ff9eb49866f20982e4c68d, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Wartermelone Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Wartermelone Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66c8f62ac1804f39a5680b0e8aeed6c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FARMINGNPC/Wheat Harvest Hope.asset
+++ b/Assets/Resources/Quests/FARMINGNPC/Wheat Harvest Hope.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Wheat Harvest Hope
+  m_EditorClassIdentifier:
+  questId: Wheat
+  questName: Wheat Harvest Hope
+  description: Harvest and present 100 Wheat to inspire the crop spirit.
+  rewardDescription: Gain the Disciple of Wheat
+  npcId: FARMINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 9e0063ffd6091384fba5f8a233b51808, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FARMINGNPC/Wheat Harvest Hope.asset.meta
+++ b/Assets/Resources/Quests/FARMINGNPC/Wheat Harvest Hope.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c401b02ff71468ea5e6625028fd3482
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FISHINGNPC.meta
+++ b/Assets/Resources/Quests/FISHINGNPC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7cc05beae92f4cf8a5ff7a56771d9fb3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FISHINGNPC/Bloopicus Maximus Rescue.asset
+++ b/Assets/Resources/Quests/FISHINGNPC/Bloopicus Maximus Rescue.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Bloopicus Maximus Rescue
+  m_EditorClassIdentifier:
+  questId: BloopicusMaximus
+  questName: Bloopicus Maximus Rescue
+  description: Catch and donate 50 Bloopicus Maximus to win their trust.
+  rewardDescription: Gain the Disciple of Bloopicus Maximus
+  npcId: FISHINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 289297afb43756445933dca5ff8d7138, type: 2}
+    amount: 50
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FISHINGNPC/Bloopicus Maximus Rescue.asset.meta
+++ b/Assets/Resources/Quests/FISHINGNPC/Bloopicus Maximus Rescue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8fdf8cf6e7c34831a086fd75c4371beb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FISHINGNPC/Flipzoid Rescue.asset
+++ b/Assets/Resources/Quests/FISHINGNPC/Flipzoid Rescue.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Flipzoid Rescue
+  m_EditorClassIdentifier:
+  questId: Flipzoid
+  questName: Flipzoid Rescue
+  description: Catch and donate 50 Flipzoids to win their trust.
+  rewardDescription: Gain the Disciple of Flipzoid
+  npcId: FISHINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: c906b6628db99c14d94b3b43d531523f, type: 2}
+    amount: 50
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FISHINGNPC/Flipzoid Rescue.asset.meta
+++ b/Assets/Resources/Quests/FISHINGNPC/Flipzoid Rescue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1264e01acba8408086f886ee7ffe314c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FISHINGNPC/Muddy Muck Muncher Rescue.asset
+++ b/Assets/Resources/Quests/FISHINGNPC/Muddy Muck Muncher Rescue.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Muddy Muck Muncher Rescue
+  m_EditorClassIdentifier:
+  questId: MuddyMuckMuncher
+  questName: Muddy Muck Muncher Rescue
+  description: Catch and donate 50 Muddy Muck Munchers to win their trust.
+  rewardDescription: Gain the Disciple of Muddy Muck Muncher
+  npcId: FISHINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 457dbb132eac48d429163353adb4b532, type: 2}
+    amount: 50
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FISHINGNPC/Muddy Muck Muncher Rescue.asset.meta
+++ b/Assets/Resources/Quests/FISHINGNPC/Muddy Muck Muncher Rescue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 81c2c03c7f8c4a02ab869ca6673b88ea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FISHINGNPC/Niblet the Bold Rescue.asset
+++ b/Assets/Resources/Quests/FISHINGNPC/Niblet the Bold Rescue.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Niblet the Bold Rescue
+  m_EditorClassIdentifier:
+  questId: NibletTheBold
+  questName: Niblet the Bold Rescue
+  description: Catch and donate 50 Niblet the Bold to win their trust.
+  rewardDescription: Gain the Disciple of Niblet the Bold
+  npcId: FISHINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 25caf48dcc8c9d64d9b2927980cfa324, type: 2}
+    amount: 50
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FISHINGNPC/Niblet the Bold Rescue.asset.meta
+++ b/Assets/Resources/Quests/FISHINGNPC/Niblet the Bold Rescue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 149952db83624f68a5d69f8ffbf3919e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FISHINGNPC/Sir Splashford III Rescue.asset
+++ b/Assets/Resources/Quests/FISHINGNPC/Sir Splashford III Rescue.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Sir Splashford III Rescue
+  m_EditorClassIdentifier:
+  questId: SirSplashfordIII
+  questName: Sir Splashford III Rescue
+  description: Catch and donate 50 Sir Splashford III to win their trust.
+  rewardDescription: Gain the Disciple of Sir Splashford III
+  npcId: FISHINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 59c67a9fee0efc84997a60754c5f02ba, type: 2}
+    amount: 50
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FISHINGNPC/Sir Splashford III Rescue.asset.meta
+++ b/Assets/Resources/Quests/FISHINGNPC/Sir Splashford III Rescue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d51676891e60418fb086260a64a8e067
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FISHINGNPC/Snapjaw Jr. Rescue.asset
+++ b/Assets/Resources/Quests/FISHINGNPC/Snapjaw Jr. Rescue.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Snapjaw Jr. Rescue
+  m_EditorClassIdentifier:
+  questId: SnapjawJr
+  questName: Snapjaw Jr. Rescue
+  description: Catch and donate 50 Snapjaw Jr. to win their trust.
+  rewardDescription: Gain the Disciple of Snapjaw Jr.
+  npcId: FISHINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: bf23b8a0a0d501543b9e7310db929300, type: 2}
+    amount: 50
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FISHINGNPC/Snapjaw Jr. Rescue.asset.meta
+++ b/Assets/Resources/Quests/FISHINGNPC/Snapjaw Jr. Rescue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f10925eb2d4f4d8a949dd8688d8e9d9b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/FISHINGNPC/Wigglelittle Rescue.asset
+++ b/Assets/Resources/Quests/FISHINGNPC/Wigglelittle Rescue.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Wigglelittle Rescue
+  m_EditorClassIdentifier:
+  questId: Wigglelittle
+  questName: Wigglelittle Rescue
+  description: Catch and donate 50 Wigglelittle to win their trust.
+  rewardDescription: Gain the Disciple of Wigglelittle
+  npcId: FISHINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: c6baa65f60afab548b279c321897df99, type: 2}
+    amount: 50
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/FISHINGNPC/Wigglelittle Rescue.asset.meta
+++ b/Assets/Resources/Quests/FISHINGNPC/Wigglelittle Rescue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 301545a0218c45109de16a9742a698ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/LOOTINGNPC.meta
+++ b/Assets/Resources/Quests/LOOTINGNPC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1500971a165b49d6994e69a73c9fcac7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/LOOTINGNPC/Bone Recall.asset
+++ b/Assets/Resources/Quests/LOOTINGNPC/Bone Recall.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Bone Recall
+  m_EditorClassIdentifier:
+  questId: Bone
+  questName: Bone Recall
+  description: Retrieve 500 Bones from the field and offer them to LOOTINGNPC.
+  rewardDescription: Gain the Disciple of Bone
+  npcId: LOOTINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: b448067cd3b40aa478fb72e658eee42b, type: 2}
+    amount: 500
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/LOOTINGNPC/Bone Recall.asset.meta
+++ b/Assets/Resources/Quests/LOOTINGNPC/Bone Recall.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d01f4a93a6144c329b3d8b6fe53588c8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/LOOTINGNPC/Leather Recall.asset
+++ b/Assets/Resources/Quests/LOOTINGNPC/Leather Recall.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Leather Recall
+  m_EditorClassIdentifier:
+  questId: Leather
+  questName: Leather Recall
+  description: Retrieve 250 Leather from the field and offer them to LOOTINGNPC.
+  rewardDescription: Gain the Disciple of Leather
+  npcId: LOOTINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 0d0c0d6eb92c2314596c9d8b51935653, type: 2}
+    amount: 250
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/LOOTINGNPC/Leather Recall.asset.meta
+++ b/Assets/Resources/Quests/LOOTINGNPC/Leather Recall.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 34902807f66d4ce1b882bae68a43dce3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC.meta
+++ b/Assets/Resources/Quests/MININGNPC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f9536cc04cbd47028b6b6b82b88f6c35
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Copium Foundation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Copium Foundation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Copium Foundation
+  m_EditorClassIdentifier:
+  questId: CopiumDisc
+  questName: Copium Foundation
+  description: Deliver 1,500 Copium Chunks so MININGNPC can forge a pact with its spirit.
+  rewardDescription: Gain the Disciple of Copium
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: cd0c8986dc3857640bf78c2cb3734d8e, type: 2}
+    amount: 1500
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Copium Foundation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Copium Foundation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd04b53062214f99ab499ed61526f6a4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Copium Resonance.asset
+++ b/Assets/Resources/Quests/MININGNPC/Copium Resonance.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Copium Resonance
+  m_EditorClassIdentifier:
+  questId: CopiumCrystalDisc
+  questName: Copium Resonance
+  description: Bring 200 Copium Crystals to unlock the crystal’s latent disciple.
+  rewardDescription: Gain the Disciple of Copium Crystal
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: c57a924f0ab50614ca64ef288331eec2, type: 2}
+    amount: 200
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Copium Resonance.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Copium Resonance.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed6f2114af7849899e821eeab0b9cc11
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Dlog Foundation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Dlog Foundation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Dlog Foundation
+  m_EditorClassIdentifier:
+  questId: DlogDisc
+  questName: Dlog Foundation
+  description: Deliver 500 Dlog Chunks so MININGNPC can forge a pact with its spirit.
+  rewardDescription: Gain the Disciple of Dlog
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 72499b5ec8c98a143937cc737473baa8, type: 2}
+    amount: 500
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Dlog Foundation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Dlog Foundation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f36100e6a0b6498cacc8700a2141020d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Dlog Resonance.asset
+++ b/Assets/Resources/Quests/MININGNPC/Dlog Resonance.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Dlog Resonance
+  m_EditorClassIdentifier:
+  questId: DlogCrystalDisc
+  questName: Dlog Resonance
+  description: Bring 75 Dlog Crystals to unlock the crystal’s latent disciple.
+  rewardDescription: Gain the Disciple of Dlog Crystal
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 2ebd59f743307bc4ca7a7d1e55491b6c, type: 2}
+    amount: 75
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Dlog Resonance.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Dlog Resonance.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9daec8cdc30544cc8f05c2d1f40de027
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Erif Foundation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Erif Foundation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Erif Foundation
+  m_EditorClassIdentifier:
+  questId: ErifDisc
+  questName: Erif Foundation
+  description: Deliver 750 Erif Chunks so MININGNPC can forge a pact with its spirit.
+  rewardDescription: Gain the Disciple of Erif
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: d2f56fea92ca73547975b06c9e6ef130, type: 2}
+    amount: 750
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Erif Foundation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Erif Foundation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2935248e3b8945549be5de2d7f258d0a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Erif Resonance.asset
+++ b/Assets/Resources/Quests/MININGNPC/Erif Resonance.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Erif Resonance
+  m_EditorClassIdentifier:
+  questId: ErifCrystalDisc
+  questName: Erif Resonance
+  description: Bring 100 Erif Crystals to unlock the crystal’s latent disciple.
+  rewardDescription: Gain the Disciple of Erif Crystal
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 01a714e515d3f4f40aca69459d70c9a3, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Erif Resonance.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Erif Resonance.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9696a1958c9543fb871ba153e1643097
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Eznorb Foundation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Eznorb Foundation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Eznorb Foundation
+  m_EditorClassIdentifier:
+  questId: EznorbDisc
+  questName: Eznorb Foundation
+  description: Deliver 100 Eznorb Chunks so MININGNPC can forge a pact with its spirit.
+  rewardDescription: Gain the Disciple of Eznorb
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: f9dad579683f8b343b6db9ed58886a07, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Eznorb Foundation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Eznorb Foundation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5265b1c5507642509053388be9525c1b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Eznorb Resonance.asset
+++ b/Assets/Resources/Quests/MININGNPC/Eznorb Resonance.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Eznorb Resonance
+  m_EditorClassIdentifier:
+  questId: EznorbCrystalDisc
+  questName: Eznorb Resonance
+  description: Bring 25 Eznorb Crystals to unlock the crystal’s latent disciple.
+  rewardDescription: Gain the Disciple of Eznorb Crystal
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: eac487199cf71634491bac5855d2e4f5, type: 2}
+    amount: 25
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Eznorb Resonance.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Eznorb Resonance.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 95d3b7ad0fe4431eaffcdc8363fbc291
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Idle Foundation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Idle Foundation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Idle Foundation
+  m_EditorClassIdentifier:
+  questId: IdleDisc
+  questName: Idle Foundation
+  description: Deliver 2,000 Idle Chunks so MININGNPC can forge a pact with its spirit.
+  rewardDescription: Gain the Disciple of Idle
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 25f9be8c6652e39409f68e3fdea67577, type: 2}
+    amount: 2000
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Idle Foundation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Idle Foundation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20baaf688b8e4fb997ed21fb66e9a449
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Idle Resonance.asset
+++ b/Assets/Resources/Quests/MININGNPC/Idle Resonance.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Idle Resonance
+  m_EditorClassIdentifier:
+  questId: IdleCrystalDisc
+  questName: Idle Resonance
+  description: Bring 250 Idle Crystals to unlock the crystal’s latent disciple.
+  rewardDescription: Gain the Disciple of Idle Crystal
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: bec6646bec02be748b6325fa80cb6655, type: 2}
+    amount: 250
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Idle Resonance.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Idle Resonance.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8759034400ef4bc7b3d53b575e8807bf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Lirium Foundation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Lirium Foundation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Lirium Foundation
+  m_EditorClassIdentifier:
+  questId: LiriumDisc
+  questName: Lirium Foundation
+  description: Deliver 1,000 Lirium Chunks so MININGNPC can forge a pact with its spirit.
+  rewardDescription: Gain the Disciple of Lirium
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 82c11950e343dcf4eb8b405b27ea5ee4, type: 2}
+    amount: 1000
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Lirium Foundation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Lirium Foundation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 484a25581e3544c6961cbf0f1ce20245
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Lirium Resonance.asset
+++ b/Assets/Resources/Quests/MININGNPC/Lirium Resonance.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Lirium Resonance
+  m_EditorClassIdentifier:
+  questId: LiriumCrystalDisc
+  questName: Lirium Resonance
+  description: Bring 150 Lirium Crystals to unlock the crystal’s latent disciple.
+  rewardDescription: Gain the Disciple of Lirium Crystal
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 3fc88fefd277cff43ba21a4816fd993c, type: 2}
+    amount: 150
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Lirium Resonance.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Lirium Resonance.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4577769316843a08fa0ce3d14f0f2c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Nori Foundation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Nori Foundation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Nori Foundation
+  m_EditorClassIdentifier:
+  questId: NoriDisc
+  questName: Nori Foundation
+  description: Deliver 250 Nori Chunks so MININGNPC can forge a pact with its spirit.
+  rewardDescription: Gain the Disciple of Nori
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 697cde1431421814ba3219fab35f6cf9, type: 2}
+    amount: 250
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Nori Foundation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Nori Foundation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b52aa3e7542466e8e40d302b3293cdb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Nori Resonance.asset
+++ b/Assets/Resources/Quests/MININGNPC/Nori Resonance.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Nori Resonance
+  m_EditorClassIdentifier:
+  questId: NoriCrystalDisc
+  questName: Nori Resonance
+  description: Bring 50 Nori Crystals to unlock the crystal’s latent disciple.
+  rewardDescription: Gain the Disciple of Nori Crystal
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 183f7bb9228fc354681abf509895d03f, type: 2}
+    amount: 50
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Nori Resonance.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Nori Resonance.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52b78ae1f4c34b698b85a0bc48fc9d71
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Stone Salvation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Stone Salvation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Stone Salvation
+  m_EditorClassIdentifier:
+  questId: StoneDisc
+  questName: Stone Salvation
+  description: Deliver 200 Stone so MININGNPC can forge a pact with the mountain spirit.
+  rewardDescription: Gain the Disciple of Stone
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 5bbcfec123bdb15458219aa5fcddc841, type: 2}
+    amount: 200
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Stone Salvation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Stone Salvation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f1974c562d242adb1ead00cc828bf8a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Vastium Foundation.asset
+++ b/Assets/Resources/Quests/MININGNPC/Vastium Foundation.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Vastium Foundation
+  m_EditorClassIdentifier:
+  questId: VastiumDisc
+  questName: Vastium Foundation
+  description: Deliver 3,000 Vastium Chunks so MININGNPC can forge a pact with its spirit.
+  rewardDescription: Gain the Disciple of Vastium
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: b44e0d1f8e117ba4d8816e75c36fab21, type: 2}
+    amount: 3000
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Vastium Foundation.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Vastium Foundation.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 816d2bc6207b4166985b96096ded2ce8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/MININGNPC/Vastium Resonance.asset
+++ b/Assets/Resources/Quests/MININGNPC/Vastium Resonance.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Vastium Resonance
+  m_EditorClassIdentifier:
+  questId: VastiumCrystalDisc
+  questName: Vastium Resonance
+  description: Bring 300 Vastium Crystals to unlock the crystal’s latent disciple.
+  rewardDescription: Gain the Disciple of Vastium Crystal
+  npcId: MININGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 4559fb45d6ad98246b96535dd6a04349, type: 2}
+    amount: 300
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/MININGNPC/Vastium Resonance.asset.meta
+++ b/Assets/Resources/Quests/MININGNPC/Vastium Resonance.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6f045aa8e994f2dbfd744f013d3614e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/WOODCUTTINGNPC.meta
+++ b/Assets/Resources/Quests/WOODCUTTINGNPC.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 736da8a5e939405f8d88fa658333603a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/WOODCUTTINGNPC/Feather Stockpile.asset
+++ b/Assets/Resources/Quests/WOODCUTTINGNPC/Feather Stockpile.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Feather Stockpile
+  m_EditorClassIdentifier:
+  questId: Feather
+  questName: Feather Stockpile
+  description: Gather 100 Feathers so WOODCUTTINGNPC can commune with the forest spirit.
+  rewardDescription: Gain the Disciple of Feather
+  npcId: WOODCUTTINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 9b8342747b02439438dbacd529ed8931, type: 2}
+    amount: 100
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/WOODCUTTINGNPC/Feather Stockpile.asset.meta
+++ b/Assets/Resources/Quests/WOODCUTTINGNPC/Feather Stockpile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c98c49b44154f42982a0521be9ee5cc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Quests/WOODCUTTINGNPC/Stick Stockpile.asset
+++ b/Assets/Resources/Quests/WOODCUTTINGNPC/Stick Stockpile.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
+  m_Name: Stick Stockpile
+  m_EditorClassIdentifier:
+  questId: Stick
+  questName: Stick Stockpile
+  description: Gather 200 Sticks so WOODCUTTINGNPC can commune with the forest spirit.
+  rewardDescription: Gain the Disciple of Stick
+  npcId: WOODCUTTINGNPC
+  requiredQuests: []
+  requirements:
+  - type: 0
+    resource: {fileID: 11400000, guid: 024c1162874b64e43be92b8892b40efb, type: 2}
+    amount: 200
+    enemies: []
+    killIcon: {fileID: 0}
+  unlockPrefab: {fileID: 0}
+  unlockObjects: []
+  unlockBuffSlots: 0

--- a/Assets/Resources/Quests/WOODCUTTINGNPC/Stick Stockpile.asset.meta
+++ b/Assets/Resources/Quests/WOODCUTTINGNPC/Stick Stockpile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5fef0b4c45a547368d145ae335051a5f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Documentation/QUESTS_SUMMARY.md
+++ b/Documentation/QUESTS_SUMMARY.md
@@ -228,3 +228,328 @@
 - **Requires:** Fan the Erif Flames
   - **Requirements:**
     - Resource x1000
+
+## MININGNPC
+### Stone Salvation
+- **Quest ID:** StoneDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 200 Stone so MININGNPC can forge a pact with the mountain spirit.
+- **Reward:** Gain the Disciple of Stone
+  - **Requirements:**
+    - Resource x200
+### Eznorb Foundation
+- **Quest ID:** EznorbDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 100 Eznorb Chunks so MININGNPC can forge a pact with its spirit.
+- **Reward:** Gain the Disciple of Eznorb
+  - **Requirements:**
+    - Resource x100
+### Nori Foundation
+- **Quest ID:** NoriDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 250 Nori Chunks so MININGNPC can forge a pact with its spirit.
+- **Reward:** Gain the Disciple of Nori
+  - **Requirements:**
+    - Resource x250
+### Dlog Foundation
+- **Quest ID:** DlogDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 500 Dlog Chunks so MININGNPC can forge a pact with its spirit.
+- **Reward:** Gain the Disciple of Dlog
+  - **Requirements:**
+    - Resource x500
+### Erif Foundation
+- **Quest ID:** ErifDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 750 Erif Chunks so MININGNPC can forge a pact with its spirit.
+- **Reward:** Gain the Disciple of Erif
+  - **Requirements:**
+    - Resource x750
+### Lirium Foundation
+- **Quest ID:** LiriumDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 1,000 Lirium Chunks so MININGNPC can forge a pact with its spirit.
+- **Reward:** Gain the Disciple of Lirium
+  - **Requirements:**
+    - Resource x1000
+### Copium Foundation
+- **Quest ID:** CopiumDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 1,500 Copium Chunks so MININGNPC can forge a pact with its spirit.
+- **Reward:** Gain the Disciple of Copium
+  - **Requirements:**
+    - Resource x1500
+### Idle Foundation
+- **Quest ID:** IdleDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 2,000 Idle Chunks so MININGNPC can forge a pact with its spirit.
+- **Reward:** Gain the Disciple of Idle
+  - **Requirements:**
+    - Resource x2000
+### Vastium Foundation
+- **Quest ID:** VastiumDisc
+- **NPC:** MININGNPC
+- **Description:** Deliver 3,000 Vastium Chunks so MININGNPC can forge a pact with its spirit.
+- **Reward:** Gain the Disciple of Vastium
+  - **Requirements:**
+    - Resource x3000
+### Eznorb Resonance
+- **Quest ID:** EznorbCrystalDisc
+- **NPC:** MININGNPC
+- **Description:** Bring 25 Eznorb Crystals to unlock the crystal’s latent disciple.
+- **Reward:** Gain the Disciple of Eznorb Crystal
+  - **Requirements:**
+    - Resource x25
+### Nori Resonance
+- **Quest ID:** NoriCrystalDisc
+- **NPC:** MININGNPC
+- **Description:** Bring 50 Nori Crystals to unlock the crystal’s latent disciple.
+- **Reward:** Gain the Disciple of Nori Crystal
+  - **Requirements:**
+    - Resource x50
+### Dlog Resonance
+- **Quest ID:** DlogCrystalDisc
+- **NPC:** MININGNPC
+- **Description:** Bring 75 Dlog Crystals to unlock the crystal’s latent disciple.
+- **Reward:** Gain the Disciple of Dlog Crystal
+  - **Requirements:**
+    - Resource x75
+### Erif Resonance
+- **Quest ID:** ErifCrystalDisc
+- **NPC:** MININGNPC
+- **Description:** Bring 100 Erif Crystals to unlock the crystal’s latent disciple.
+- **Reward:** Gain the Disciple of Erif Crystal
+  - **Requirements:**
+    - Resource x100
+### Lirium Resonance
+- **Quest ID:** LiriumCrystalDisc
+- **NPC:** MININGNPC
+- **Description:** Bring 150 Lirium Crystals to unlock the crystal’s latent disciple.
+- **Reward:** Gain the Disciple of Lirium Crystal
+  - **Requirements:**
+    - Resource x150
+### Copium Resonance
+- **Quest ID:** CopiumCrystalDisc
+- **NPC:** MININGNPC
+- **Description:** Bring 200 Copium Crystals to unlock the crystal’s latent disciple.
+- **Reward:** Gain the Disciple of Copium Crystal
+  - **Requirements:**
+    - Resource x200
+### Idle Resonance
+- **Quest ID:** IdleCrystalDisc
+- **NPC:** MININGNPC
+- **Description:** Bring 250 Idle Crystals to unlock the crystal’s latent disciple.
+- **Reward:** Gain the Disciple of Idle Crystal
+  - **Requirements:**
+    - Resource x250
+### Vastium Resonance
+- **Quest ID:** VastiumCrystalDisc
+- **NPC:** MININGNPC
+- **Description:** Bring 300 Vastium Crystals to unlock the crystal’s latent disciple.
+- **Reward:** Gain the Disciple of Vastium Crystal
+  - **Requirements:**
+    - Resource x300
+
+## FISHINGNPC
+### Muddy Muck Muncher Rescue
+- **Quest ID:** MuddyMuckMuncher
+- **NPC:** FISHINGNPC
+- **Description:** Catch and donate 50 Muddy Muck Munchers to win their trust.
+- **Reward:** Gain the Disciple of Muddy Muck Muncher
+  - **Requirements:**
+    - Resource x50
+### Sir Splashford III Rescue
+- **Quest ID:** SirSplashfordIII
+- **NPC:** FISHINGNPC
+- **Description:** Catch and donate 50 Sir Splashford III to win their trust.
+- **Reward:** Gain the Disciple of Sir Splashford III
+  - **Requirements:**
+    - Resource x50
+### Wigglelittle Rescue
+- **Quest ID:** Wigglelittle
+- **NPC:** FISHINGNPC
+- **Description:** Catch and donate 50 Wigglelittle to win their trust.
+- **Reward:** Gain the Disciple of Wigglelittle
+  - **Requirements:**
+    - Resource x50
+### Snapjaw Jr. Rescue
+- **Quest ID:** SnapjawJr
+- **NPC:** FISHINGNPC
+- **Description:** Catch and donate 50 Snapjaw Jr. to win their trust.
+- **Reward:** Gain the Disciple of Snapjaw Jr.
+  - **Requirements:**
+    - Resource x50
+### Flipzoid Rescue
+- **Quest ID:** Flipzoid
+- **NPC:** FISHINGNPC
+- **Description:** Catch and donate 50 Flipzoids to win their trust.
+- **Reward:** Gain the Disciple of Flipzoid
+  - **Requirements:**
+    - Resource x50
+### Niblet the Bold Rescue
+- **Quest ID:** NibletTheBold
+- **NPC:** FISHINGNPC
+- **Description:** Catch and donate 50 Niblet the Bold to win their trust.
+- **Reward:** Gain the Disciple of Niblet the Bold
+  - **Requirements:**
+    - Resource x50
+### Bloopicus Maximus Rescue
+- **Quest ID:** BloopicusMaximus
+- **NPC:** FISHINGNPC
+- **Description:** Catch and donate 50 Bloopicus Maximus to win their trust.
+- **Reward:** Gain the Disciple of Bloopicus Maximus
+  - **Requirements:**
+    - Resource x50
+
+## WOODCUTTINGNPC
+### Stick Stockpile
+- **Quest ID:** Stick
+- **NPC:** WOODCUTTINGNPC
+- **Description:** Gather 200 Sticks so WOODCUTTINGNPC can commune with the forest spirit.
+- **Reward:** Gain the Disciple of Stick
+  - **Requirements:**
+    - Resource x200
+### Feather Stockpile
+- **Quest ID:** Feather
+- **NPC:** WOODCUTTINGNPC
+- **Description:** Gather 100 Feathers so WOODCUTTINGNPC can commune with the forest spirit.
+- **Reward:** Gain the Disciple of Feather
+  - **Requirements:**
+    - Resource x100
+
+## FARMINGNPC
+### Corn Harvest Hope
+- **Quest ID:** Corn
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Corn to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Corn
+  - **Requirements:**
+    - Resource x100
+### Wheat Harvest Hope
+- **Quest ID:** Wheat
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Wheat to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Wheat
+  - **Requirements:**
+    - Resource x100
+### Wartermelone Harvest Hope
+- **Quest ID:** Wartermelone
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Wartermelone to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Wartermelone
+  - **Requirements:**
+    - Resource x100
+### Carrot Harvest Hope
+- **Quest ID:** Carrot
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Carrots to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Carrot
+  - **Requirements:**
+    - Resource x100
+### Spud Harvest Hope
+- **Quest ID:** Spud
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Spuds to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Spud
+  - **Requirements:**
+    - Resource x100
+### Tomato Harvest Hope
+- **Quest ID:** Tomato
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Tomatoes to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Tomato
+  - **Requirements:**
+    - Resource x100
+### Lettuce Harvest Hope
+- **Quest ID:** Lettuce
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Lettuce to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Lettuce
+  - **Requirements:**
+    - Resource x100
+### Cucumber Harvest Hope
+- **Quest ID:** Cucumber
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Cucumbers to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Cucumber
+  - **Requirements:**
+    - Resource x100
+### Onion Harvest Hope
+- **Quest ID:** Onion
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Onions to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Onion
+  - **Requirements:**
+    - Resource x100
+### Leek Harvest Hope
+- **Quest ID:** Leek
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Leeks to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Leek
+  - **Requirements:**
+    - Resource x100
+### Parsnip Harvest Hope
+- **Quest ID:** Parsnip
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Parsnips to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Parsnip
+  - **Requirements:**
+    - Resource x100
+### Pepper Harvest Hope
+- **Quest ID:** Pepper
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Peppers to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Pepper
+  - **Requirements:**
+    - Resource x100
+### Chillie Harvest Hope
+- **Quest ID:** Chillie
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Chillies to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Chillie
+  - **Requirements:**
+    - Resource x100
+### Pumking Harvest Hope
+- **Quest ID:** Pumking
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Pumkings to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Pumking
+  - **Requirements:**
+    - Resource x100
+### Strawberry Harvest Hope
+- **Quest ID:** Strawberry
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Strawberries to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Strawberry
+  - **Requirements:**
+    - Resource x100
+### Funion Harvest Hope
+- **Quest ID:** Funion
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Funions to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Funion
+  - **Requirements:**
+    - Resource x100
+### Turnip Harvest Hope
+- **Quest ID:** Turnip
+- **NPC:** FARMINGNPC
+- **Description:** Harvest and present 100 Turnips to inspire the crop spirit.
+- **Reward:** Gain the Disciple of Turnip
+  - **Requirements:**
+    - Resource x100
+
+## LOOTINGNPC
+### Bone Recall
+- **Quest ID:** Bone
+- **NPC:** LOOTINGNPC
+- **Description:** Retrieve 500 Bones from the field and offer them to LOOTINGNPC.
+- **Reward:** Gain the Disciple of Bone
+  - **Requirements:**
+    - Resource x500
+### Leather Recall
+- **Quest ID:** Leather
+- **NPC:** LOOTINGNPC
+- **Description:** Retrieve 250 Leather from the field and offer them to LOOTINGNPC.
+- **Reward:** Gain the Disciple of Leather
+  - **Requirements:**
+    - Resource x250


### PR DESCRIPTION
## Summary
- create QuestData assets for new MININGNPC, FISHINGNPC, WOODCUTTINGNPC, FARMINGNPC, and LOOTINGNPC quests
- document these quests in `QUESTS_SUMMARY.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ad746e440832e9d87714531999630