### PR TITLE
Fix echo spawn skill list

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -338,9 +338,8 @@ namespace TimelessEchoes.Enemies
                             var disable = config != null && config.disableSkills;
                             for (var c = 0; c < count; c++)
                             {
-                                var target = skills[Mathf.Min(c, skills.Count - 1)];
                                 var combat = config != null && config.combatEnabled;
-                                EchoManager.SpawnEcho(new List<Skill> { target }, ms.echoDuration, combat, disable);
+                                EchoManager.SpawnEcho(skills, ms.echoDuration, combat, disable);
                             }
                         }
                     }

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -133,9 +133,8 @@ namespace TimelessEchoes.Tasks
                             bool disable = config != null && config.disableSkills;
                             for (int c = 0; c < count; c++)
                             {
-                                var skill = skills[Mathf.Min(c, skills.Count - 1)];
                                 bool combat = config != null && config.combatEnabled;
-                                EchoManager.SpawnEcho(new System.Collections.Generic.List<Skill> { skill }, ms.echoDuration, combat, disable);
+                                EchoManager.SpawnEcho(skills, ms.echoDuration, combat, disable);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- ensure milestone-based echoes get all capable skills when spawned

## Testing
- `grep -n "SpawnEcho" -n Assets/Scripts/Tasks/BaseTask.cs`
- `grep -n "SpawnEcho" -n Assets/Scripts/Enemies/Enemy.cs`


------
https://chatgpt.com/codex/tasks/task_e_687c23b76dc8832eaba7c51e0962eeb1