### PR TITLE
Add combatEnabled to EchoSpawnConfig

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using TimelessEchoes.Upgrades;
 using TimelessEchoes.Hero;
 using TimelessEchoes.Skills;
+using TimelessEchoes.Tasks;
 using UnityEngine;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
@@ -25,7 +26,7 @@ namespace TimelessEchoes.Buffs
         private readonly List<ActiveBuff> activeBuffs = new();
         private readonly List<BuffRecipe> slotAssignments = new(new BuffRecipe[5]);
 
-        private HeroController SpawnEcho(bool combat)
+        private HeroController SpawnEcho(bool combat, bool disableSkills)
         {
             var hero = Hero.HeroController.Instance;
             if (hero == null)
@@ -51,6 +52,12 @@ namespace TimelessEchoes.Buffs
                 if (hp != null)
                     hp.Immortal = false;
                 echo.AllowAttacks = combat;
+                if (disableSkills)
+                {
+                    var tc = echo.GetComponent<TaskController>();
+                    if (tc != null)
+                        Destroy(tc);
+                }
             }
 
             return echo;
@@ -209,8 +216,12 @@ namespace TimelessEchoes.Buffs
                 for (int i = 0; i < needed; i++)
                 {
                     var combatSkill = SkillController.Instance?.CombatSkill;
-                    bool combat = combatSkill != null && (recipe.echoSpawnConfig.capableSkills == null || recipe.echoSpawnConfig.capableSkills.Count == 0 || recipe.echoSpawnConfig.capableSkills.Contains(combatSkill));
-                    var c = SpawnEcho(combat);
+                    bool combat = recipe.echoSpawnConfig.combatEnabled && combatSkill != null &&
+                                   (recipe.echoSpawnConfig.capableSkills == null ||
+                                    recipe.echoSpawnConfig.capableSkills.Count == 0 ||
+                                    recipe.echoSpawnConfig.capableSkills.Contains(combatSkill));
+                    bool disable = recipe.echoSpawnConfig.disableSkills;
+                    var c = SpawnEcho(combat, disable);
                     if (c != null)
                         buff.echoes.Add(c);
                 }

--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -283,11 +283,12 @@ namespace TimelessEchoes.Enemies
                             var skills = config != null && config.capableSkills != null && config.capableSkills.Count > 0
                                 ? config.capableSkills
                                 : new System.Collections.Generic.List<Skill> { skill };
+                            bool disable = config != null && config.disableSkills;
                             for (int c = 0; c < count; c++)
                             {
                                 var target = skills[Mathf.Min(c, skills.Count - 1)];
-                                bool combat = controller.CombatSkill == target;
-                                TimelessEchoes.Hero.EchoManager.SpawnEcho(new System.Collections.Generic.List<Skill> { target }, ms.echoDuration, combat);
+                                bool combat = config != null && config.combatEnabled && controller.CombatSkill == target;
+                                TimelessEchoes.Hero.EchoManager.SpawnEcho(new System.Collections.Generic.List<Skill> { target }, ms.echoDuration, combat, disable);
                             }
                         }
                     }

--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -13,6 +13,7 @@ namespace TimelessEchoes.Hero
     {
         public System.Collections.Generic.List<Skill> capableSkills = new();
         public float lifetime = 10f;
+        public bool disableSkills;
 
         private HeroController hero;
         private TaskController taskController;
@@ -27,24 +28,32 @@ namespace TimelessEchoes.Hero
 
         private void OnEnable()
         {
-            if (hero != null && taskController != null)
+            if (hero != null && taskController != null && !disableSkills)
                 AssignTask();
         }
 
         /// <summary>
         /// Configure the echo after it is spawned.
         /// </summary>
-        public void Init(System.Collections.Generic.IEnumerable<Skill> skills, float duration)
+        public void Init(System.Collections.Generic.IEnumerable<Skill> skills, float duration, bool disable)
         {
             capableSkills = skills != null ? new System.Collections.Generic.List<Skill>(skills) : new System.Collections.Generic.List<Skill>();
             lifetime = duration;
             remaining = duration;
+            disableSkills = disable;
 
-            if (isActiveAndEnabled && hero != null && taskController != null)
+            if (hero != null)
+            {
+                var combatSkill = SkillController.Instance?.CombatSkill;
+                bool combatOnly = disableSkills || (capableSkills != null && capableSkills.Count == 1 && combatSkill != null && capableSkills.Contains(combatSkill));
+                hero.UnlimitedAggroRange = combatOnly;
+            }
+
+            if (!disableSkills && isActiveAndEnabled && hero != null && taskController != null)
                 AssignTask();
         }
 
-        private void Update()
+    private void Update()
         {
             remaining -= Time.deltaTime;
             if (remaining <= 0f)
@@ -53,7 +62,7 @@ namespace TimelessEchoes.Hero
                 return;
             }
 
-            if (taskController != null)
+            if (!disableSkills && taskController != null)
             {
                 bool hasTask = false;
                 if (capableSkills == null || capableSkills.Count == 0)
@@ -81,6 +90,19 @@ namespace TimelessEchoes.Hero
                     Destroy(gameObject);
                 }
             }
+            else if (disableSkills)
+            {
+                var combatSkill = SkillController.Instance?.CombatSkill;
+                if (capableSkills != null && combatSkill != null && capableSkills.Contains(combatSkill) && hero != null && hero.AllowAttacks)
+                    return; // stay alive for combat
+                Destroy(gameObject);
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (hero != null)
+                hero.UnlimitedAggroRange = false;
         }
 
         private void AssignTask()
@@ -88,19 +110,23 @@ namespace TimelessEchoes.Hero
             if (hero == null || taskController == null)
                 return;
 
+            if (disableSkills)
+                return;
+
             if (capableSkills == null || capableSkills.Count == 0)
             {
                 taskController.SelectEarliestTask(hero);
                 return;
             }
-
-            foreach (var s in capableSkills)
+            if (capableSkills.Count == 1)
             {
-                if (s == null) continue;
-                taskController.SelectEarliestTask(hero, s);
-                if (hero.CurrentTask is BaseTask b && b.associatedSkill == s)
-                    break;
+                var s = capableSkills[0];
+                if (s != null)
+                    taskController.SelectEarliestTask(hero, s);
+                return;
             }
+
+            taskController.SelectEarliestTask(hero, capableSkills);
         }
     }
 }

--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -9,7 +9,7 @@ namespace TimelessEchoes.Hero
     /// </summary>
     public static class EchoManager
     {
-        public static HeroController SpawnEcho(System.Collections.Generic.IEnumerable<Skill> skills, float duration, bool combat)
+        public static HeroController SpawnEcho(System.Collections.Generic.IEnumerable<Skill> skills, float duration, bool combat, bool disableSkills = false)
         {
             var hero = HeroController.Instance;
             if (hero == null)
@@ -38,15 +38,15 @@ namespace TimelessEchoes.Hero
                 echoHero.AllowAttacks = combat;
 
                 var echo = obj.AddComponent<EchoController>();
-                echo.Init(skills, duration);
+                echo.Init(skills, duration, disableSkills);
             }
 
             return echoHero;
         }
 
-        public static HeroController SpawnEcho(Skill skill, float duration, bool combat)
+        public static HeroController SpawnEcho(Skill skill, float duration, bool combat, bool disableSkills = false)
         {
-            return SpawnEcho(new System.Collections.Generic.List<Skill> { skill }, duration, combat);
+            return SpawnEcho(new System.Collections.Generic.List<Skill> { skill }, duration, combat, disableSkills);
         }
     }
 }

--- a/Assets/Scripts/Hero/EchoSpawnConfig.cs
+++ b/Assets/Scripts/Hero/EchoSpawnConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Sirenix.OdinInspector;
 using TimelessEchoes.Skills;
 
 namespace TimelessEchoes
@@ -10,6 +11,16 @@ namespace TimelessEchoes
     {
         [Min(1)]
         public int echoCount = 1;
+        [HideIf(nameof(disableSkills))]
         public List<Skill> capableSkills = new();
+
+        /// <summary>
+        /// When true, spawned Echoes ignore all task related behaviour.
+        /// </summary>
+        public bool disableSkills;
+        /// <summary>
+        /// When true, spawned Echoes can perform combat actions.
+        /// </summary>
+        public bool combatEnabled = true;
     }
 }

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -55,6 +55,8 @@ namespace TimelessEchoes.Hero
             set => allowAttacks = value;
         }
 
+        public bool UnlimitedAggroRange { get; set; }
+
         private Transform currentEnemy;
         private Health currentEnemyHealth;
 
@@ -418,7 +420,10 @@ namespace TimelessEchoes.Hero
 
             var nearest = allowAttacks && currentEnemy != null ? currentEnemy : null;
             if (allowAttacks && nearest == null)
-                nearest = FindNearestEnemy();
+            {
+                float range = UnlimitedAggroRange ? float.PositiveInfinity : stats.visionRange;
+                nearest = FindNearestEnemy(range);
+            }
 
             if (allowAttacks && nearest != null)
             {
@@ -487,11 +492,11 @@ namespace TimelessEchoes.Hero
         }
 
 
-        private Transform FindNearestEnemy()
+        private Transform FindNearestEnemy(float range)
         {
             Transform nearest = null;
             var best = float.MaxValue;
-            var hits = Physics2D.OverlapCircleAll(transform.position, stats.visionRange, enemyMask);
+            var hits = Physics2D.OverlapCircleAll(transform.position, range, enemyMask);
             foreach (var h in hits)
             {
                 var hp = h.GetComponent<Health>();
@@ -505,6 +510,11 @@ namespace TimelessEchoes.Hero
             }
 
             return nearest;
+        }
+
+        private Transform FindNearestEnemy()
+        {
+            return FindNearestEnemy(stats.visionRange);
         }
 
         private void HandleCombat(Transform enemy)

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -130,11 +130,14 @@ namespace TimelessEchoes.Tasks
                             var skills = config != null && config.capableSkills != null && config.capableSkills.Count > 0
                                 ? config.capableSkills
                                 : new System.Collections.Generic.List<Skill> { associatedSkill };
+                            bool disable = config != null && config.disableSkills;
                             for (int c = 0; c < count; c++)
                             {
                                 var skill = skills[Mathf.Min(c, skills.Count - 1)];
-                                bool combat = SkillController.Instance != null && SkillController.Instance.CombatSkill == skill;
-                                EchoManager.SpawnEcho(new System.Collections.Generic.List<Skill> { skill }, ms.echoDuration, combat);
+                                bool combat = config != null && config.combatEnabled &&
+                                              SkillController.Instance != null &&
+                                              SkillController.Instance.CombatSkill == skill;
+                                EchoManager.SpawnEcho(new System.Collections.Generic.List<Skill> { skill }, ms.echoDuration, combat, disable);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- extend `EchoSpawnConfig` with a `disableSkills` flag and hide the skills list when enabled
- propagate `disableSkills` and `combatEnabled` when spawning echoes
- ensure combat-only echoes gain unlimited aggro range
- allow echoes with multiple skills to search tasks across all capabilities

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687b691e51cc832e9ba03c35c563655e