### PR TITLE
Use 'Trek #' label in stats panel

### DIFF
--- a/Assets/Scripts/UI/RunStatsPanelUI.cs
+++ b/Assets/Scripts/UI/RunStatsPanelUI.cs
@@ -150,7 +150,7 @@ namespace TimelessEchoes.UI
             runStatUI.transform.position = pos;
 
             if (runStatUI.runIdText != null)
-                runStatUI.runIdText.text = $"Run {record.RunNumber}";
+                runStatUI.runIdText.text = $"Trek {record.RunNumber}";
 
             if (runStatUI.distanceTasksResourcesText != null)
             {


### PR DESCRIPTION
## Summary
- show `Trek` instead of `Run` on run record tooltip

## Testing
- `grep -n "Trek" Assets/Scripts/UI/RunStatsPanelUI.cs`

------
https://chatgpt.com/codex/tasks/task_e_687f532f7154832e848dcfb82e76b881