### PR TITLE
Fix unknown resource label

### DIFF
--- a/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
+++ b/Assets/Scripts/Upgrades/ResourceInventoryUI.cs
@@ -149,7 +149,15 @@ namespace TimelessEchoes.Upgrades
             if (selectedResourceNameText != null && index >= 0 && index < resources.Count)
             {
                 var res = resources[index];
-                selectedResourceNameText.text = res ? res.name : string.Empty;
+                if (res)
+                {
+                    bool unlocked = resourceManager && resourceManager.IsUnlocked(res);
+                    selectedResourceNameText.text = unlocked ? res.name : "???";
+                }
+                else
+                {
+                    selectedResourceNameText.text = string.Empty;
+                }
             }
 
             if (scrollToSlot)


### PR DESCRIPTION
## Summary
- show `???` in `ResourceInventoryUI` when an unknown resource is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c40759c74832eb698a4eaa9d6037e