### PR TITLE
Disable AutoBuff animator for Echoes

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -141,6 +141,9 @@ namespace TimelessEchoes.Hero
                 nextIsEcho = false;
             }
 
+            if (IsEcho && autoBuffAnimator != null)
+                autoBuffAnimator.gameObject.SetActive(false);
+
             if (!IsEcho)
             {
                 if (Instance != null && Instance != this) Destroy(Instance.gameObject);
@@ -709,6 +712,13 @@ namespace TimelessEchoes.Hero
         private void OnAutoBuffChanged()
         {
             if (autoBuffAnimator == null) return;
+            // Echoes should never display the autobuff overlay
+            if (IsEcho)
+            {
+                autoBuffAnimator.gameObject.SetActive(false);
+                return;
+            }
+
             autoBuffAnimator.gameObject.SetActive(AutoBuff);
             if (animator != null)
             {


### PR DESCRIPTION
## Summary
- ensure echoes don't display the AutoBuff overlay
- deactivate the AutoBuffAnimator for echo characters

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c8e380a98832eb85e23f07d4b4043