### PR TITLE
Add task speed buff

### DIFF
--- a/Assets/Scripts/Buffs/BuffManager.cs
+++ b/Assets/Scripts/Buffs/BuffManager.cs
@@ -255,6 +255,17 @@ namespace TimelessEchoes.Buffs
             }
         }
 
+        public float TaskSpeedMultiplier
+        {
+            get
+            {
+                var percent = 0f;
+                foreach (var b in activeBuffs)
+                    percent += b.recipe.taskSpeedPercent;
+                return 1f + percent / 100f;
+            }
+        }
+
         public float LifestealPercent
         {
             get

--- a/Assets/Scripts/Buffs/BuffRecipe.cs
+++ b/Assets/Scripts/Buffs/BuffRecipe.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Blindsided.Utilities;
 using TimelessEchoes.Upgrades;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace TimelessEchoes.Buffs
@@ -10,26 +11,60 @@ namespace TimelessEchoes.Buffs
     [CreateAssetMenu(fileName = "BuffRecipe", menuName = "SO/Buff Recipe")]
     public class BuffRecipe : ScriptableObject
     {
+        [TitleGroup("General")]
         [Tooltip("Display name for this buff. If empty the asset name will be used.")]
         public string title;
 
+        [TitleGroup("General")]
         [TextArea]
         public string description;
 
+        [TitleGroup("General")]
         public Sprite buffIcon;
-        [Min(0f)] public float baseDuration = 30f;
+
+        [TitleGroup("General")]
+        [MinValue(0f)]
+        public float baseDuration = 30f;
+
+        [TitleGroup("General")]
+        [Tooltip("Percent of longest run distance this buff remains active. 0 = no distance limit")]
+        [Range(0f,1f)]
+        public float distancePercent;
+
+        [TitleGroup("General")]
         [SerializeField]
         public TimelessEchoes.EchoSpawnConfig echoSpawnConfig;
-        [Range(-100f, 100f)] public float moveSpeedPercent;
-        [Range(-100f, 100f)] public float damagePercent;
-        [Range(-100f, 100f)] public float defensePercent;
-        [Range(-100f, 100f)] public float attackSpeedPercent;
+
+        [TitleGroup("Effects")]
+        [Range(-100f, 100f)]
+        public float moveSpeedPercent;
+
+        [TitleGroup("Effects")]
+        [Range(-100f, 100f)]
+        public float damagePercent;
+
+        [TitleGroup("Effects")]
+        [Range(-100f, 100f)]
+        public float defensePercent;
+
+        [TitleGroup("Effects")]
+        [Range(-100f, 100f)]
+        public float attackSpeedPercent;
+
+        [TitleGroup("Effects")]
+        [Range(-100f, 100f)]
+        public float taskSpeedPercent;
+
+        [TitleGroup("Effects")]
         [Tooltip("Percent of damage returned as health while active.")]
-        [Range(0f, 100f)] public float lifestealPercent;
+        [Range(0f, 100f)]
+        public float lifestealPercent;
+
+        [TitleGroup("Effects")]
         [Tooltip("Tasks complete instantly while active.")]
         public bool instantTasks;
-        [Tooltip("Percent of longest run distance this buff remains active. 0 = no distance limit")]
-        [Range(0f,1f)] public float distancePercent;
+
+        [TitleGroup("Requirements")]
         public List<ResourceRequirement> requirements = new();
 
         public string Title => string.IsNullOrEmpty(title) ? name : title;

--- a/Assets/Scripts/Tasks/ContinuousTask.cs
+++ b/Assets/Scripts/Tasks/ContinuousTask.cs
@@ -68,6 +68,10 @@ namespace TimelessEchoes.Tasks
             var controller = SkillController.Instance ?? FindFirstObjectByType<SkillController>();
             if (controller != null && associatedSkill != null)
                 delta *= controller.GetTaskSpeedMultiplier(associatedSkill);
+
+            var buffManager = BuffManager.Instance ?? FindFirstObjectByType<BuffManager>();
+            if (buffManager != null)
+                delta *= buffManager.TaskSpeedMultiplier;
             timer += delta;
             if (!isComplete)
             {

--- a/Assets/Scripts/Tests/Editor/BuffTaskSpeedTests.cs
+++ b/Assets/Scripts/Tests/Editor/BuffTaskSpeedTests.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using TimelessEchoes.Buffs;
+using TimelessEchoes.Tasks;
+using TimelessEchoes.Skills;
+
+namespace TimelessEchoes.Tests
+{
+    public class BuffTaskSpeedTests
+    {
+        private GameObject buffObj;
+        private BuffManager manager;
+        private BuffRecipe recipe;
+
+        private GameObject controllerObj;
+        private SkillController controller;
+        private Skill skill;
+        private TaskData data;
+        private MiningTask task;
+        private GameObject taskObj;
+
+        [SetUp]
+        public void SetUp()
+        {
+            buffObj = new GameObject();
+            manager = buffObj.AddComponent<BuffManager>();
+            recipe = ScriptableObject.CreateInstance<BuffRecipe>();
+            recipe.taskSpeedPercent = 100f;
+
+            var listField = typeof(BuffManager).GetField("activeBuffs", BindingFlags.NonPublic | BindingFlags.Instance);
+            var list = (List<BuffManager.ActiveBuff>)listField.GetValue(manager);
+            list.Add(new BuffManager.ActiveBuff { recipe = recipe, remaining = 5f });
+
+            controllerObj = new GameObject();
+            controller = controllerObj.AddComponent<SkillController>();
+            skill = ScriptableObject.CreateInstance<Skill>();
+            skill.taskSpeedPerLevel = 0f;
+
+            var skillsField = typeof(SkillController).GetField("skills", BindingFlags.NonPublic | BindingFlags.Instance);
+            skillsField.SetValue(controller, new List<Skill> { skill });
+
+            var progressField = typeof(SkillController).GetField("progress", BindingFlags.NonPublic | BindingFlags.Instance);
+            var dict = (Dictionary<Skill, SkillController.SkillProgress>)progressField.GetValue(controller);
+            dict[skill] = new SkillController.SkillProgress { Level = 0, CurrentXP = 0f };
+
+            data = ScriptableObject.CreateInstance<TaskData>();
+            data.taskDuration = 10f;
+
+            taskObj = new GameObject();
+            task = taskObj.AddComponent<MiningTask>();
+            task.associatedSkill = skill;
+            task.taskData = data;
+
+            task.StartTask();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(taskObj);
+            Object.DestroyImmediate(controllerObj);
+            Object.DestroyImmediate(buffObj);
+            Object.DestroyImmediate(skill);
+            Object.DestroyImmediate(data);
+            Object.DestroyImmediate(recipe);
+        }
+
+        [UnityTest]
+        public System.Collections.IEnumerator TickUsesBuffSpeedMultiplier()
+        {
+            yield return null;
+            float dt = Time.deltaTime;
+
+            task.Tick(null);
+
+            var timerField = typeof(ContinuousTask).GetField("timer", BindingFlags.NonPublic | BindingFlags.Instance);
+            float timer = (float)timerField.GetValue(task);
+
+            Assert.AreEqual(dt * 2f, timer, 0.0001f);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow buff recipes to modify task speed and organize fields with Odin
- compute task speed multiplier from active buffs
- apply buff task speed multiplier in tasks
- test buff-driven task speed multiplier

## Testing
- `unity-editor -batchmode -projectPath . -runTests -testPlatform editmode -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f3f4ab86c832eb33bbeb91b160f93