### PR TITLE
Fix EchoActivator missing on hero spawn

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -290,6 +290,8 @@ namespace TimelessEchoes
             if (hero != null)
             {
                 hero.gameObject.SetActive(true);
+                if (hero.GetComponent<EchoActivator>() == null)
+                    hero.gameObject.AddComponent<EchoActivator>();
                 var hp = hero.GetComponent<HeroHealth>();
                 if (hp != null)
                 {


### PR DESCRIPTION
## Summary
- automatically add `EchoActivator` to the hero when a run begins

## Testing
- `dotnet test --no-build` *(fails: MSBUILD error - no project file)*

------
https://chatgpt.com/codex/tasks/task_e_687ebd6964e4832e87b2933ec94f644a