### PR TITLE
Ensure unique quest IDs

### DIFF
--- a/Assets/Resources/Quests/Eva/Berry Sweet.asset
+++ b/Assets/Resources/Quests/Eva/Berry Sweet.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Berry Sweet
   m_EditorClassIdentifier:
-  questId: Strawberry
+  questId: BerrySweet
   questName: Berry Sweet
   description: Bring 30 Pumkings to satisfy Eva's cravings.
   rewardDescription: 'Unlock the Strawberry crop'

--- a/Assets/Resources/Quests/Eva/Carrot Conjuring.asset
+++ b/Assets/Resources/Quests/Eva/Carrot Conjuring.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Carrot Conjuring
   m_EditorClassIdentifier: 
-  questId: Carrot
+  questId: CarrotConjuring
   questName: Carrot Conjuring
   description: "Eva polishes a bright carrot. \u201CCarrots sharpen vision\u2014no
     offense, love.\u201D She grins. \u201CGather 100 so Mildred sees in starlight

--- a/Assets/Resources/Quests/Eva/Carrot Craze.asset
+++ b/Assets/Resources/Quests/Eva/Carrot Craze.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Carrot Craze
   m_EditorClassIdentifier:
-  questId: Carrot
+  questId: CarrotCraze
   questName: Carrot Craze
   description: Harvest 10 Wartermelone for Eva to unlock carrot seeds.
   rewardDescription: 'Unlock the Carrot crop'

--- a/Assets/Resources/Quests/Eva/Chili Challenge.asset
+++ b/Assets/Resources/Quests/Eva/Chili Challenge.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Chili Challenge
   m_EditorClassIdentifier:
-  questId: Chillie
+  questId: ChiliChallenge
   questName: Chili Challenge
   description: Offer 15 Peppers to test some fiery magic.
   rewardDescription: 'Unlock the Chillie crop'

--- a/Assets/Resources/Quests/Eva/Chillie Charm.asset
+++ b/Assets/Resources/Quests/Eva/Chillie Charm.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Chillie Charm
   m_EditorClassIdentifier: 
-  questId: Chillie
+  questId: ChillieCharm
   questName: Chillie Charm
   description: A chilie glows in her hand. “Chillies are peppers with purpose.
     Fetch 100 and I’ll craft charms that melt frost and fear alike.”

--- a/Assets/Resources/Quests/Eva/Cool Cucumber.asset
+++ b/Assets/Resources/Quests/Eva/Cool Cucumber.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Cool Cucumber
   m_EditorClassIdentifier:
-  questId: Cucumber
+  questId: CoolCucumber
   questName: Cool Cucumber
   description: Hand over 20 Lettuce for a refreshing crop upgrade.
   rewardDescription: 'Unlock the Cucumber crop'

--- a/Assets/Resources/Quests/Eva/Cucumber Chant.asset
+++ b/Assets/Resources/Quests/Eva/Cucumber Chant.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Cucumber Chant
   m_EditorClassIdentifier: 
-  questId: Cucumber
+  questId: CucumberChant
   questName: Cucumber Chant
   description: Eva snaps a cucumber; a cool mist forms. “Cucumbers calm tempers
     and bruises. Bring 100 so we can chill the forge—and soothe Utoes after his

--- a/Assets/Resources/Quests/Eva/Funion Festival.asset
+++ b/Assets/Resources/Quests/Eva/Funion Festival.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Funion Festival
   m_EditorClassIdentifier: 
-  questId: Funion
+  questId: FunionFestival
   questName: Funion Festival
   description: Eva laughs, flipping a ring-shaped funion. “These crunchy halos
     turn any frown upside-down. Deliver 100 to fuel the festival feast and lace the

--- a/Assets/Resources/Quests/Eva/Funky Funion.asset
+++ b/Assets/Resources/Quests/Eva/Funky Funion.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Funky Funion
   m_EditorClassIdentifier:
-  questId: Funion
+  questId: FunkyFunion
   questName: Funky Funion
   description: Donate 20 Strawberries for Eva's new stew.
   rewardDescription: 'Unlock the Funion crop'

--- a/Assets/Resources/Quests/Eva/Leek Lattice.asset
+++ b/Assets/Resources/Quests/Eva/Leek Lattice.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Leek Lattice
   m_EditorClassIdentifier: 
-  questId: Leek
+  questId: LeekLattice
   questName: Leek Lattice
   description: She weaves leeks into a glowing grid. “Leeks channel moonlight into
     straight lines. Provide 100 sturdy stalks and we’ll raise protective lattices

--- a/Assets/Resources/Quests/Eva/Leek Leak.asset
+++ b/Assets/Resources/Quests/Eva/Leek Leak.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Leek Leak
   m_EditorClassIdentifier:
-  questId: Leek
+  questId: LeekLeak
   questName: Leek Leak
   description: Share 20 Onions so Eva can grow hearty leeks.
   rewardDescription: 'Unlock the Leek crop'

--- a/Assets/Resources/Quests/Eva/Lettuce Feast.asset
+++ b/Assets/Resources/Quests/Eva/Lettuce Feast.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Lettuce Feast
   m_EditorClassIdentifier:
-  questId: Lettuce
+  questId: LettuceFeast
   questName: Lettuce Feast
   description: Supply 20 Tomatoes so Eva can craft a healthy salad.
   rewardDescription: 'Unlock the Lettuce crop'

--- a/Assets/Resources/Quests/Eva/Lettuce Lullaby.asset
+++ b/Assets/Resources/Quests/Eva/Lettuce Lullaby.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Lettuce Lullaby
   m_EditorClassIdentifier: 
-  questId: Lettuce
+  questId: LettuceLullaby
   questName: Lettuce Lullaby
   description: She fans a leafy head. “A bed of crisp lettuce hushes restless spirits.
     Deliver 100 heads so we can line every cot and craft dream-wraps for Mildred’s

--- a/Assets/Resources/Quests/Eva/Onion Odyssey.asset
+++ b/Assets/Resources/Quests/Eva/Onion Odyssey.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Onion Odyssey
   m_EditorClassIdentifier:
-  questId: Onion
+  questId: OnionOdyssey
   questName: Onion Odyssey
   description: Deliver 20 Cucumbers for a tearful experiment.
   rewardDescription: 'Unlock the Onion crop'

--- a/Assets/Resources/Quests/Eva/Onion Orison.asset
+++ b/Assets/Resources/Quests/Eva/Onion Orison.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Onion Orison
   m_EditorClassIdentifier: 
-  questId: Onion
+  questId: OnionOrison
   questName: Onion Orison
   description: Tears sparkle as she peels an onion. “Onion prayers sting but cleanse.
     Harvest 100 bulbs so we can cry away curses—Mildred will handle the mopping.”

--- a/Assets/Resources/Quests/Eva/Parsnip Pact.asset
+++ b/Assets/Resources/Quests/Eva/Parsnip Pact.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Parsnip Pact
   m_EditorClassIdentifier: 
-  questId: Parsnip
+  questId: ParsnipPact
   questName: Parsnip Pact
   description: Eva carves runes into a parsnip. “Parsnips remember winter’s patience.
     Bring 100 so we can seal a pact of endurance—Utoes could use the stamina for

--- a/Assets/Resources/Quests/Eva/Parsnip Plan.asset
+++ b/Assets/Resources/Quests/Eva/Parsnip Plan.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Parsnip Plan
   m_EditorClassIdentifier:
-  questId: Parsnip
+  questId: ParsnipPlan
   questName: Parsnip Plan
   description: Provide 20 Leeks to expand the root cellar.
   rewardDescription: 'Unlock the Parsnip crop'

--- a/Assets/Resources/Quests/Eva/Pepper Petition.asset
+++ b/Assets/Resources/Quests/Eva/Pepper Petition.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Pepper Petition
   m_EditorClassIdentifier: 
-  questId: Pepper
+  questId: PepperPetition
   questName: Pepper Petition
   description: She sniffs fiery flakes. “A pinch of pepper wakes even lazy gods.
     Deliver 100 peppers so Mildred’s whiskers twitch and the spirits perk up to

--- a/Assets/Resources/Quests/Eva/Pepper Pursuit.asset
+++ b/Assets/Resources/Quests/Eva/Pepper Pursuit.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Pepper Pursuit
   m_EditorClassIdentifier:
-  questId: Pepper
+  questId: PepperPursuit
   questName: Pepper Pursuit
   description: Gather 20 Parsnips to spice up the fields.
   rewardDescription: 'Unlock the Pepper crop'

--- a/Assets/Resources/Quests/Eva/Pumking Parade.asset
+++ b/Assets/Resources/Quests/Eva/Pumking Parade.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Pumking Parade
   m_EditorClassIdentifier: 
-  questId: Pumking
+  questId: PumkingParade
   questName: Pumking Parade
   description: Eva pats a massive gourd. “Lantern lords of the harvest! Bring 100
     pumkings so we can host a parade bright enough for spirits and cats both.”

--- a/Assets/Resources/Quests/Eva/Pumking Party.asset
+++ b/Assets/Resources/Quests/Eva/Pumking Party.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Pumking Party
   m_EditorClassIdentifier:
-  questId: Pumking
+  questId: PumkingParty
   questName: Pumking Party
   description: Trade 25 Chillies for seeds fit for a king.
   rewardDescription: 'Unlock the Pumking crop'

--- a/Assets/Resources/Quests/Eva/Spud Bud.asset
+++ b/Assets/Resources/Quests/Eva/Spud Bud.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Spud Bud
   m_EditorClassIdentifier:
-  questId: Spud
+  questId: SpudBud
   questName: Spud Bud
   description: Bring 15 Carrots so Eva can perfect potato farming.
   rewardDescription: 'Unlock the Spud crop'

--- a/Assets/Resources/Quests/Eva/Spud Spellwork.asset
+++ b/Assets/Resources/Quests/Eva/Spud Spellwork.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Spud Spellwork
   m_EditorClassIdentifier: 
-  questId: Spud
+  questId: SpudSpellwork
   questName: Spud Spellwork
   description: A potato hovers between her palms. “Spuds ground wild magic. Deliver
     100 hearty tubers so we can steady tonight’s rituals—and bake a pillow for

--- a/Assets/Resources/Quests/Eva/Strawberry Summons.asset
+++ b/Assets/Resources/Quests/Eva/Strawberry Summons.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Strawberry Summons
   m_EditorClassIdentifier: 
-  questId: Strawberry
+  questId: StrawberrySummons
   questName: Strawberry Summons
   description: She plucks a ruby berry. “Strawberries call early-summer sprites.
     Gather 100 so we can sweet-talk them into blessing the fields—Mildred’s already

--- a/Assets/Resources/Quests/Eva/Tomato Talisman.asset
+++ b/Assets/Resources/Quests/Eva/Tomato Talisman.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Tomato Talisman
   m_EditorClassIdentifier: 
-  questId: Tomato
+  questId: TomatoTalisman
   questName: Tomato Talisman
   description: Tomato juice glows as she crushes it. “These sun-hearts bottle warmth
     for winter. Fetch 100 ripe orbs—Utoes says the pulp gives regen a red-hot kick.”

--- a/Assets/Resources/Quests/Eva/Tomato Triumph.asset
+++ b/Assets/Resources/Quests/Eva/Tomato Triumph.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Tomato Triumph
   m_EditorClassIdentifier:
-  questId: Tomato
+  questId: TomatoTriumph
   questName: Tomato Triumph
   description: Deliver 20 Spuds for Evas secret sauce recipe.
   rewardDescription: 'Unlock the Tomato crop'

--- a/Assets/Resources/Quests/Eva/Turnip Time.asset
+++ b/Assets/Resources/Quests/Eva/Turnip Time.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Turnip Time
   m_EditorClassIdentifier:
-  questId: Turnip
+  questId: TurnipTime
   questName: Turnip Time
   description: Deliver 30 Funions to master the final crop.
   rewardDescription: 'Unlock the Turnip crop'

--- a/Assets/Resources/Quests/Eva/Turnip Triumph.asset
+++ b/Assets/Resources/Quests/Eva/Turnip Triumph.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac6c671cb40351d45bf3a24266e13ced, type: 3}
   m_Name: Turnip Triumph
   m_EditorClassIdentifier: 
-  questId: Turnip
+  questId: TurnipTriumph
   questName: Turnip Triumph
   description: She balances a stout turnip on her hat. “Turnips are victory in
     root form. Bring 100 so we can crown the season’s triumph—and give Utoes


### PR DESCRIPTION
## Summary
- assign unique `questId` values to quests in `Assets/Resources/Quests/Eva`

## Testing
- `grep -r "questId:" Assets/Resources/Quests | sed 's/.*questId: //' | sort | uniq -d`

------
https://chatgpt.com/codex/tasks/task_e_687c3212f294832e8621dfbd18fe9047