### PR TITLE
Fix echoes claiming tasks when skills disabled

### DIFF
--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -37,6 +37,13 @@ namespace TimelessEchoes.Hero
 
                 echoHero.AllowAttacks = combat;
 
+                if (disableSkills)
+                {
+                    var tc = obj.GetComponent<TaskController>();
+                    if (tc != null)
+                        Object.Destroy(tc);
+                }
+
                 var echo = obj.AddComponent<EchoController>();
                 echo.Init(skills, duration, disableSkills, combat);
             }


### PR DESCRIPTION
## Summary
- prevent skill-disabled echoes from retaining a TaskController

## Testing
- `unity-editor -quit -batchmode -runTests -projectPath . -testPlatform editmode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c20f13568832e8bc8f84582b9020b