### PR TITLE
Refactor clone terminology

### DIFF
--- a/Assets/Resources/Buffs/MoveSpeed.asset
+++ b/Assets/Resources/Buffs/MoveSpeed.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   description: Increases Movespeed by 40% for its duration.
   buffIcon: {fileID: -5882155960153656733, guid: 75e6aad650cc46242a07d1d673daedeb, type: 3}
   baseDuration: 120
-  cloneCount: 1
+  echoCount: 1
   moveSpeedPercent: 40
   damagePercent: 0
   defensePercent: 0

--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -24,16 +24,16 @@ namespace TimelessEchoes.Buffs
         private readonly List<ActiveBuff> activeBuffs = new();
         private readonly List<BuffRecipe> slotAssignments = new(new BuffRecipe[5]);
 
-        private HeroController SpawnClone()
+        private HeroController SpawnEcho()
         {
             var hero = Hero.HeroController.Instance;
             if (hero == null)
                 return null;
 
-            Hero.HeroController.PrepareForClone();
+            Hero.HeroController.PrepareForEcho();
             var obj = Instantiate(hero.gameObject, hero.transform.position, hero.transform.rotation, hero.transform.parent);
-            var clone = obj.GetComponent<Hero.HeroController>();
-            if (clone != null)
+            var echo = obj.GetComponent<Hero.HeroController>();
+            if (echo != null)
             {
                 var renderers = obj.GetComponentsInChildren<SpriteRenderer>();
                 foreach (var r in renderers)
@@ -43,7 +43,7 @@ namespace TimelessEchoes.Buffs
                     r.color = c;
                 }
 
-                var hp = clone.GetComponent<Hero.HeroHealth>();
+                var hp = echo.GetComponent<Hero.HeroHealth>();
                 if (hp != null)
                 {
                     hp.Immortal = true;
@@ -51,7 +51,7 @@ namespace TimelessEchoes.Buffs
                 }
             }
 
-            return clone;
+            return echo;
         }
 
         public int UnlockedSlots
@@ -201,14 +201,14 @@ namespace TimelessEchoes.Buffs
                 TELogger.Log($"Buff {recipe.name} extended", TELogCategory.Buff, this);
             }
 
-            if (recipe.cloneCount > 0)
+            if (recipe.echoCount > 0)
             {
-                int needed = recipe.cloneCount - buff.clones.Count;
+                int needed = recipe.echoCount - buff.echoes.Count;
                 for (int i = 0; i < needed; i++)
                 {
-                    var c = SpawnClone();
+                    var c = SpawnEcho();
                     if (c != null)
-                        buff.clones.Add(c);
+                        buff.echoes.Add(c);
                 }
             }
 
@@ -346,7 +346,7 @@ namespace TimelessEchoes.Buffs
         public void ClearActiveBuffs()
         {
             foreach (var buff in activeBuffs)
-                DestroyClones(buff);
+                DestroyEchoes(buff);
             activeBuffs.Clear();
         }
 
@@ -366,19 +366,19 @@ namespace TimelessEchoes.Buffs
         {
             if (index < 0 || index >= activeBuffs.Count) return;
             var buff = activeBuffs[index];
-            DestroyClones(buff);
+            DestroyEchoes(buff);
             activeBuffs.RemoveAt(index);
             if (buff.recipe != null)
                 TELogger.Log($"Buff {buff.recipe.name} expired", TELogCategory.Buff, this);
         }
 
-        private void DestroyClones(ActiveBuff buff)
+        private void DestroyEchoes(ActiveBuff buff)
         {
-            if (buff == null || buff.clones == null) return;
-            foreach (var c in buff.clones)
+            if (buff == null || buff.echoes == null) return;
+            foreach (var c in buff.echoes)
                 if (c != null)
                     Destroy(c.gameObject);
-            buff.clones.Clear();
+            buff.echoes.Clear();
         }
 
 
@@ -388,7 +388,7 @@ namespace TimelessEchoes.Buffs
             public BuffRecipe recipe;
             public float remaining;
             public float expireAtDistance = float.PositiveInfinity;
-            public List<HeroController> clones = new();
+            public List<HeroController> echoes = new();
         }
     }
 }

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -18,7 +18,7 @@ namespace TimelessEchoes.Buffs
 
         public Sprite buffIcon;
         [Min(0f)] public float baseDuration = 30f;
-        [Min(0)] public int cloneCount;
+        [Min(0)] public int echoCount;
         [Range(-100f, 100f)] public float moveSpeedPercent;
         [Range(-100f, 100f)] public float damagePercent;
         [Range(-100f, 100f)] public float defensePercent;

--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -14,11 +14,11 @@ namespace TimelessEchoes.Hero
             if (hero == null)
                 return null;
 
-            HeroController.PrepareForClone();
+            HeroController.PrepareForEcho();
             GameObject obj = Object.Instantiate(hero.gameObject, hero.transform.position, hero.transform.rotation, hero.transform.parent);
 
-            var clone = obj.GetComponent<HeroController>();
-            if (clone != null)
+            var echoHero = obj.GetComponent<HeroController>();
+            if (echoHero != null)
             {
                 foreach (var r in obj.GetComponentsInChildren<SpriteRenderer>())
                 {
@@ -27,20 +27,20 @@ namespace TimelessEchoes.Hero
                     r.color = c;
                 }
 
-                var hp = clone.GetComponent<HeroHealth>();
+                var hp = echoHero.GetComponent<HeroHealth>();
                 if (hp != null)
                 {
                     hp.Immortal = true;
                     hp.Init((int)hp.MaxHealth);
                 }
 
-                clone.AllowAttacks = false;
+                echoHero.AllowAttacks = false;
 
                 var echo = obj.AddComponent<EchoController>();
                 echo.Init(skill, duration);
             }
 
-            return clone;
+            return echoHero;
         }
     }
 }

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -27,14 +27,14 @@ namespace TimelessEchoes.Hero
     public class HeroController : MonoBehaviour
     {
         public static HeroController Instance { get; private set; }
-        private static bool nextIsClone;
+        private static bool nextIsEcho;
 
-        public static void PrepareForClone()
+        public static void PrepareForEcho()
         {
-            nextIsClone = true;
+            nextIsEcho = true;
         }
 
-        [HideInInspector] public bool IsClone;
+        [HideInInspector] public bool IsEcho;
         [SerializeField] private HeroStats stats;
         [SerializeField] private Animator animator;
         [SerializeField] private SpriteRenderer spriteRenderer;
@@ -130,13 +130,13 @@ namespace TimelessEchoes.Hero
 
         private void Awake()
         {
-            if (nextIsClone)
+            if (nextIsEcho)
             {
-                IsClone = true;
-                nextIsClone = false;
+                IsEcho = true;
+                nextIsEcho = false;
             }
 
-            if (!IsClone)
+            if (!IsEcho)
             {
                 if (Instance != null && Instance != this) Destroy(Instance.gameObject);
                 Instance = this;
@@ -178,7 +178,7 @@ namespace TimelessEchoes.Hero
 
         private void Update()
         {
-            if (!IsClone)
+            if (!IsEcho)
                 BuffManager.Instance?.Tick(Time.deltaTime);
             if (stats != null)
                 ai.maxSpeed = (baseMoveSpeed + moveSpeedBonus) *
@@ -215,7 +215,7 @@ namespace TimelessEchoes.Hero
                     Log("BuffManager missing", TELogCategory.Buff, this);
             }
 
-            if (!IsClone)
+            if (!IsEcho)
                 buffController?.Resume();
 
             if (mapUI == null)
@@ -243,26 +243,26 @@ namespace TimelessEchoes.Hero
             lastAttack = Time.time - 1f / CurrentAttackRate;
 
             var skillController = SkillController.Instance;
-            if (!IsClone && skillController != null)
+            if (!IsEcho && skillController != null)
                 skillController.OnMilestoneUnlocked += OnMilestoneUnlocked;
 
-            if (!IsClone)
+            if (!IsEcho)
                 Enemy.OnEngage += OnEnemyEngage;
         }
 
         private void OnDisable()
         {
-            if (!IsClone)
+            if (!IsEcho)
                 buffController?.Pause();
 
             if (CurrentTask is BaseTask baseTask)
                 baseTask.ReleaseClaim(this);
 
             var skillController = SkillController.Instance;
-            if (!IsClone && skillController != null)
+            if (!IsEcho && skillController != null)
                 skillController.OnMilestoneUnlocked -= OnMilestoneUnlocked;
 
-            if (!IsClone)
+            if (!IsEcho)
                 Enemy.OnEngage -= OnEnemyEngage;
         }
 
@@ -271,7 +271,7 @@ namespace TimelessEchoes.Hero
             if (CurrentTask is BaseTask baseTask)
                 baseTask.ReleaseClaim(this);
 
-            if (!IsClone && Instance == this)
+            if (!IsEcho && Instance == this)
                 Instance = null;
         }
 

--- a/Assets/Scripts/Hero/HeroHealth.cs
+++ b/Assets/Scripts/Hero/HeroHealth.cs
@@ -16,7 +16,7 @@ namespace TimelessEchoes.Hero
         protected override void Awake()
         {
             controller = GetComponent<HeroController>();
-            if (!controller || !controller.IsClone)
+            if (!controller || !controller.IsEcho)
             {
                 if (Instance != null && Instance != this) Destroy(Instance.gameObject);
                 Instance = this;
@@ -26,7 +26,7 @@ namespace TimelessEchoes.Hero
 
         private void OnDestroy()
         {
-            if (!controller || !controller.IsClone)
+            if (!controller || !controller.IsEcho)
             {
                 if (Instance == this)
                     Instance = null;

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -98,7 +98,7 @@ namespace TimelessEchoes.Tasks
         protected float GrantCompletionXP()
         {
             lastGrantedXp = 0f;
-            if (claimedBy != null && claimedBy.IsClone)
+            if (claimedBy != null && claimedBy.IsEcho)
                 return 0f;
             if (associatedSkill == null || taskData == null || taskData.xpForCompletion <= 0f)
                 return 0f;


### PR DESCRIPTION
## Summary
- rename clone-related APIs to echo terminology
- update buff recipe fields to use `echoCount`
- adjust hero controller logic and echo spawning helpers
- update MoveSpeed asset field

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_687b49b2e0e4832ebc108c5e57eeee37