### PR TITLE
Allow combat echoes to use hero stats and health

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -24,7 +24,7 @@ namespace TimelessEchoes.Buffs
         private readonly List<ActiveBuff> activeBuffs = new();
         private readonly List<BuffRecipe> slotAssignments = new(new BuffRecipe[5]);
 
-        private HeroController SpawnEcho()
+        private HeroController SpawnEcho(bool combat)
         {
             var hero = Hero.HeroController.Instance;
             if (hero == null)
@@ -45,10 +45,9 @@ namespace TimelessEchoes.Buffs
 
                 var hp = echo.GetComponent<Hero.HeroHealth>();
                 if (hp != null)
-                {
-                    hp.Immortal = true;
-                    hp.Init((int)hp.MaxHealth);
-                }
+                    Object.Destroy(hp);
+                echo.gameObject.AddComponent<Hero.EchoHealthProxy>();
+                echo.AllowAttacks = combat;
             }
 
             return echo;
@@ -206,7 +205,7 @@ namespace TimelessEchoes.Buffs
                 int needed = recipe.echoCount - buff.echoes.Count;
                 for (int i = 0; i < needed; i++)
                 {
-                    var c = SpawnEcho();
+                    var c = SpawnEcho(recipe.combatEnabled);
                     if (c != null)
                         buff.echoes.Add(c);
                 }

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -27,6 +27,8 @@ namespace TimelessEchoes.Buffs
         [Range(0f, 100f)] public float lifestealPercent;
         [Tooltip("Tasks complete instantly while active.")]
         public bool instantTasks;
+        [Tooltip("If true, echoes spawned by this buff can fight enemies.")]
+        public bool combatEnabled;
         [Tooltip("Percent of longest run distance this buff remains active. 0 = no distance limit")]
         [Range(0f,1f)] public float distancePercent;
         public List<ResourceRequirement> requirements = new();

--- a/Assets/Scripts/Hero/EchoHealthProxy.cs
+++ b/Assets/Scripts/Hero/EchoHealthProxy.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+namespace TimelessEchoes.Hero
+{
+    /// <summary>
+    /// Redirects damage taken by an echo to the main hero's health component.
+    /// </summary>
+    public class EchoHealthProxy : MonoBehaviour, IDamageable, IHasHealth
+    {
+        public float CurrentHealth => HeroHealth.Instance != null ? HeroHealth.Instance.CurrentHealth : 0f;
+        public float MaxHealth => HeroHealth.Instance != null ? HeroHealth.Instance.MaxHealth : 0f;
+
+        public void TakeDamage(float amount, float bonusDamage = 0f)
+        {
+            HeroHealth.Instance?.TakeDamage(amount, bonusDamage);
+        }
+    }
+}

--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -8,7 +8,7 @@ namespace TimelessEchoes.Hero
     /// </summary>
     public static class EchoManager
     {
-        public static HeroController SpawnEcho(Skill skill, float duration)
+        public static HeroController SpawnEcho(Skill skill, float duration, bool combat)
         {
             var hero = HeroController.Instance;
             if (hero == null)
@@ -29,12 +29,10 @@ namespace TimelessEchoes.Hero
 
                 var hp = echoHero.GetComponent<HeroHealth>();
                 if (hp != null)
-                {
-                    hp.Immortal = true;
-                    hp.Init((int)hp.MaxHealth);
-                }
+                    Object.Destroy(hp);
+                echoHero.gameObject.AddComponent<EchoHealthProxy>();
 
-                echoHero.AllowAttacks = false;
+                echoHero.AllowAttacks = combat;
 
                 var echo = obj.AddComponent<EchoController>();
                 echo.Init(skill, duration);

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -171,7 +171,7 @@ namespace TimelessEchoes.Hero
                 ai.maxSpeed = (baseMoveSpeed + moveSpeedBonus) *
                               (buffController != null ? buffController.MoveSpeedMultiplier : 1f);
                 var hp = Mathf.RoundToInt(baseHealth + healthBonus);
-                health.Init(hp);
+                health?.Init(hp);
             }
         }
 
@@ -227,7 +227,7 @@ namespace TimelessEchoes.Hero
                 ai.maxSpeed = (baseMoveSpeed + moveSpeedBonus) *
                               (buffController != null ? buffController.MoveSpeedMultiplier : 1f);
                 var hp = Mathf.RoundToInt(baseHealth + healthBonus);
-                health.Init(hp);
+                health?.Init(hp);
             }
 
             // Hero no longer relocates to a task controller entry point
@@ -289,8 +289,8 @@ namespace TimelessEchoes.Hero
                     if (newMax > 0 && Mathf.Abs(newMax - oldMax) > 0.01f)
                     {
                         var newCurrent = Mathf.Min(oldCurrent + (newMax - oldMax), newMax);
-                        health.Init(newMax);
-                        if (newCurrent < newMax)
+                        health?.Init(newMax);
+                        if (newCurrent < newMax && health != null)
                             health.TakeDamage(newMax - newCurrent);
                     }
                 }

--- a/Assets/Scripts/Hero/HeroHealth.cs
+++ b/Assets/Scripts/Hero/HeroHealth.cs
@@ -66,6 +66,12 @@ namespace TimelessEchoes.Hero
         public override void TakeDamage(float amount, float bonusDamage = 0f)
         {
             if (Immortal) return;
+            controller = controller != null ? controller : GetComponent<HeroController>();
+            if (controller != null && controller.IsEcho && Instance != null && Instance != this)
+            {
+                Instance.TakeDamage(amount, bonusDamage);
+                return;
+            }
             base.TakeDamage(amount, bonusDamage);
         }
     }

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -125,7 +125,8 @@ namespace TimelessEchoes.Tasks
                         if (ms != null && ms.type == MilestoneType.SpawnEcho && UnityEngine.Random.value <= ms.chance)
                         {
                             var skill = ms.targetSkill != null ? ms.targetSkill : associatedSkill;
-                            EchoManager.SpawnEcho(skill, ms.echoDuration);
+                            bool combat = SkillController.Instance != null && SkillController.Instance.CombatSkill == skill;
+                            EchoManager.SpawnEcho(skill, ms.echoDuration, combat);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- enable combat toggles on buffs
- make EchoManager take combat flag when spawning
- hook combat skill milestones when enemies die

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b4dd8e6dc832e830830db040f3a69