### PR TITLE
Refactor DiscipleGeneratorProgressUI

### DIFF
--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorUIManager.cs
@@ -17,7 +17,7 @@ namespace TimelessEchoes.NpcGeneration
         [SerializeField] private Button collectAllButton;
 
         private DiscipleGenerationManager generationManager;
-        private readonly Dictionary<DiscipleGenerator, List<DiscipleGeneratorProgressUI>> entries = new();
+        private readonly Dictionary<DiscipleGenerator, DiscipleGeneratorProgressUI> entries = new();
 
         private void Awake()
         {
@@ -67,16 +67,9 @@ namespace TimelessEchoes.NpcGeneration
                 if (gen == null || !gen.RequirementsMet)
                     continue;
 
-                var list = new List<DiscipleGeneratorProgressUI>();
-                foreach (var entry in gen.ResourceEntries)
-                {
-                    if (entry.resource == null) continue;
-                    var ui = Instantiate(progressUIPrefab, progressUIParent);
-                    ui.SetData(gen, entry.resource, entry.amount);
-                    list.Add(ui);
-                }
-
-                entries[gen] = list;
+                var ui = Instantiate(progressUIPrefab, progressUIParent);
+                ui.SetData(gen);
+                entries[gen] = ui;
             }
 
             UpdateCollectAllButton();

--- a/Assets/Scripts/References/UI/DiscipleGeneratedResourceUIReferences.cs
+++ b/Assets/Scripts/References/UI/DiscipleGeneratedResourceUIReferences.cs
@@ -1,0 +1,16 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace References.UI
+{
+    /// <summary>
+    /// Holds references for a generated resource entry on a disciple generator UI.
+    /// </summary>
+    public class DiscipleGeneratedResourceUIReferences : MonoBehaviour
+    {
+        public Image iconImage;
+        public Button selectButton;
+        public TMP_Text awaitingCollectionText;
+    }
+}


### PR DESCRIPTION
## Summary
- support multiple resource displays per generator
- add `DiscipleGeneratedResourceUIReferences` for generated resource entries
- update `DiscipleGeneratorProgressUI` to spawn resource entries and update their values
- simplify `DiscipleGeneratorUIManager` to create one progress UI per generator

## Testing
- `echo "Running tests (none available)"`

------
https://chatgpt.com/codex/tasks/task_e_687c941bf00c832eac150293815aefcf