### PR TITLE
Fix echo distance tracking

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -190,7 +190,7 @@ namespace TimelessEchoes.Hero
                               (buffController != null ? buffController.MoveSpeedMultiplier : 1f);
             UpdateAnimation();
             UpdateBehavior();
-            if (mapUI != null)
+            if (!IsEcho && mapUI != null)
                 mapUI.UpdateDistance(transform.position.x);
 
             var tracker = GameplayStatTracker.Instance;
@@ -198,7 +198,7 @@ namespace TimelessEchoes.Hero
             {
                 Log("GameplayStatTracker missing", TELogCategory.General, this);
             }
-            else
+            else if (!IsEcho)
             {
                 tracker.RecordHeroPosition(transform.position);
                 BuffManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);


### PR DESCRIPTION
## Summary
- ignore echoes when updating map distance and GameplayStatTracker

## Testing
- `unity-editor --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8ccf9a08832ebe202723d5ffea6e