### PR TITLE
Move GetWeight to TaskData

### DIFF
--- a/Assets/Scripts/Tasks/TaskData.cs
+++ b/Assets/Scripts/Tasks/TaskData.cs
@@ -66,5 +66,15 @@ namespace TimelessEchoes.Tasks
 
         [HideInInspector]
         public Persistent persistent = new();
+
+        public float GetWeight(float worldX)
+        {
+            var baseWeight = Mathf.Max(0f, weight);
+            if (worldX < minX)
+                return 0f;
+            if (worldX > maxX)
+                return baseWeight * 0.1f;
+            return baseWeight;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- relocate task weight calculation into `TaskData`
- remove `WeightedTaskSpawn` and store `TaskData` directly in `WeightedTaskCategory`
- update `ProceduralTaskGenerator` to use the new structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688167a2fad0832ea8b30810155470ad