### PR TITLE
Fix instant quest behavior and editor fields

### DIFF
--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -29,6 +29,7 @@ namespace TimelessEchoes.Quests
             public RequirementType type;
             [ShowIf("@type == RequirementType.Resource || type == RequirementType.Donation")]
             public Resource resource;
+            [HideIf("type", RequirementType.Instant)]
             public int amount = 1;
             [ShowIf("type", RequirementType.Kill)]
             public List<EnemyStats> enemies = new();

--- a/Assets/Scripts/Quests/QuestManager.cs
+++ b/Assets/Scripts/Quests/QuestManager.cs
@@ -340,22 +340,6 @@ namespace TimelessEchoes.Quests
 
             inst.ui = null;
 
-            var instant = false;
-            foreach (var req in quest.requirements)
-            {
-                if (req.type == QuestData.RequirementType.Instant)
-                {
-                    instant = true;
-                    break;
-                }
-            }
-
-            if (instant)
-            {
-                CompleteQuest(inst);
-                return;
-            }
-
             active[quest.questId] = inst;
             UpdateProgress(inst);
         }


### PR DESCRIPTION
## Summary
- show quest amount only when requirement isn't Instant
- remove auto-completion for instant quests so they still require a hand‑in

## Testing
- `npm test` *(fails: no `package.json`)*
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_687de47d3cec832e87f574ea81f10f37