### PR TITLE
Fix compile errors in Enemy and task code

### DIFF
--- a/Assets/Scripts/Enemies/Enemy.cs
+++ b/Assets/Scripts/Enemies/Enemy.cs
@@ -337,9 +337,9 @@ namespace TimelessEchoes.Enemies
                                 ? config.capableSkills
                                 : new List<Skill> { skill };
                             var disable = config != null && config.disableSkills;
-                            var controller = StatUpgradeController.Instance;
-                            var echoUpgrade = controller?.AllUpgrades.FirstOrDefault(u => u != null && u.name == "Echo Lifetime");
-                            float bonus = echoUpgrade != null ? controller.GetTotalValue(echoUpgrade) : 0f;
+                            var upgradeController = StatUpgradeController.Instance;
+                            var echoUpgrade = upgradeController?.AllUpgrades.FirstOrDefault(u => u != null && u.name == "Echo Lifetime");
+                            float bonus = echoUpgrade != null ? upgradeController.GetTotalValue(echoUpgrade) : 0f;
                             for (var c = 0; c < count; c++)
                             {
                                 var combat = config != null && config.combatEnabled;

--- a/Assets/Scripts/Tasks/BaseTask.cs
+++ b/Assets/Scripts/Tasks/BaseTask.cs
@@ -4,6 +4,7 @@ using TimelessEchoes.Buffs;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TimelessEchoes.Upgrades;
 
 namespace TimelessEchoes.Tasks
 {
@@ -132,9 +133,9 @@ namespace TimelessEchoes.Tasks
                                 ? config.capableSkills
                                 : new System.Collections.Generic.List<Skill> { associatedSkill };
                             bool disable = config != null && config.disableSkills;
-                            var controller = StatUpgradeController.Instance;
-                            var echoUpgrade = controller?.AllUpgrades.FirstOrDefault(u => u != null && u.name == "Echo Lifetime");
-                            float bonus = echoUpgrade != null ? controller.GetTotalValue(echoUpgrade) : 0f;
+                            var upgradeController = StatUpgradeController.Instance;
+                            var echoUpgrade = upgradeController?.AllUpgrades.FirstOrDefault(u => u != null && u.name == "Echo Lifetime");
+                            float bonus = echoUpgrade != null ? upgradeController.GetTotalValue(echoUpgrade) : 0f;
                             for (int c = 0; c < count; c++)
                             {
                                 bool combat = config != null && config.combatEnabled;


### PR DESCRIPTION
## Summary
- rename nested StatUpgradeController variable to avoid shadowing
- add missing Upgrades namespace in BaseTask

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c6dc304ac832eb1429c23f299fcd0