### PR TITLE
Sync town crops with disciple progress

### DIFF
--- a/Assets/Scripts/NpcGeneration/DiscipleCropGrowth.cs
+++ b/Assets/Scripts/NpcGeneration/DiscipleCropGrowth.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+
+namespace TimelessEchoes.NpcGeneration
+{
+    /// <summary>
+    /// Updates a town crop sprite based on its disciple generator progress.
+    /// </summary>
+    public class DiscipleCropGrowth : MonoBehaviour
+    {
+        [SerializeField] private string discipleName;
+        [SerializeField] private DiscipleGenerator generator;
+        [SerializeField] private SpriteRenderer spriteRenderer;
+        [SerializeField] private Sprite[] growthStages = new Sprite[4];
+
+        private int currentStage = -1;
+
+        private void Awake()
+        {
+            if (spriteRenderer == null)
+                spriteRenderer = GetComponent<SpriteRenderer>();
+        }
+
+        private void Start()
+        {
+            if (generator == null)
+                FindGenerator();
+        }
+
+        private void Update()
+        {
+            if (generator == null)
+            {
+                FindGenerator();
+                if (generator == null)
+                    return;
+            }
+
+            if (growthStages == null || growthStages.Length == 0 || generator.Interval <= 0f)
+                return;
+
+            float pct = Mathf.Clamp01(generator.Progress / generator.Interval);
+            int stage = Mathf.Clamp(Mathf.FloorToInt(pct * growthStages.Length), 0, growthStages.Length - 1);
+
+            if (stage != currentStage)
+            {
+                currentStage = stage;
+                if (spriteRenderer != null && currentStage < growthStages.Length)
+                    spriteRenderer.sprite = growthStages[currentStage];
+            }
+        }
+
+        private void FindGenerator()
+        {
+            if (string.IsNullOrEmpty(discipleName))
+                return;
+
+            var manager = DiscipleGenerationManager.Instance;
+            if (manager == null)
+                return;
+
+            foreach (var gen in manager.Generators)
+            {
+                if (gen != null && gen.DiscipleName == discipleName)
+                {
+                    generator = gen;
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `DiscipleCropGrowth` component for static crops in town
- crops update their sprite according to the disciple generator's progress

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8f48ab8c832e8035b496a95c688f