### PR TITLE
Implement Echo milestone feature

### DIFF
--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using TimelessEchoes.Skills;
+using TimelessEchoes.Tasks;
+using UnityEngine;
+
+namespace TimelessEchoes.Hero
+{
+    /// <summary>
+    /// Controls Echo behaviour and lifetime.
+    /// </summary>
+    public class EchoController : MonoBehaviour
+    {
+        public Skill targetSkill;
+        public float lifetime = 10f;
+
+        private HeroController hero;
+        private TaskController taskController;
+        private float remaining;
+
+        private void Awake()
+        {
+            hero = GetComponent<HeroController>();
+            taskController = GetComponentInParent<TaskController>();
+            remaining = lifetime;
+        }
+
+        private void OnEnable()
+        {
+            if (hero != null && taskController != null)
+                taskController.SelectEarliestTask(hero, targetSkill);
+        }
+
+        private void Update()
+        {
+            remaining -= Time.deltaTime;
+            if (remaining <= 0f)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            if (taskController != null && targetSkill != null)
+            {
+                bool hasTask = taskController.tasks.Any(t => t is BaseTask b &&
+                                                            b.associatedSkill == targetSkill &&
+                                                            !t.IsComplete());
+                if (!hasTask)
+                    Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+using TimelessEchoes.Skills;
+
+namespace TimelessEchoes.Hero
+{
+    /// <summary>
+    /// Utility for spawning Echo helpers.
+    /// </summary>
+    public static class EchoManager
+    {
+        public static HeroController SpawnEcho(GameObject prefab, Skill skill, float duration)
+        {
+            var hero = HeroController.Instance;
+            if (hero == null)
+                return null;
+
+            HeroController.PrepareForClone();
+            GameObject obj = prefab != null ?
+                Object.Instantiate(prefab, hero.transform.position, hero.transform.rotation, hero.transform.parent) :
+                Object.Instantiate(hero.gameObject, hero.transform.position, hero.transform.rotation, hero.transform.parent);
+
+            var clone = obj.GetComponent<HeroController>();
+            if (clone != null)
+            {
+                foreach (var r in obj.GetComponentsInChildren<SpriteRenderer>())
+                {
+                    var c = r.color;
+                    c.a = 0.7f;
+                    r.color = c;
+                }
+
+                var hp = clone.GetComponent<HeroHealth>();
+                if (hp != null)
+                {
+                    hp.Immortal = true;
+                    hp.Init((int)hp.MaxHealth);
+                }
+
+                var echo = obj.AddComponent<EchoController>();
+                echo.targetSkill = skill;
+                echo.lifetime = duration;
+            }
+
+            return clone;
+        }
+    }
+}

--- a/Assets/Scripts/Skills/MilestoneBonus.cs
+++ b/Assets/Scripts/Skills/MilestoneBonus.cs
@@ -10,7 +10,8 @@ namespace TimelessEchoes.Skills
         InstantKill,
         DoubleResources,
         DoubleXP,
-        StatIncrease
+        StatIncrease,
+        SpawnEcho
     }
 
     [Serializable]
@@ -21,6 +22,14 @@ namespace TimelessEchoes.Skills
         public string bonusID;
 
         public MilestoneType type;
+
+        [ShowIf("type", MilestoneType.SpawnEcho)]
+        public GameObject echoPrefab;
+        [ShowIf("type", MilestoneType.SpawnEcho)]
+        public Skill targetSkill;
+        [ShowIf("type", MilestoneType.SpawnEcho)]
+        [Min(0f)]
+        public float echoDuration = 10f;
 
         [Range(0f, 1f)]
         [HideIf("type", MilestoneType.StatIncrease)]
@@ -62,6 +71,8 @@ namespace TimelessEchoes.Skills
                     if (statAmount != 0f)
                         amountText = percentBonus ? $" by {statAmount * 100f:0.#}%" : $" by {statAmount:0.#}";
                     return $"Increases {statName}{amountText}.";
+                case MilestoneType.SpawnEcho:
+                    return $"Provides a {chance * 100f:0.#}% chance to summon an Echo that performs {targetSkill?.skillName ?? skillName} tasks for {echoDuration:0.#} seconds.";
                 default:
                     return string.Empty;
             }

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -111,6 +111,24 @@ namespace TimelessEchoes.Tasks
 
             controller?.AddExperience(associatedSkill, amount);
             lastGrantedXp = amount;
+
+            if (controller != null && associatedSkill != null)
+            {
+                var progress = controller.GetProgress(associatedSkill);
+                if (progress != null)
+                {
+                    foreach (var id in progress.Milestones)
+                    {
+                        var ms = associatedSkill.milestones.Find(m => m.bonusID == id);
+                        if (ms != null && ms.type == MilestoneType.SpawnEcho && UnityEngine.Random.value <= ms.chance)
+                        {
+                            var skill = ms.targetSkill != null ? ms.targetSkill : associatedSkill;
+                            EchoManager.SpawnEcho(ms.echoPrefab, skill, ms.echoDuration);
+                        }
+                    }
+                }
+            }
+
             return amount;
         }
     }}

--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -275,6 +275,12 @@ namespace TimelessEchoes.Tasks
 
         public void SelectEarliestTask(HeroController targetHero)
         {
+            Skill filter = targetHero != null ? targetHero.GetComponent<TimelessEchoes.Hero.EchoController>()?.targetSkill : null;
+            SelectEarliestTask(targetHero, filter);
+        }
+
+        public void SelectEarliestTask(HeroController targetHero, Skill requiredSkill)
+        {
             if (targetHero == null)
             {
                 Log("SelectEarliestTask called but hero is null", TELogCategory.Task, this);
@@ -290,6 +296,8 @@ namespace TimelessEchoes.Tasks
                 if (task is BaseTask baseTask)
                 {
                     if (baseTask.ClaimedBy != null && baseTask.ClaimedBy != targetHero)
+                        continue;
+                    if (requiredSkill != null && baseTask.associatedSkill != requiredSkill)
                         continue;
                 }
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ If an enemy enters the hero's vision range the hero automatically engages in
 combat using projectile attacks. Combat strength and movement speed are
 modified by stat upgrades.
 
+## Echoes
+Clones spawned by milestones are referred to as **Echoes**. An Echo performs
+tasks of a specified skill for a limited time when summoned.
+
 ## Tasks
 Task scripts can be found under `Assets/Scripts/Tasks`. A `TaskController`
 builds the task list from assigned objects or from a `ProceduralTaskGenerator`.


### PR DESCRIPTION
## Summary
- extend `MilestoneType` with `SpawnEcho` and add related fields
- spawn Echo clones via new `EchoManager` and `EchoController`
- allow task selection filtering by skill
- spawn Echoes on task completion via milestones
- document Echoes in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b3e3816b0832e8cc6bc785dd29ef0