### PR TITLE
Fix Echo clones not ignoring tasks and affecting buffs

### DIFF
--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -26,7 +26,20 @@ namespace TimelessEchoes.Hero
 
         private void OnEnable()
         {
-            if (hero != null && taskController != null)
+            if (hero != null && taskController != null && targetSkill != null)
+                taskController.SelectEarliestTask(hero, targetSkill);
+        }
+
+        /// <summary>
+        /// Configure the echo after it is spawned.
+        /// </summary>
+        public void Init(Skill skill, float duration)
+        {
+            targetSkill = skill;
+            lifetime = duration;
+            remaining = duration;
+
+            if (isActiveAndEnabled && hero != null && taskController != null)
                 taskController.SelectEarliestTask(hero, targetSkill);
         }
 

--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -37,8 +37,7 @@ namespace TimelessEchoes.Hero
                 clone.AllowAttacks = false;
 
                 var echo = obj.AddComponent<EchoController>();
-                echo.targetSkill = skill;
-                echo.lifetime = duration;
+                echo.Init(skill, duration);
             }
 
             return clone;

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -178,7 +178,8 @@ namespace TimelessEchoes.Hero
 
         private void Update()
         {
-            BuffManager.Instance?.Tick(Time.deltaTime);
+            if (!IsClone)
+                BuffManager.Instance?.Tick(Time.deltaTime);
             if (stats != null)
                 ai.maxSpeed = (baseMoveSpeed + moveSpeedBonus) *
                               (buffController != null ? buffController.MoveSpeedMultiplier : 1f);
@@ -214,7 +215,8 @@ namespace TimelessEchoes.Hero
                     Log("BuffManager missing", TELogCategory.Buff, this);
             }
 
-            buffController?.Resume();
+            if (!IsClone)
+                buffController?.Resume();
 
             if (mapUI == null)
                 mapUI = FindFirstObjectByType<MapUI>();
@@ -241,24 +243,27 @@ namespace TimelessEchoes.Hero
             lastAttack = Time.time - 1f / CurrentAttackRate;
 
             var skillController = SkillController.Instance;
-            if (skillController != null)
+            if (!IsClone && skillController != null)
                 skillController.OnMilestoneUnlocked += OnMilestoneUnlocked;
 
-            Enemy.OnEngage += OnEnemyEngage;
+            if (!IsClone)
+                Enemy.OnEngage += OnEnemyEngage;
         }
 
         private void OnDisable()
         {
-            buffController?.Pause();
+            if (!IsClone)
+                buffController?.Pause();
 
             if (CurrentTask is BaseTask baseTask)
                 baseTask.ReleaseClaim(this);
 
             var skillController = SkillController.Instance;
-            if (skillController != null)
+            if (!IsClone && skillController != null)
                 skillController.OnMilestoneUnlocked -= OnMilestoneUnlocked;
 
-            Enemy.OnEngage -= OnEnemyEngage;
+            if (!IsClone)
+                Enemy.OnEngage -= OnEnemyEngage;
         }
 
         private void OnDestroy()

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -98,6 +98,8 @@ namespace TimelessEchoes.Tasks
         protected float GrantCompletionXP()
         {
             lastGrantedXp = 0f;
+            if (claimedBy != null && claimedBy.IsClone)
+                return 0f;
             if (associatedSkill == null || taskData == null || taskData.xpForCompletion <= 0f)
                 return 0f;
 


### PR DESCRIPTION
## Summary
- prevent EchoController from selecting tasks before being initialized
- add configuration method to properly assign echo skill and duration
- skip buff timer ticks and enemy events for clone heroes
- avoid granting XP or spawning echoes when a clone completes a task

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b47975b7c832eb7c906bc4c1fb72c