### PR TITLE
Enable auto-walk when no tasks remain

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -83,6 +83,9 @@ namespace TimelessEchoes.Hero
         private HeroHealth health;
         private float healthBonus;
 
+        [SerializeField] private float idleWalkStep = 5f;
+        private Transform idleWalkTarget;
+
         private bool isRolling;
         private float lastAttack = float.NegativeInfinity;
 
@@ -250,6 +253,13 @@ namespace TimelessEchoes.Hero
             destinationOverride = false;
             lastAttack = Time.time - 1f / CurrentAttackRate;
 
+            if (idleWalkTarget == null)
+            {
+                idleWalkTarget = new GameObject("IdleWalkTarget").transform;
+                idleWalkTarget.hideFlags = HideFlags.HideInHierarchy;
+            }
+            idleWalkTarget.position = transform.position;
+
             var skillController = SkillController.Instance;
             if (!IsEcho && skillController != null)
                 skillController.OnMilestoneUnlocked += OnMilestoneUnlocked;
@@ -277,6 +287,10 @@ namespace TimelessEchoes.Hero
 
             if (!IsEcho)
                 Enemy.OnEngage -= OnEnemyEngage;
+
+            if (idleWalkTarget != null)
+                Destroy(idleWalkTarget.gameObject);
+            idleWalkTarget = null;
         }
 
         private void OnDestroy()
@@ -286,6 +300,9 @@ namespace TimelessEchoes.Hero
 
             if (!IsEcho && Instance == this)
                 Instance = null;
+
+            if (idleWalkTarget != null)
+                Destroy(idleWalkTarget.gameObject);
         }
 
         private void OnMilestoneUnlocked(Skill skill, MilestoneBonus milestone)
@@ -477,7 +494,14 @@ namespace TimelessEchoes.Hero
 
             if (CurrentTask == null)
             {
-                setter.target = null;
+                if (taskController == null || taskController.tasks.Count == 0)
+                {
+                    AutoAdvance();
+                }
+                else
+                {
+                    setter.target = null;
+                }
                 return;
             }
 
@@ -684,6 +708,24 @@ namespace TimelessEchoes.Hero
 
             var threshold = ai.endReachedDistance + 0.1f;
             return Vector2.Distance(transform.position, dest.position) <= threshold;
+        }
+
+        private void AutoAdvance()
+        {
+            if (idleWalkTarget == null)
+            {
+                idleWalkTarget = new GameObject("IdleWalkTarget").transform;
+                idleWalkTarget.hideFlags = HideFlags.HideInHierarchy;
+            }
+
+            var pos = transform.position;
+            if (idleWalkTarget.position.x - pos.x < 1f)
+                idleWalkTarget.position = new Vector3(pos.x + idleWalkStep, pos.y, pos.z);
+
+            if (setter.target != idleWalkTarget)
+                setter.target = idleWalkTarget;
+
+            ai.canMove = true;
         }
 
         private void OnAutoBuffChanged()


### PR DESCRIPTION
## Summary
- have the HeroController create a hidden target for automatic movement
- walk right when no tasks exist so new chunks can spawn
- clean up the temporary target on disable/destroy

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687dc383af0c832eb9fadd30cb9ae4d7