### PR TITLE
Fix distance tracking for echoes

### DIFF
--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -220,7 +220,8 @@ namespace TimelessEchoes.Hero
             }
             else
             {
-                tracker.RecordHeroPosition(transform.position);
+                if (!IsEcho)
+                    tracker.RecordHeroPosition(transform.position);
                 BuffManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);
 #if !DISABLESTEAMWORKS
                 RichPresenceManager.Instance?.UpdateDistance(tracker.CurrentRunDistance);


### PR DESCRIPTION
## Summary
- prevent echo clones from updating run distance statistics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee27af02c832eb2d8fa3ed53f5d1a