### PR TITLE
Prevent hero from reacting to echo combat

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -372,7 +372,7 @@ namespace TimelessEchoes.Enemies
 
         private void HandleAllyEngaged(Enemy other)
         {
-            if (other != this && other != null && hero != null)
+            if (other != this && other != null && hero != null && other.IsEngaged)
             {
                 var dist = Vector2.Distance(transform.position, other.transform.position);
                 if (dist <= stats.assistRange)

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -590,6 +590,9 @@ namespace TimelessEchoes.Hero
             if (!allowAttacks)
                 return;
 
+            if (!enemy.IsEngaged)
+                return;
+
             if (currentEnemy != null && currentEnemy != enemy.transform)
                 return;
 

--- a/Assets/Scripts/Steamworks.NET/SlimeCombatTracker.cs
+++ b/Assets/Scripts/Steamworks.NET/SlimeCombatTracker.cs
@@ -58,7 +58,7 @@ namespace TimelessEchoes
 
         private void OnEnemyEngage(Enemy enemy)
         {
-            if (enemy == null || enemy.Stats == null)
+            if (enemy == null || enemy.Stats == null || !enemy.IsEngaged)
                 return;
 
             var name = enemy.Stats.enemyName;


### PR DESCRIPTION
## Summary
- fire enemy engagement events even when enemies target echoes
- ignore non-hero engagements for ally assistance and hero reaction
- track only hero-targeting slimes for achievements

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_687c1b5a0594832eb4fb642e87b24cfe