### PR TITLE
Update Disciple UI name and totals

### DIFF
--- a/Assets/Scripts/NpcGeneration/DiscipleGenerator.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGenerator.cs
@@ -34,6 +34,7 @@ namespace TimelessEchoes.NpcGeneration
         private bool setup;
 
         public float Interval => data != null ? data.generationInterval : 0f;
+        public string DiscipleName => data != null ? data.name : string.Empty;
         public float Progress { get; private set; }
         public IReadOnlyList<Disciple.ResourceEntry> ResourceEntries => data ? data.resources : null;
         public bool RequirementsMet => QuestCompleted();

--- a/Assets/Scripts/NpcGeneration/DiscipleGeneratorProgressUI.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleGeneratorProgressUI.cs
@@ -59,9 +59,7 @@ namespace TimelessEchoes.NpcGeneration
 
             if (resourceNameText != null)
             {
-                var first = generator.ResourceEntries != null && generator.ResourceEntries.Count > 0 ?
-                    generator.ResourceEntries[0].resource : null;
-                resourceNameText.text = first ? first.name : string.Empty;
+                resourceNameText.text = generator != null ? generator.DiscipleName : string.Empty;
             }
 
             if (collectButton != null)
@@ -109,11 +107,14 @@ namespace TimelessEchoes.NpcGeneration
 
             if (resourceManager != null && totalCollectedText != null)
             {
-                double total = 0;
+                var parts = new List<string>();
                 foreach (var entry in generator.ResourceEntries)
-                    if (entry.resource != null)
-                        total += generator.GetTotalCollected(entry.resource);
-                totalCollectedText.text = CalcUtils.FormatNumber(total, true);
+                {
+                    if (entry.resource == null) continue;
+                    var val = generator.GetTotalCollected(entry.resource);
+                    parts.Add(CalcUtils.FormatNumber(val, true));
+                }
+                totalCollectedText.text = string.Join(", ", parts);
             }
 
             foreach (var pair in resourceUIs)


### PR DESCRIPTION
## Summary
- display the disciple scriptable object's name in the generator UI
- show collected totals per resource, separated by commas

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687c97dec380832e910abcd921436822