### PR TITLE
Fix left/right edge detection for terrain tasks

### DIFF
--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -578,6 +578,15 @@ namespace TimelessEchoes.Tasks
                 var bottomLimit = Mathf.Max(areaBottom + bottomBuffer, terrainMap.cellBounds.yMin);
                 if (cell.y < bottomLimit)
                     return false;
+
+                var areaLeft = terrainMap.WorldToCell(new Vector3(transform.position.x + minX, transform.position.y, 0f)).x;
+                var areaRight = terrainMap.WorldToCell(new Vector3(transform.position.x + maxX, transform.position.y, 0f)).x;
+                var leftLimit = Mathf.Max(areaLeft, terrainMap.cellBounds.xMin);
+                var rightLimit = Mathf.Min(areaRight, terrainMap.cellBounds.xMax);
+                var offset = settings.taskSettings.edgeOffset;
+                if (cell.x > leftLimit + offset && cell.x < rightLimit - offset)
+                    return false;
+
                 return isEdge;
             }
 


### PR DESCRIPTION
## Summary
- update edge-only rule to respect horizontal bounds

## Testing
- `pre-commit` *(fails: no linting config)*

------
https://chatgpt.com/codex/tasks/task_e_68817d743c68832ea3fef33b8028dcb5