### PR TITLE
Add additional disciple assets

### DIFF
--- a/Assets/Resources/Disciples/Bloopicus Maximus.asset
+++ b/Assets/Resources/Disciples/Bloopicus Maximus.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Bloopicus Maximus
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 289297afb43756445933dca5ff8d7138, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 8fdf8cf6e7c34831a086fd75c4371beb, type: 2}
+  generationInterval: 120

--- a/Assets/Resources/Disciples/Bloopicus Maximus.asset.meta
+++ b/Assets/Resources/Disciples/Bloopicus Maximus.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80d20e1b70564d1ca907fa988a95cbdf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Bone.asset
+++ b/Assets/Resources/Disciples/Bone.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Bone
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: b448067cd3b40aa478fb72e658eee42b, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: d01f4a93a6144c329b3d8b6fe53588c8, type: 2}
+  generationInterval: 180

--- a/Assets/Resources/Disciples/Bone.asset.meta
+++ b/Assets/Resources/Disciples/Bone.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 89bdc7b5e6d9445691112729152a3628
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Carrot.asset
+++ b/Assets/Resources/Disciples/Carrot.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Carrot
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 9e342e09a47b4014ab320cc6d06a2a3d, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 299dd56fdf6c4f46a2ba0c9ce54134b3, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Carrot.asset.meta
+++ b/Assets/Resources/Disciples/Carrot.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d0638c81d0447f6bf6705a455ebbe1e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Chillie.asset
+++ b/Assets/Resources/Disciples/Chillie.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Chillie
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 52b45ffed04e559418584d82175340a6, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: b42f62b9f4cc4bc4b2a511adf4b80b47, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Chillie.asset.meta
+++ b/Assets/Resources/Disciples/Chillie.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7c328cfa2a241989de4a6058d5d00a1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Copium Crystal.asset
+++ b/Assets/Resources/Disciples/Copium Crystal.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Copium Crystal
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: c57a924f0ab50614ca64ef288331eec2, type: 2}
+    amount: 1
+  requiredQuest: {fileID: 11400000, guid: ed6f2114af7849899e821eeab0b9cc11, type: 2}
+  generationInterval: 900

--- a/Assets/Resources/Disciples/Copium Crystal.asset.meta
+++ b/Assets/Resources/Disciples/Copium Crystal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 67500f45a53845569ae72b99acf7de59
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Copium.asset
+++ b/Assets/Resources/Disciples/Copium.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Copium
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: cd0c8986dc3857640bf78c2cb3734d8e, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: dd04b53062214f99ab499ed61526f6a4, type: 2}
+  generationInterval: 600

--- a/Assets/Resources/Disciples/Copium.asset.meta
+++ b/Assets/Resources/Disciples/Copium.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b6d6239eaf249a5bea22f46f41682e9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Corn.asset
+++ b/Assets/Resources/Disciples/Corn.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Corn
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 1fd4ff0f627126a4a8ca50ea71793823, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 2e4539a46ec54a6d90649879059b2af0, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Corn.asset.meta
+++ b/Assets/Resources/Disciples/Corn.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 495017d9374e47bdabc79d7c8aa47cbd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Cucumber.asset
+++ b/Assets/Resources/Disciples/Cucumber.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Cucumber
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 5eaebeeea7cd85948922c1bcab927ca6, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 63132c136be84bcb8e37cb2c7beaa70b, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Cucumber.asset.meta
+++ b/Assets/Resources/Disciples/Cucumber.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c9864b68dc646658267782d0f05d0f2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Dlog Crystal.asset
+++ b/Assets/Resources/Disciples/Dlog Crystal.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Dlog Crystal
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 2ebd59f743307bc4ca7a7d1e55491b6c, type: 2}
+    amount: 1
+  requiredQuest: {fileID: 11400000, guid: 9daec8cdc30544cc8f05c2d1f40de027, type: 2}
+  generationInterval: 900

--- a/Assets/Resources/Disciples/Dlog Crystal.asset.meta
+++ b/Assets/Resources/Disciples/Dlog Crystal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66feef7b7c1c40289fbf022e1aec5406
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Dlog.asset
+++ b/Assets/Resources/Disciples/Dlog.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Dlog
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 72499b5ec8c98a143937cc737473baa8, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: f36100e6a0b6498cacc8700a2141020d, type: 2}
+  generationInterval: 600

--- a/Assets/Resources/Disciples/Dlog.asset.meta
+++ b/Assets/Resources/Disciples/Dlog.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49b7e8915a59405280cc0bf55b1c5432
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Erif Crystal.asset
+++ b/Assets/Resources/Disciples/Erif Crystal.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Erif Crystal
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 01a714e515d3f4f40aca69459d70c9a3, type: 2}
+    amount: 1
+  requiredQuest: {fileID: 11400000, guid: 9696a1958c9543fb871ba153e1643097, type: 2}
+  generationInterval: 900

--- a/Assets/Resources/Disciples/Erif Crystal.asset.meta
+++ b/Assets/Resources/Disciples/Erif Crystal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e4c7ba16372470ba5772c3bec7ebc68
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Erif.asset
+++ b/Assets/Resources/Disciples/Erif.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Erif
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: d2f56fea92ca73547975b06c9e6ef130, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 2935248e3b8945549be5de2d7f258d0a, type: 2}
+  generationInterval: 600

--- a/Assets/Resources/Disciples/Erif.asset.meta
+++ b/Assets/Resources/Disciples/Erif.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52e58249562b4a888e21c218ca616a17
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Eznorb Crystal.asset
+++ b/Assets/Resources/Disciples/Eznorb Crystal.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Eznorb Crystal
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: eac487199cf71634491bac5855d2e4f5, type: 2}
+    amount: 1
+  requiredQuest: {fileID: 11400000, guid: 95d3b7ad0fe4431eaffcdc8363fbc291, type: 2}
+  generationInterval: 900

--- a/Assets/Resources/Disciples/Eznorb Crystal.asset.meta
+++ b/Assets/Resources/Disciples/Eznorb Crystal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9837f688e33476ba37f778a804ae8b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Eznorb.asset
+++ b/Assets/Resources/Disciples/Eznorb.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Eznorb
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: f9dad579683f8b343b6db9ed58886a07, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 5265b1c5507642509053388be9525c1b, type: 2}
+  generationInterval: 600

--- a/Assets/Resources/Disciples/Eznorb.asset.meta
+++ b/Assets/Resources/Disciples/Eznorb.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3942732828504873b59fc03e65ddcc5e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Feather.asset
+++ b/Assets/Resources/Disciples/Feather.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Feather
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 9b8342747b02439438dbacd529ed8931, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 6c98c49b44154f42982a0521be9ee5cc, type: 2}
+  generationInterval: 60

--- a/Assets/Resources/Disciples/Feather.asset.meta
+++ b/Assets/Resources/Disciples/Feather.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e818f87efc524432a6c9df5b09bc8cb0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Flipzoid.asset
+++ b/Assets/Resources/Disciples/Flipzoid.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Flipzoid
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: c906b6628db99c14d94b3b43d531523f, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 1264e01acba8408086f886ee7ffe314c, type: 2}
+  generationInterval: 120

--- a/Assets/Resources/Disciples/Flipzoid.asset.meta
+++ b/Assets/Resources/Disciples/Flipzoid.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1429db69d9c545149f61e81fb1b95ada
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Funion.asset
+++ b/Assets/Resources/Disciples/Funion.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Funion
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: b4981418ea008e74f8918c87bac15573, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 8da9a6e1d21d4e9c996c570e171386dd, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Funion.asset.meta
+++ b/Assets/Resources/Disciples/Funion.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 55ae3fdc37ba4744a38b764f3a74721c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Idle Crystal.asset
+++ b/Assets/Resources/Disciples/Idle Crystal.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Idle Crystal
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: bec6646bec02be748b6325fa80cb6655, type: 2}
+    amount: 1
+  requiredQuest: {fileID: 11400000, guid: 8759034400ef4bc7b3d53b575e8807bf, type: 2}
+  generationInterval: 900

--- a/Assets/Resources/Disciples/Idle Crystal.asset.meta
+++ b/Assets/Resources/Disciples/Idle Crystal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1626825d5fd84a19af6ac265ff9fe570
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Idle.asset
+++ b/Assets/Resources/Disciples/Idle.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Idle
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 25f9be8c6652e39409f68e3fdea67577, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 20baaf688b8e4fb997ed21fb66e9a449, type: 2}
+  generationInterval: 600

--- a/Assets/Resources/Disciples/Idle.asset.meta
+++ b/Assets/Resources/Disciples/Idle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3cb5a4456b974f46967a1649ba1867e3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Leather.asset
+++ b/Assets/Resources/Disciples/Leather.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Leather
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 0d0c0d6eb92c2314596c9d8b51935653, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 34902807f66d4ce1b882bae68a43dce3, type: 2}
+  generationInterval: 180

--- a/Assets/Resources/Disciples/Leather.asset.meta
+++ b/Assets/Resources/Disciples/Leather.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4967996f48be440aa6ed130454cb7bcf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Leek.asset
+++ b/Assets/Resources/Disciples/Leek.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Leek
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 92206defd8abd854c835604fc2ebfc33, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: eeb83a9d24684f268c13f0f594b4f6b6, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Leek.asset.meta
+++ b/Assets/Resources/Disciples/Leek.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10bf5c9b7c9d4333ae8d4a8ab98fbc41
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Lettuce.asset
+++ b/Assets/Resources/Disciples/Lettuce.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Lettuce
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 49595052db28a8e48a4eb1fa7d04b7f6, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: d127e8e24879479db87e9c6e51a90a9b, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Lettuce.asset.meta
+++ b/Assets/Resources/Disciples/Lettuce.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52fa3ce3ef4443399a1ed7a9103d315c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Lirium Crystal.asset
+++ b/Assets/Resources/Disciples/Lirium Crystal.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Lirium Crystal
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 3fc88fefd277cff43ba21a4816fd993c, type: 2}
+    amount: 1
+  requiredQuest: {fileID: 11400000, guid: f4577769316843a08fa0ce3d14f0f2c9, type: 2}
+  generationInterval: 900

--- a/Assets/Resources/Disciples/Lirium Crystal.asset.meta
+++ b/Assets/Resources/Disciples/Lirium Crystal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 418801cac16744c68765e26ff4bfc0b8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Lirium.asset
+++ b/Assets/Resources/Disciples/Lirium.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Lirium
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 82c11950e343dcf4eb8b405b27ea5ee4, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 484a25581e3544c6961cbf0f1ce20245, type: 2}
+  generationInterval: 600

--- a/Assets/Resources/Disciples/Lirium.asset.meta
+++ b/Assets/Resources/Disciples/Lirium.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8fbce09c607454dae117efe2e29a7a1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Muddy Muck Muncher.asset
+++ b/Assets/Resources/Disciples/Muddy Muck Muncher.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Muddy Muck Muncher
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 457dbb132eac48d429163353adb4b532, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 81c2c03c7f8c4a02ab869ca6673b88ea, type: 2}
+  generationInterval: 120

--- a/Assets/Resources/Disciples/Muddy Muck Muncher.asset.meta
+++ b/Assets/Resources/Disciples/Muddy Muck Muncher.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: be190da634bc4a27a8e28b0553fbe6d2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Niblet the Bold.asset
+++ b/Assets/Resources/Disciples/Niblet the Bold.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Niblet the Bold
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 25caf48dcc8c9d64d9b2927980cfa324, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 149952db83624f68a5d69f8ffbf3919e, type: 2}
+  generationInterval: 120

--- a/Assets/Resources/Disciples/Niblet the Bold.asset.meta
+++ b/Assets/Resources/Disciples/Niblet the Bold.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63ed806001e84d1e80b769c3156afd60
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Nori Crystal.asset
+++ b/Assets/Resources/Disciples/Nori Crystal.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Nori Crystal
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 183f7bb9228fc354681abf509895d03f, type: 2}
+    amount: 1
+  requiredQuest: {fileID: 11400000, guid: 52b78ae1f4c34b698b85a0bc48fc9d71, type: 2}
+  generationInterval: 900

--- a/Assets/Resources/Disciples/Nori Crystal.asset.meta
+++ b/Assets/Resources/Disciples/Nori Crystal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b0af6446fdb45689693a4ab07a2fb7b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Nori.asset
+++ b/Assets/Resources/Disciples/Nori.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Nori
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 697cde1431421814ba3219fab35f6cf9, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 8b52aa3e7542466e8e40d302b3293cdb, type: 2}
+  generationInterval: 600

--- a/Assets/Resources/Disciples/Nori.asset.meta
+++ b/Assets/Resources/Disciples/Nori.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea56c5fd13654407aca2bece31a53206
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Onion.asset
+++ b/Assets/Resources/Disciples/Onion.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Onion
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: b5b12e283249229419b1a300192d8601, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 87abd56902144b1dadb888cbe0725f6e, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Onion.asset.meta
+++ b/Assets/Resources/Disciples/Onion.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a4463ad1b2ce4e08a47cbd059c1fb23a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Parsnip.asset
+++ b/Assets/Resources/Disciples/Parsnip.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Parsnip
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: fb12ddb33d729bf48a519c61510dca6a, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 55788ebec3e1482b84b4a3b78dcf71c4, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Parsnip.asset.meta
+++ b/Assets/Resources/Disciples/Parsnip.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d6b00213c524a03b2d41d7b167257c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Pepper.asset
+++ b/Assets/Resources/Disciples/Pepper.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Pepper
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: db783fe988c6728428405a8c18c3f5d8, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: fe2ce9e6ea8a418281ecbe6848e2a57b, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Pepper.asset.meta
+++ b/Assets/Resources/Disciples/Pepper.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a029aced5de46c8b3fbf6d7f9b4cd3f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Pumking.asset
+++ b/Assets/Resources/Disciples/Pumking.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Pumking
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: c11abbf84f4141844b21de6f7af929ea, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 859bb4c70e524cb0a25939c862d10120, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Pumking.asset.meta
+++ b/Assets/Resources/Disciples/Pumking.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a494cac5c6846cfaf7411d9f7c76da1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Sir Splashford III.asset
+++ b/Assets/Resources/Disciples/Sir Splashford III.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Sir Splashford III
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 59c67a9fee0efc84997a60754c5f02ba, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: d51676891e60418fb086260a64a8e067, type: 2}
+  generationInterval: 120

--- a/Assets/Resources/Disciples/Sir Splashford III.asset.meta
+++ b/Assets/Resources/Disciples/Sir Splashford III.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8b15f1194f848a59f7ac9e989f7b51f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Snapjaw Jr..asset
+++ b/Assets/Resources/Disciples/Snapjaw Jr..asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Snapjaw Jr.
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: bf23b8a0a0d501543b9e7310db929300, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: f10925eb2d4f4d8a949dd8688d8e9d9b, type: 2}
+  generationInterval: 120

--- a/Assets/Resources/Disciples/Snapjaw Jr..asset.meta
+++ b/Assets/Resources/Disciples/Snapjaw Jr..asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c124a633aa8447b8ec1067d9f2e7f29
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Spud.asset
+++ b/Assets/Resources/Disciples/Spud.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Spud
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: fd0a53a91094b2b4da64fec1b7c7bace, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 9a289dbcc84c4cf9a655456d6f0ec3a9, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Spud.asset.meta
+++ b/Assets/Resources/Disciples/Spud.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3798657823124276b972201fb35d11a5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Stick.asset
+++ b/Assets/Resources/Disciples/Stick.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Stick
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 024c1162874b64e43be92b8892b40efb, type: 2}
+    amount: 10
+  requiredQuest: {fileID: 11400000, guid: 5fef0b4c45a547368d145ae335051a5f, type: 2}
+  generationInterval: 60

--- a/Assets/Resources/Disciples/Stick.asset.meta
+++ b/Assets/Resources/Disciples/Stick.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab5156eefa814b7f8815fca599398d72
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Stone.asset
+++ b/Assets/Resources/Disciples/Stone.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Stone
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 5bbcfec123bdb15458219aa5fcddc841, type: 2}
+    amount: 10
+  requiredQuest: {fileID: 11400000, guid: 6f1974c562d242adb1ead00cc828bf8a, type: 2}
+  generationInterval: 120

--- a/Assets/Resources/Disciples/Stone.asset.meta
+++ b/Assets/Resources/Disciples/Stone.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb2636a3f9b54d6aa4788a36fbe33d48
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Strawberry.asset
+++ b/Assets/Resources/Disciples/Strawberry.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Strawberry
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: dcd8ad1628b899a48847deb1cb2b3739, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: f9201696220a43f3894f210eb3b4e416, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Strawberry.asset.meta
+++ b/Assets/Resources/Disciples/Strawberry.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e541c423cba446f99289b9196198255b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Tomato.asset
+++ b/Assets/Resources/Disciples/Tomato.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Tomato
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: e8e8a19bb4573f540a00a6d78dddd0db, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 5a8deab080374f1db840b6c30e777ade, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Tomato.asset.meta
+++ b/Assets/Resources/Disciples/Tomato.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48da4a0bdf634dc69e56c6b28d6e4c33
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Turnip.asset
+++ b/Assets/Resources/Disciples/Turnip.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Turnip
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 420847cbb07e26640a57575ee30d5120, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 6780ea978db14e2382604414b9809001, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Turnip.asset.meta
+++ b/Assets/Resources/Disciples/Turnip.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 83d79d3612fb452c85b99bc52f416dc2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Vastium Crystal.asset
+++ b/Assets/Resources/Disciples/Vastium Crystal.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Vastium Crystal
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 4559fb45d6ad98246b96535dd6a04349, type: 2}
+    amount: 1
+  requiredQuest: {fileID: 11400000, guid: a6f045aa8e994f2dbfd744f013d3614e, type: 2}
+  generationInterval: 900

--- a/Assets/Resources/Disciples/Vastium Crystal.asset.meta
+++ b/Assets/Resources/Disciples/Vastium Crystal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f0b34c88c8cf4eb1911517b206792994
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Vastium.asset
+++ b/Assets/Resources/Disciples/Vastium.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Vastium
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: b44e0d1f8e117ba4d8816e75c36fab21, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 816d2bc6207b4166985b96096ded2ce8, type: 2}
+  generationInterval: 600

--- a/Assets/Resources/Disciples/Vastium.asset.meta
+++ b/Assets/Resources/Disciples/Vastium.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b49c392304104e738eb43c5a20059055
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Wartermelone.asset
+++ b/Assets/Resources/Disciples/Wartermelone.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Wartermelone
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: ae1b523394ff9eb49866f20982e4c68d, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 66c8f62ac1804f39a5680b0e8aeed6c9, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Wartermelone.asset.meta
+++ b/Assets/Resources/Disciples/Wartermelone.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f85100b3f3814011af9e617902225ec4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Wheat.asset
+++ b/Assets/Resources/Disciples/Wheat.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Wheat
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: 9e0063ffd6091384fba5f8a233b51808, type: 2}
+    amount: 5
+  requiredQuest: {fileID: 11400000, guid: 7c401b02ff71468ea5e6625028fd3482, type: 2}
+  generationInterval: 300

--- a/Assets/Resources/Disciples/Wheat.asset.meta
+++ b/Assets/Resources/Disciples/Wheat.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b732fdf13c9a4a7b95ab59249739fbf4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Resources/Disciples/Wigglelittle.asset
+++ b/Assets/Resources/Disciples/Wigglelittle.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf4798b78fe46a04a8303222d6541b8f, type: 3}
+  m_Name: Wigglelittle
+  m_EditorClassIdentifier:
+  resources:
+  - resource: {fileID: 11400000, guid: c6baa65f60afab548b279c321897df99, type: 2}
+    amount: 2
+  requiredQuest: {fileID: 11400000, guid: 301545a0218c45109de16a9742a698ce, type: 2}
+  generationInterval: 120

--- a/Assets/Resources/Disciples/Wigglelittle.asset.meta
+++ b/Assets/Resources/Disciples/Wigglelittle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1fdd5559cd64cb4b474c469ca54e497
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Documentation/DISCIPLES_SUMMARY.md
+++ b/Documentation/DISCIPLES_SUMMARY.md
@@ -14,3 +14,229 @@
 - **Resource:** Slime x10
 - **Generation Interval:** 60s
 - **Requires:** Flip That Flop
+
+### Stick
+- **Resource:** Stick x10
+- **Generation Interval:** 60s
+- **Requires:** Stick Stockpile
+
+### Feather
+- **Resource:** Feather x5
+- **Generation Interval:** 60s
+- **Requires:** Feather Stockpile
+
+### Stone
+- **Resource:** Stone x10
+- **Generation Interval:** 120s
+- **Requires:** Stone Salvation
+
+### Eznorb
+- **Resource:** Eznorb Chunks x2
+- **Generation Interval:** 600s
+- **Requires:** Eznorb Foundation
+
+### Nori
+- **Resource:** Nori Chunks x2
+- **Generation Interval:** 600s
+- **Requires:** Nori Foundation
+
+### Dlog
+- **Resource:** Dlog Chunks x2
+- **Generation Interval:** 600s
+- **Requires:** Dlog Foundation
+
+### Erif
+- **Resource:** Erif Chunks x2
+- **Generation Interval:** 600s
+- **Requires:** Erif Foundation
+
+### Lirium
+- **Resource:** Lirium Chunks x2
+- **Generation Interval:** 600s
+- **Requires:** Lirium Foundation
+
+### Copium
+- **Resource:** Copium Chunks x2
+- **Generation Interval:** 600s
+- **Requires:** Copium Foundation
+
+### Idle
+- **Resource:** Idle Chunks x2
+- **Generation Interval:** 600s
+- **Requires:** Idle Foundation
+
+### Vastium
+- **Resource:** Vastium Chunks x2
+- **Generation Interval:** 600s
+- **Requires:** Vastium Foundation
+
+### Eznorb Crystal
+- **Resource:** Eznorb Crystal x1
+- **Generation Interval:** 900s
+- **Requires:** Eznorb Resonance
+
+### Nori Crystal
+- **Resource:** Nori Crystal x1
+- **Generation Interval:** 900s
+- **Requires:** Nori Resonance
+
+### Dlog Crystal
+- **Resource:** Dlog Crystal x1
+- **Generation Interval:** 900s
+- **Requires:** Dlog Resonance
+
+### Erif Crystal
+- **Resource:** Erif Crystal x1
+- **Generation Interval:** 900s
+- **Requires:** Erif Resonance
+
+### Lirium Crystal
+- **Resource:** Lirium Crystal x1
+- **Generation Interval:** 900s
+- **Requires:** Lirium Resonance
+
+### Copium Crystal
+- **Resource:** Copium Crystal x1
+- **Generation Interval:** 900s
+- **Requires:** Copium Resonance
+
+### Idle Crystal
+- **Resource:** Idle Crystal x1
+- **Generation Interval:** 900s
+- **Requires:** Idle Resonance
+
+### Vastium Crystal
+- **Resource:** Vastium Crystal x1
+- **Generation Interval:** 900s
+- **Requires:** Vastium Resonance
+
+### Muddy Muck Muncher
+- **Resource:** Muddy Muck Muncher x2
+- **Generation Interval:** 120s
+- **Requires:** Muddy Muck Muncher Rescue
+
+### Sir Splashford III
+- **Resource:** Sir Splashford III x2
+- **Generation Interval:** 120s
+- **Requires:** Sir Splashford III Rescue
+
+### Wigglelittle
+- **Resource:** Wigglelittle x2
+- **Generation Interval:** 120s
+- **Requires:** Wigglelittle Rescue
+
+### Snapjaw Jr.
+- **Resource:** Snapjaw Jr. x2
+- **Generation Interval:** 120s
+- **Requires:** Snapjaw Jr. Rescue
+
+### Flipzoid
+- **Resource:** Flipzoid x2
+- **Generation Interval:** 120s
+- **Requires:** Flipzoid Rescue
+
+### Niblet the Bold
+- **Resource:** Niblet the Bold x2
+- **Generation Interval:** 120s
+- **Requires:** Niblet the Bold Rescue
+
+### Bloopicus Maximus
+- **Resource:** Bloopicus Maximus x2
+- **Generation Interval:** 120s
+- **Requires:** Bloopicus Maximus Rescue
+
+### Corn
+- **Resource:** Corn x5
+- **Generation Interval:** 300s
+- **Requires:** Corn Harvest Hope
+
+### Wheat
+- **Resource:** Wheat x5
+- **Generation Interval:** 300s
+- **Requires:** Wheat Harvest Hope
+
+### Wartermelone
+- **Resource:** Wartermelone x5
+- **Generation Interval:** 300s
+- **Requires:** Wartermelone Harvest Hope
+
+### Carrot
+- **Resource:** Carrot x5
+- **Generation Interval:** 300s
+- **Requires:** Carrot Harvest Hope
+
+### Spud
+- **Resource:** Spud x5
+- **Generation Interval:** 300s
+- **Requires:** Spud Harvest Hope
+
+### Tomato
+- **Resource:** Tomato x5
+- **Generation Interval:** 300s
+- **Requires:** Tomato Harvest Hope
+
+### Lettuce
+- **Resource:** Lettuce x5
+- **Generation Interval:** 300s
+- **Requires:** Lettuce Harvest Hope
+
+### Cucumber
+- **Resource:** Cucumber x5
+- **Generation Interval:** 300s
+- **Requires:** Cucumber Harvest Hope
+
+### Onion
+- **Resource:** Onion x5
+- **Generation Interval:** 300s
+- **Requires:** Onion Harvest Hope
+
+### Leek
+- **Resource:** Leek x5
+- **Generation Interval:** 300s
+- **Requires:** Leek Harvest Hope
+
+### Parsnip
+- **Resource:** Parsnip x5
+- **Generation Interval:** 300s
+- **Requires:** Parsnip Harvest Hope
+
+### Pepper
+- **Resource:** Pepper x5
+- **Generation Interval:** 300s
+- **Requires:** Pepper Harvest Hope
+
+### Chillie
+- **Resource:** Chillie x5
+- **Generation Interval:** 300s
+- **Requires:** Chillie Harvest Hope
+
+### Pumking
+- **Resource:** Pumking x5
+- **Generation Interval:** 300s
+- **Requires:** Pumking Harvest Hope
+
+### Strawberry
+- **Resource:** Strawberry x5
+- **Generation Interval:** 300s
+- **Requires:** Strawberry Harvest Hope
+
+### Funion
+- **Resource:** Funion x5
+- **Generation Interval:** 300s
+- **Requires:** Funion Harvest Hope
+
+### Turnip
+- **Resource:** Turnip x5
+- **Generation Interval:** 300s
+- **Requires:** Turnip Harvest Hope
+
+### Bone
+- **Resource:** Bone x5
+- **Generation Interval:** 180s
+- **Requires:** Bone Recall
+
+### Leather
+- **Resource:** Leather x2
+- **Generation Interval:** 180s
+- **Requires:** Leather Recall
+


### PR DESCRIPTION
## Summary
- add asset files for Stick, Feather, Stone and many other disciples
- update `DISCIPLES_SUMMARY.md` with disciple configuration details

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687adb6f8f80832e819e9e0d5a068caf