### PR TITLE
Fix death animation frame for large slimes

### DIFF
--- a/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Blue/Die.anim
+++ b/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Blue/Die.anim
@@ -27,7 +27,7 @@ AnimationClip:
     - time: 0.16666667
       value: {fileID: -1473831661389435138, guid: 3e01acf9edb65ef40a82049bae8cb803, type: 3}
     - time: 0.25
-      value: {fileID: 531796579635036575, guid: 3e01acf9edb65ef40a82049bae8cb803, type: 3}
+      value: {fileID: 1786753803120523485, guid: 3e01acf9edb65ef40a82049bae8cb803, type: 3}
     - time: 0.33333334
       value: {fileID: 2752902821166742420, guid: 3e01acf9edb65ef40a82049bae8cb803, type: 3}
     - time: 0.41666666

--- a/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Green/Die.anim
+++ b/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Green/Die.anim
@@ -27,7 +27,7 @@ AnimationClip:
     - time: 0.16666667
       value: {fileID: 8503437504210849829, guid: 1c0a69916f13b9a49b6510e7029d8536, type: 3}
     - time: 0.25
-      value: {fileID: 4505700887261528831, guid: 1c0a69916f13b9a49b6510e7029d8536, type: 3}
+      value: {fileID: 5456964202584782195, guid: 1c0a69916f13b9a49b6510e7029d8536, type: 3}
     - time: 0.33333334
       value: {fileID: 4937255999451253013, guid: 1c0a69916f13b9a49b6510e7029d8536, type: 3}
     - time: 0.41666666

--- a/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Pink/Die.anim
+++ b/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Pink/Die.anim
@@ -27,7 +27,7 @@ AnimationClip:
     - time: 0.16666667
       value: {fileID: 2072014423713880344, guid: 96d41862c586be04e828327c29a2bef5, type: 3}
     - time: 0.25
-      value: {fileID: 7575724073549956062, guid: 96d41862c586be04e828327c29a2bef5, type: 3}
+      value: {fileID: -5550986131262993513, guid: 96d41862c586be04e828327c29a2bef5, type: 3}
     - time: 0.33333334
       value: {fileID: 7678711396147903173, guid: 96d41862c586be04e828327c29a2bef5, type: 3}
     - time: 0.41666666

--- a/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Red/Die.anim
+++ b/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Red/Die.anim
@@ -27,7 +27,7 @@ AnimationClip:
     - time: 0.16666667
       value: {fileID: 243392352856207370, guid: 01b1882953a269b409729dc78a891b9c, type: 3}
     - time: 0.25
-      value: {fileID: -3308336903761473447, guid: 01b1882953a269b409729dc78a891b9c, type: 3}
+      value: {fileID: 7196023808350325997, guid: 01b1882953a269b409729dc78a891b9c, type: 3}
     - time: 0.33333334
       value: {fileID: -5275980773344156750, guid: 01b1882953a269b409729dc78a891b9c, type: 3}
     - time: 0.41666666

--- a/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Yellow/Die.anim
+++ b/Assets/Art/Packs/Cute_Fantasy/Enemies/Slime/Slime_Big/Yellow/Die.anim
@@ -27,7 +27,7 @@ AnimationClip:
     - time: 0.16666667
       value: {fileID: -4966869954662797664, guid: d4a94f9066ffb51419de58b5392e7d5a, type: 3}
     - time: 0.25
-      value: {fileID: -4966869954662797664, guid: d4a94f9066ffb51419de58b5392e7d5a, type: 3}
+      value: {fileID: 1040728083163823532, guid: d4a94f9066ffb51419de58b5392e7d5a, type: 3}
     - time: 0.33333334
       value: {fileID: 1937371054651581015, guid: d4a94f9066ffb51419de58b5392e7d5a, type: 3}
     - time: 0.41666666


### PR DESCRIPTION
## Summary
- update the fourth frame of each large slime death animation so they show sprite 15

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d7fa12fec832eba332476326386bf