### PR TITLE
Update terrain edge settings

### DIFF
--- a/Assets/Scripts/MapGeneration/TerrainSettings.cs
+++ b/Assets/Scripts/MapGeneration/TerrainSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Sirenix.OdinInspector;
 using UnityEngine;
 using VinTools.BetterRuleTiles;
+using UnityEngine.Serialization;
 
 namespace TimelessEchoes.MapGeneration
 {
@@ -19,7 +20,11 @@ namespace TimelessEchoes.MapGeneration
             public bool edgeOnly;
             [ShowIf(nameof(edgeOnly))]
             [MinValue(0)]
-            public int edgeOffset;
+            [FormerlySerializedAs("edgeOffset")]
+            public int innerEdgeOffset;
+            [ShowIf(nameof(edgeOnly))]
+            [MinValue(0)]
+            public int outerEdgeOffset;
             [HideIf(nameof(edgeOnly))]
             public int taskEdgeAvoidance;
         }

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -571,7 +571,7 @@ namespace TimelessEchoes.Tasks
             if (settings == null) return false;
             var tile = terrainMap.GetTile(cell);
             if (tile != settings.tile) return false;
-            var isEdge = IsEdge(cell, settings.tile, settings.taskSettings.edgeOffset);
+            var isEdge = IsEdge(cell, settings.tile, settings.taskSettings.innerEdgeOffset);
             if (settings.taskSettings.edgeOnly)
             {
                 var areaBottom = terrainMap.WorldToCell(transform.position).y;
@@ -579,7 +579,10 @@ namespace TimelessEchoes.Tasks
                 if (cell.y < bottomLimit)
                     return false;
 
-                return isEdge;
+                var nearOuter = IsEdge(cell, settings.tile, settings.taskSettings.innerEdgeOffset +
+                                               settings.taskSettings.outerEdgeOffset);
+                var beyondInner = !IsEdge(cell, settings.tile, settings.taskSettings.innerEdgeOffset - 1);
+                return nearOuter && beyondInner;
             }
 
             if (settings.taskSettings.taskEdgeAvoidance > 0)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Maps are created by the `TilemapChunkGenerator` which lays out water, sand and
 grass tiles. Decorative tiles can be spawned with weighted probabilities and
 optional rotation.
 
+Each terrain type exposes task settings controlling where procedural tasks may
+appear. The `innerEdgeOffset` pulls the allowed spawn zone inward from the tile
+edge, while `outerEdgeOffset` extends the valid edge region outward. When
+`edgeOnly` is enabled on a terrain, tasks spawn only within this band between the
+two offsets.
+
 ## Building
 Use **File > Build Settings...** to create standalone builds.
 


### PR DESCRIPTION
## Summary
- support separate inner and outer edge offsets for TerrainSettings
- update ProceduralTaskGenerator edge checks
- explain new offsets in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881880a2d64832ebc9c205722279866