### PR TITLE
Fix AutoBuff persistence across hero death

### DIFF
--- a/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
+++ b/Assets/Scripts/Blindsided/SaveData/StaticReferences.cs
@@ -122,9 +122,14 @@ namespace Blindsided.SaveData
             }
         }
 
+        /// <summary>
+        ///     Indicates whether autobuff is enabled. The saved preference can
+        ///     temporarily be disabled for the remainder of a run without
+        ///     affecting the persisted value.
+        /// </summary>
         public static bool AutoBuff
         {
-            get => oracle.saveData.AutoBuff;
+            get => oracle.saveData.AutoBuff && !autoBuffDisabledThisRun;
             set
             {
                 if (oracle.saveData.AutoBuff != value)
@@ -132,6 +137,21 @@ namespace Blindsided.SaveData
                     oracle.saveData.AutoBuff = value;
                     AutoBuffChanged?.Invoke();
                 }
+            }
+        }
+
+        private static bool autoBuffDisabledThisRun;
+
+        /// <summary>
+        ///     Temporarily enable or disable autobuff until the next run starts.
+        /// </summary>
+        /// <param name="disabled">True to disable autobuff for the current run.</param>
+        public static void SetAutoBuffRunDisabled(bool disabled)
+        {
+            if (autoBuffDisabledThisRun != disabled)
+            {
+                autoBuffDisabledThisRun = disabled;
+                AutoBuffChanged?.Invoke();
             }
         }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -241,6 +241,8 @@ namespace TimelessEchoes
         private void StartRun()
         {
             HideTooltip();
+            // Re-enable autobuff for the new run based on the saved preference.
+            SetAutoBuffRunDisabled(false);
             returnOnDeathQueued = false;
             retreatQueued = false;
             if (returnOnDeathText != null)
@@ -390,8 +392,8 @@ namespace TimelessEchoes
             }
 
             BuffManager.Instance?.ClearActiveBuffs();
-            // Disable autobuff when the hero dies to prevent automatic casting
-            AutoBuff = false;
+            // Temporarily disable autobuff for the remainder of this run.
+            SetAutoBuffRunDisabled(true);
             UpdateAutoBuffUI();
 
             runEndedByDeath = true;


### PR DESCRIPTION
## Summary
- keep the player's Autobuff setting in save data
- temporarily disable Autobuff when the hero dies
- re‑enable Autobuff when a new run starts

## Testing
- `apt-get update`
- `apt-get install -y mono-mcs`
- `mcs Assets/Scripts/Blindsided/SaveData/StaticReferences.cs` *(fails: `CS1014`)*

------
https://chatgpt.com/codex/tasks/task_e_687ebb68b628832e856dc33e22309550