### PR TITLE
Add BuffsCast stat

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -144,6 +144,7 @@ namespace Blindsided.SaveData
             public float DamageDealt;
             public float DamageTaken;
             public int TimesReaped;
+            public int BuffsCast;
             public double TotalResourcesGathered;
 
             // Records for the most recent runs. Limited to the last 50.

--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -160,9 +160,11 @@ namespace TimelessEchoes.Buffs
             foreach (var req in recipe.requirements)
                 resourceManager?.Spend(req.resource, req.amount);
 
-            var buff = activeBuffs.Find(b => b.recipe == recipe);
             var tracker = TimelessEchoes.Stats.GameplayStatTracker.Instance ??
                           FindFirstObjectByType<TimelessEchoes.Stats.GameplayStatTracker>();
+            tracker?.AddBuffCast();
+
+            var buff = activeBuffs.Find(b => b.recipe == recipe);
             float expireDist = float.PositiveInfinity;
             if (recipe.distancePercent > 0f && tracker != null)
                 expireDist = tracker.LongestRun * recipe.distancePercent;

--- a/Assets/Scripts/Stats/GameplayStatTracker.cs
+++ b/Assets/Scripts/Stats/GameplayStatTracker.cs
@@ -46,6 +46,11 @@ namespace TimelessEchoes.Stats
 
         public int TimesReaped { get; private set; }
 
+        /// <summary>
+        /// Number of times a buff has been cast.
+        /// </summary>
+        public int BuffsCast { get; private set; }
+
         public double TotalResourcesGathered { get; private set; }
 
         public IReadOnlyList<GameData.RunRecord> RecentRuns => recentRuns;
@@ -119,6 +124,7 @@ namespace TimelessEchoes.Stats
             g.DamageDealt = DamageDealt;
             g.DamageTaken = DamageTaken;
             g.TimesReaped = TimesReaped;
+            g.BuffsCast = BuffsCast;
             g.TotalResourcesGathered = TotalResourcesGathered;
             g.RecentRuns = new List<GameData.RunRecord>(recentRuns);
             g.LongestRun = LongestRun;
@@ -152,6 +158,7 @@ namespace TimelessEchoes.Stats
             DamageDealt = g.DamageDealt;
             DamageTaken = g.DamageTaken;
             TimesReaped = g.TimesReaped;
+            BuffsCast = g.BuffsCast;
             TotalResourcesGathered = g.TotalResourcesGathered;
             recentRuns.Clear();
             if (g.RecentRuns != null)
@@ -250,6 +257,11 @@ namespace TimelessEchoes.Stats
         public void AddTimesReaped()
         {
             TimesReaped++;
+        }
+
+        public void AddBuffCast()
+        {
+            BuffsCast++;
         }
 
         public void AddResources(double amount, bool bonus = false)

--- a/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
+++ b/Assets/Scripts/Steamworks.NET/SteamStatsUpdater.cs
@@ -135,6 +135,16 @@ namespace TimelessEchoes
                 }
             }
 
+            if (SteamUserStats.GetStat("BuffsCast", out int storedBuffs))
+            {
+                int newBuffs = tracker.BuffsCast;
+                if (newBuffs > storedBuffs)
+                {
+                    SteamUserStats.SetStat("BuffsCast", newBuffs);
+                    changed = true;
+                }
+            }
+
             if (changed)
                 SteamUserStats.StoreStats();
         }


### PR DESCRIPTION
## Summary
- track number of buffs cast in `GameplayStatTracker`
- persist BuffsCast in save data
- increment BuffsCast whenever a buff is purchased
- sync BuffsCast to Steam stats

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5de69538832e983a62c80e2a29d0