### PR TITLE
Fix bottom buffer usage in task generation

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -485,10 +485,13 @@ namespace TimelessEchoes.Tasks
             var worldX = transform.position.x + localX;
             var baseCell = terrainMap.WorldToCell(new Vector3(worldX, transform.position.y, 0f));
 
-            var maxY = Mathf.Clamp(terrainMap.cellBounds.yMax - topBuffer,
+            var areaBottom = terrainMap.WorldToCell(transform.position).y;
+            var minY = Mathf.Clamp(areaBottom + bottomBuffer,
                                    terrainMap.cellBounds.yMin,
                                    terrainMap.cellBounds.yMax);
-            var minY = terrainMap.cellBounds.yMin + bottomBuffer;
+            var maxY = Mathf.Clamp(areaBottom + Mathf.RoundToInt(height) - topBuffer,
+                                   terrainMap.cellBounds.yMin,
+                                   terrainMap.cellBounds.yMax);
 
             var validYs = new List<int>();
             for (var y = maxY; y >= minY; y--)
@@ -593,7 +596,8 @@ namespace TimelessEchoes.Tasks
             var isEdge = IsEdge(cell, settings.tile, settings.taskSettings.edgeOffset);
             if (settings.taskSettings.edgeOnly)
             {
-                var bottomLimit = terrainMap.cellBounds.yMin + bottomBuffer;
+                var areaBottom = terrainMap.WorldToCell(transform.position).y;
+                var bottomLimit = Mathf.Max(areaBottom + bottomBuffer, terrainMap.cellBounds.yMin);
                 if (cell.y < bottomLimit)
                     return false;
                 return isEdge;


### PR DESCRIPTION
## Summary
- constrain terrain spot selection to the generation area
- respect bottom buffer when validating edge-only terrain rules

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881779a415c832eaccac1cb7ca029a7