### PR TITLE
Implement Echo Lifetime upgrade

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -8,6 +8,7 @@ using TimelessEchoes.Stats;
 using TimelessEchoes.Tasks;
 using TimelessEchoes.Upgrades;
 using UnityEngine;
+using System.Linq;
 using static TimelessEchoes.TELogger;
 using Random = UnityEngine.Random;
 
@@ -336,10 +337,13 @@ namespace TimelessEchoes.Enemies
                                 ? config.capableSkills
                                 : new List<Skill> { skill };
                             var disable = config != null && config.disableSkills;
+                            var controller = StatUpgradeController.Instance;
+                            var echoUpgrade = controller?.AllUpgrades.FirstOrDefault(u => u != null && u.name == "Echo Lifetime");
+                            float bonus = echoUpgrade != null ? controller.GetTotalValue(echoUpgrade) : 0f;
                             for (var c = 0; c < count; c++)
                             {
                                 var combat = config != null && config.combatEnabled;
-                                EchoManager.SpawnEcho(skills, ms.echoDuration, combat, disable);
+                                EchoManager.SpawnEcho(skills, ms.echoDuration + bonus, combat, disable);
                             }
                         }
                     }

--- a/Assets/Scripts/Skills/MilestoneBonus.cs
+++ b/Assets/Scripts/Skills/MilestoneBonus.cs
@@ -1,6 +1,8 @@
 using System;
 using Sirenix.OdinInspector;
 using UnityEngine;
+using TimelessEchoes.Upgrades;
+using System.Linq;
 
 namespace TimelessEchoes.Skills
 {
@@ -78,7 +80,12 @@ namespace TimelessEchoes.Skills
                         else
                             skillText = "various";
                     }
-                    return $"Provides a {chance * 100f:0.#}% chance to summon an Echo that performs {skillText} tasks for {echoDuration:0.#} seconds.";
+
+                    var controller = StatUpgradeController.Instance;
+                    var echoUpgrade = controller?.AllUpgrades.FirstOrDefault(u => u != null && u.name == "Echo Lifetime");
+                    float bonus = echoUpgrade != null ? controller.GetTotalValue(echoUpgrade) : 0f;
+                    float totalDuration = echoDuration + bonus;
+                    return $"Provides a {chance * 100f:0.#}% chance to summon an Echo that performs {skillText} tasks for {totalDuration:0.#} seconds.";
                 default:
                     return string.Empty;
             }

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -3,6 +3,7 @@ using TimelessEchoes.Skills;
 using TimelessEchoes.Buffs;
 using UnityEngine;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TimelessEchoes.Tasks
 {
@@ -131,10 +132,13 @@ namespace TimelessEchoes.Tasks
                                 ? config.capableSkills
                                 : new System.Collections.Generic.List<Skill> { associatedSkill };
                             bool disable = config != null && config.disableSkills;
+                            var controller = StatUpgradeController.Instance;
+                            var echoUpgrade = controller?.AllUpgrades.FirstOrDefault(u => u != null && u.name == "Echo Lifetime");
+                            float bonus = echoUpgrade != null ? controller.GetTotalValue(echoUpgrade) : 0f;
                             for (int c = 0; c < count; c++)
                             {
                                 bool combat = config != null && config.combatEnabled;
-                                EchoManager.SpawnEcho(skills, ms.echoDuration, combat, disable);
+                                EchoManager.SpawnEcho(skills, ms.echoDuration + bonus, combat, disable);
                             }
                         }
                     }

--- a/Assets/Scripts/Upgrades/StatUpgradeController.cs
+++ b/Assets/Scripts/Upgrades/StatUpgradeController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using TimelessEchoes.Skills;
 using static Blindsided.EventHandler;
 using static Blindsided.Oracle;
 using static TimelessEchoes.TELogger;
@@ -67,6 +68,25 @@ namespace TimelessEchoes.Upgrades
         public float GetMultiplier(StatUpgrade upgrade)
         {
             return 1f + GetIncrease(upgrade);
+        }
+
+        /// <summary>
+        ///     Calculates the total value for a stat including flat and percent bonuses.
+        /// </summary>
+        public float GetTotalValue(StatUpgrade upgrade)
+        {
+            if (upgrade == null) return 0f;
+
+            int lvl = GetLevel(upgrade);
+            float baseVal = GetBaseValue(upgrade);
+            float levelIncrease = lvl * upgrade.statIncreasePerLevel;
+
+            var skillCtrl = SkillController.Instance;
+            float flat = skillCtrl ? skillCtrl.GetFlatStatBonus(upgrade) : 0f;
+            float percent = skillCtrl ? skillCtrl.GetPercentStatBonus(upgrade) : 0f;
+
+            float totalBeforePercent = baseVal + levelIncrease + flat;
+            return totalBeforePercent * (1f + percent);
         }
 
         public bool CanUpgrade(StatUpgrade upgrade)


### PR DESCRIPTION
## Summary
- support Echo Lifetime upgrade with a helper in `StatUpgradeController`
- extend milestone Echo spawn duration by the Echo Lifetime stat
- show the extended time in milestone descriptions

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6b920ad0832e905515fe037bef02