### PR TITLE
Fix hero task reset on echo completion

### DIFF
--- a/Assets/Scripts/Tasks/TaskController.cs
+++ b/Assets/Scripts/Tasks/TaskController.cs
@@ -263,8 +263,12 @@ namespace TimelessEchoes.Tasks
 
             if (removed && hero != null)
             {
-                hero.SetTask(null);
-                SelectEarliestTask(hero);
+                var current = hero.CurrentTask;
+                if (current == null || current.IsComplete() || !tasks.Contains(current))
+                {
+                    hero.SetTask(null);
+                    SelectEarliestTask(hero);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- keep hero task active when echoes finish their own tasks

## Testing
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_687cb1ebf55c832e8a2d1ae26b592649