### PR TITLE
Fix WeightedTaskSpawn weight logic

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -941,9 +941,12 @@ namespace TimelessEchoes.Tasks
                 if (prefab == null || prefab.taskData == null) return 0f;
                 var min = overrideRange ? minX : prefab.taskData.minX;
                 var max = overrideRange ? maxX : prefab.taskData.maxX;
-                if (worldX < min || worldX > max)
+                var baseWeight = Mathf.Max(0f, weight);
+                if (worldX < min)
                     return 0f;
-                return Mathf.Max(0f, weight);
+                if (worldX > max)
+                    return baseWeight * 0.1f;
+                return baseWeight;
             }
         }
 


### PR DESCRIPTION
## Summary
- update `WeightedTaskSpawn.GetWeight` logic so tasks near the edge get reduced weight

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ffa2452a8832ebd3d5d2a5afded28