### PR TITLE
Add instant completion quest type

### DIFF
--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -42,7 +42,8 @@ namespace TimelessEchoes.Quests
             Kill,
             Donation,
             DistanceRun,
-            DistanceTravel
+            DistanceTravel,
+            Instant
         }
     }
 }

--- a/Assets/Scripts/Quests/QuestEntryUI.cs
+++ b/Assets/Scripts/Quests/QuestEntryUI.cs
@@ -101,6 +101,11 @@ namespace TimelessEchoes.Quests
                                 slot.iconImage.sprite = null;
                                 slot.iconImage.color = Color.white;
                             }
+                            else if (req.type == QuestData.RequirementType.Instant)
+                            {
+                                slot.iconImage.sprite = null;
+                                slot.iconImage.color = Color.white;
+                            }
                         }
 
                         if (slot.countText != null)
@@ -159,6 +164,11 @@ namespace TimelessEchoes.Quests
                     slot.iconImage.sprite = null;
                     slot.iconImage.color = Color.white;
                 }
+                else if (req.type == QuestData.RequirementType.Instant)
+                {
+                    slot.iconImage.sprite = null;
+                    slot.iconImage.color = Color.white;
+                }
             }
         }
 
@@ -179,6 +189,8 @@ namespace TimelessEchoes.Quests
                     return "Run Distance";
                 case QuestData.RequirementType.DistanceTravel:
                     return "Travel";
+                case QuestData.RequirementType.Instant:
+                    return "Instant";
                 default:
                     return type.ToString();
             }

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -219,6 +219,10 @@ namespace TimelessEchoes.Quests
                     if (req.amount > 0)
                         pct = travelled / req.amount;
                 }
+                else if (req.type == QuestData.RequirementType.Instant)
+                {
+                    pct = 1f;
+                }
 
                 progress += Mathf.Clamp01(pct);
             }
@@ -335,6 +339,23 @@ namespace TimelessEchoes.Quests
             }
 
             inst.ui = null;
+
+            var instant = false;
+            foreach (var req in quest.requirements)
+            {
+                if (req.type == QuestData.RequirementType.Instant)
+                {
+                    instant = true;
+                    break;
+                }
+            }
+
+            if (instant)
+            {
+                CompleteQuest(inst);
+                return;
+            }
+
             active[quest.questId] = inst;
             UpdateProgress(inst);
         }


### PR DESCRIPTION
## Summary
- implement new `Instant` quest requirement
- auto-complete quests with the Instant requirement
- update quest UI to recognize the new requirement

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687de0d175dc832e81e5619b3f877106