### PR TITLE
Hide amount field for meet quest requirements

### DIFF
--- a/Assets/Scripts/Quests/QuestData.cs
+++ b/Assets/Scripts/Quests/QuestData.cs
@@ -30,6 +30,7 @@ namespace TimelessEchoes.Quests
             [ShowIf("@type == RequirementType.Resource || type == RequirementType.Donation")]
             public Resource resource;
             [HideIf("type", RequirementType.Instant)]
+            [HideIf("type", RequirementType.Meet)]
             public int amount = 1;
             [ShowIf("type", RequirementType.Kill)]
             public List<EnemyStats> enemies = new();


### PR DESCRIPTION
## Summary
- hide the `amount` inspector field when quest requirement type is `Meet`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df505a144832eac9443a8a2de1955