### PR TITLE
Fix echo behaviour when skill list empty

### DIFF
--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -56,7 +56,10 @@ namespace TimelessEchoes.Hero
 
             if (hero != null)
             {
-                bool combatOnly = combatEnabled && (disableSkills || capableSkills == null || capableSkills.Count == 0);
+                // When skills are not restricted, echoes should still focus on tasks
+                // rather than roaming across the map for combat. Treat an empty
+                // skill list as "all skills" instead of "combat only".
+                bool combatOnly = combatEnabled && disableSkills;
                 hero.UnlimitedAggroRange = combatOnly;
             }
 

--- a/Assets/Scripts/Hero/EchoSpawnConfig.cs
+++ b/Assets/Scripts/Hero/EchoSpawnConfig.cs
@@ -12,6 +12,7 @@ namespace TimelessEchoes
         [Min(1)]
         public int echoCount = 1;
         [HideIf(nameof(disableSkills))]
+        [Tooltip("Skills this Echo can perform. Leave empty to allow all skills.")]
         public List<Skill> capableSkills = new();
 
         /// <summary>


### PR DESCRIPTION
## Summary
- limit combat aggro range unless skills are explicitly disabled
- clarify that leaving EchoSpawnConfig `capableSkills` empty allows all skills

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c29d653c8832e8fa0ee05fbabde23