### PR TITLE
Hide buff tooltip when skill window open

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -7,6 +7,7 @@ using UnityEngine.UI;
 using static Blindsided.EventHandler;
 using static TimelessEchoes.TELogger;
 using static Blindsided.Utilities.CalcUtils;
+using TimelessEchoes.UI;
 
 namespace TimelessEchoes.Buffs
 {
@@ -351,6 +352,12 @@ namespace TimelessEchoes.Buffs
             if (runSlotTooltip == null || runSlotTooltip.tooltipPanel == null || slot < 0 ||
                 slot >= runSlotButtons.Length)
                 return;
+
+            if (RunCalebUIManager.Instance != null && RunCalebUIManager.Instance.IsSkillsWindowOpen)
+            {
+                runSlotTooltip.tooltipPanel.SetActive(false);
+                return;
+            }
 
             if (buffManager != null && !buffManager.IsSlotUnlocked(slot))
             {

--- a/Assets/Scripts/UI/RunCalebUIManager.cs
+++ b/Assets/Scripts/UI/RunCalebUIManager.cs
@@ -12,10 +12,13 @@ namespace TimelessEchoes.UI
     /// </summary>
     public class RunCalebUIManager : MonoBehaviour
     {
+        public static RunCalebUIManager Instance { get; private set; }
         [SerializeField] private RunCalebUIReferences uiReferences;
         [SerializeField] private GameObject skillsWindow;
         [SerializeField] private BuffManager buffManager;
         [SerializeField] private RegenManager regenManager;
+
+        public bool IsSkillsWindowOpen => skillsWindow != null && skillsWindow.activeSelf;
 
         private HeroController hero;
         private HeroHealth heroHealth;
@@ -29,6 +32,14 @@ namespace TimelessEchoes.UI
 
         private void Awake()
         {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+
             if (uiReferences == null)
                 uiReferences = GetComponent<RunCalebUIReferences>();
             if (buffManager == null)
@@ -41,6 +52,8 @@ namespace TimelessEchoes.UI
 
         private void OnDestroy()
         {
+            if (Instance == this)
+                Instance = null;
             if (uiReferences != null && uiReferences.skillsButton != null)
                 uiReferences.skillsButton.onClick.RemoveListener(ToggleSkills);
             if (heroHealth != null)
@@ -76,7 +89,16 @@ namespace TimelessEchoes.UI
         private void ToggleSkills()
         {
             if (skillsWindow != null)
-                skillsWindow.SetActive(!skillsWindow.activeSelf);
+            {
+                bool newState = !skillsWindow.activeSelf;
+                skillsWindow.SetActive(newState);
+                if (newState)
+                {
+                    var tooltip = FindFirstObjectByType<RunBuffTooltipUIReferences>();
+                    if (tooltip != null && tooltip.tooltipPanel != null)
+                        tooltip.tooltipPanel.SetActive(false);
+                }
+            }
         }
 
         private void OnHealthChanged(float current, float max)


### PR DESCRIPTION
## Summary
- add `Instance` and `IsSkillsWindowOpen` to `RunCalebUIManager`
- close open buff tooltip when toggling skills
- suppress tooltip display while skills window is active

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687cc4c8ca54832e91705b512b16ddf6