### PR TITLE
Format EnemyStats with Odin groups

### DIFF
--- a/Assets/Scripts/Enemies/EnemyStats.cs
+++ b/Assets/Scripts/Enemies/EnemyStats.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Sirenix.OdinInspector;
 using Blindsided.Utilities;
 
 namespace TimelessEchoes.Enemies
@@ -7,25 +8,53 @@ namespace TimelessEchoes.Enemies
     [CreateAssetMenu(fileName = "EnemyStats", menuName = "SO/Enemy Stats")]
     public class EnemyStats : ScriptableObject
     {
+        [TitleGroup("General")]
         public string enemyName;
-        [Tooltip("Lower numbers appear first in the stats panel")] public int displayOrder = 0;
+
+        [TitleGroup("General")]
+        [Tooltip("Lower numbers appear first in the stats panel")]
+        public int displayOrder = 0;
+
+        [TitleGroup("References")]
         public Sprite icon;
+
+        [TitleGroup("Balance Data")]
         public int maxHealth = 10;
+
+        [TitleGroup("Balance Data")]
         public int experience = 10;
+
+        [TitleGroup("Balance Data")]
         public float defense = 0f;
+
+        [TitleGroup("Balance Data")]
         public int damage = 1;
+
+        [TitleGroup("Balance Data")]
         public float moveSpeed = 3f;
+
+        [TitleGroup("Balance Data")]
         public float attackSpeed = 1f;
+
         /// <summary>
         /// Distance within which the enemy can perform attacks.
         /// </summary>
+        [TitleGroup("Balance Data")]
         public float attackRange = 1f;
+
+        [TitleGroup("Balance Data")]
         public float visionRange = 5f;
+
         /// <summary>
         /// Distance within which allies will join an engaged enemy.
         /// </summary>
+        [TitleGroup("Balance Data")]
         public float assistRange = 8f;
+
+        [TitleGroup("Balance Data")]
         public float wanderDistance = 2f;
+
+        [TitleGroup("References")]
         public GameObject projectilePrefab;
     }
 }


### PR DESCRIPTION
## Summary
- group `EnemyStats` fields with Odin Inspector attributes
- split references from balance data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d834ebd6c832e9becd25bf946ff0f