### PR TITLE
Tint combat only echoes red

### DIFF
--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -28,7 +28,13 @@ namespace TimelessEchoes.Hero
                 {
                     var c = r.color;
                     c.a = 0.7f;
-                    r.color = c;
+
+                    // Combat only echoes should appear slightly red to
+                    // differentiate them from regular echoes.
+                    if (combat && disableSkills)
+                        r.color = new Color(1f, 0.5f, 0.5f, c.a);
+                    else
+                        r.color = c;
                 }
 
                 // Echoes share the primary hero's health. Keep the existing


### PR DESCRIPTION
## Summary
- tint combat-only echoes red so they stand out

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cc60dcac0832e98a4e3daaa8a85e3