### PR TITLE
Fix buff UI hero alive check

### DIFF
--- a/Assets/Scripts/Buffs/BuffUIManager.cs
+++ b/Assets/Scripts/Buffs/BuffUIManager.cs
@@ -42,6 +42,10 @@ namespace TimelessEchoes.Buffs
         {
             if (buffManager == null) return;
 
+            if (heroHealth == null || !heroHealth.gameObject.activeInHierarchy)
+                heroHealth = Hero.HeroHealth.Instance ??
+                             FindFirstObjectByType<Hero.HeroHealth>();
+
             var transparent = new Color(1f, 1f, 1f, 0f);
             var grey = new Color(1f, 1f, 1f, 0.4f);
             var unlocked = buffManager.UnlockedSlots;


### PR DESCRIPTION
## Summary
- refresh heroHealth reference when updating buff UI

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb164f5d8832e9bb82b421fe780f2