### PR TITLE
Fix auto buff toggling when returning to town

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -466,6 +466,9 @@ namespace TimelessEchoes
         private IEnumerator ReturnToTavernRoutine()
         {
             HideTooltip();
+            // Reactivate autobuff if it was temporarily disabled by death.
+            SetAutoBuffRunDisabled(false);
+            UpdateAutoBuffUI();
             returnOnDeathQueued = false;
             retreatQueued = false;
             if (returnOnDeathText != null)


### PR DESCRIPTION
## Summary
- ensure AutoBuff reactivates when the player returns to town after death

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f2b02d260832eace7d3084f9f9507