### PR TITLE
Fix combat echo initialization

### DIFF
--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -60,6 +60,9 @@ namespace TimelessEchoes.Hero
                 hero.UnlimitedAggroRange = combatOnly;
             }
 
+            if (combatEnabled && isActiveAndEnabled && !CombatEchoes.Contains(this))
+                CombatEchoes.Add(this);
+
             if (!disableSkills && isActiveAndEnabled && hero != null && taskController != null)
                 AssignTask();
         }


### PR DESCRIPTION
## Summary
- ensure combat-enabled echoes register in CombatEchoes when initialized

## Testing
- `echo "No programmatic tests provided."`

------
https://chatgpt.com/codex/tasks/task_e_687c16fc41b0832e9408e4841c227cf9