### PR TITLE
Fix AutoBuff wipe

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/GameData.cs
+++ b/Assets/Scripts/Blindsided/SaveData/GameData.cs
@@ -27,6 +27,10 @@ namespace Blindsided.SaveData
         [HideReferenceObjectPicker]
         public List<string> BuffSlots = new() { "MoveSpeed", null, null, null, null };
         public int UnlockedBuffSlots = 1;
+        /// <summary>
+        ///     Automatically cast available buffs when enabled.
+        /// </summary>
+        public bool AutoBuff;
         [HideReferenceObjectPicker] public Dictionary<string, double> FishDonations = new();
 
         [HideReferenceObjectPicker] public HashSet<string> CompletedNpcTasks = new();
@@ -76,10 +80,6 @@ namespace Blindsided.SaveData
             public float MusicVolume = 0.25f;
             public float SfxVolume = 0.7f;
 
-            /// <summary>
-            ///     Automatically cast available buffs when enabled.
-            /// </summary>
-            public bool AutoBuff;
         }
 
         [HideReferenceObjectPicker]

--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -124,12 +124,12 @@ namespace Blindsided.SaveData
 
         public static bool AutoBuff
         {
-            get => oracle.saveData.SavedPreferences.AutoBuff;
+            get => oracle.saveData.AutoBuff;
             set
             {
-                if (oracle.saveData.SavedPreferences.AutoBuff != value)
+                if (oracle.saveData.AutoBuff != value)
                 {
-                    oracle.saveData.SavedPreferences.AutoBuff = value;
+                    oracle.saveData.AutoBuff = value;
                     AutoBuffChanged?.Invoke();
                 }
             }


### PR DESCRIPTION
## Summary
- move AutoBuff boolean from `SavedPreferences` to the main `GameData` class
- reference the new location from `StaticReferences`

## Testing
- `unity-editor -runTests -batchmode -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dd9e9219c832ea030a87271c722eb