### PR TITLE
Refine task border offsets

### DIFF
--- a/Assets/Scriptables/Map/Grass.asset
+++ b/Assets/Scriptables/Map/Grass.asset
@@ -15,8 +15,11 @@ MonoBehaviour:
   tile: {fileID: -6080419730213009515, guid: c2d01cf7440e16c4a99ec3041497a57d, type: 2}
   taskSettings:
     taskDensity: 0.1
-    edgeOnly: 0
-    taskEdgeAvoidance: 0
+    borderOnly: 0
+    topBorderOffset: 0
+    bottomBorderOffset: 0
+    leftBorderOffset: 0
+    rightBorderOffset: 0
   decor:
     density: 1
     decor: []

--- a/Assets/Scriptables/Map/Sand.asset
+++ b/Assets/Scriptables/Map/Sand.asset
@@ -15,8 +15,11 @@ MonoBehaviour:
   tile: {fileID: 0}
   taskSettings:
     taskDensity: 0.1
-    edgeOnly: 0
-    taskEdgeAvoidance: 0
+    borderOnly: 0
+    topBorderOffset: 0
+    bottomBorderOffset: 0
+    leftBorderOffset: 0
+    rightBorderOffset: 0
   decor:
     density: 1
     decor: []

--- a/Assets/Scriptables/Map/Water.asset
+++ b/Assets/Scriptables/Map/Water.asset
@@ -15,8 +15,11 @@ MonoBehaviour:
   tile: {fileID: 0}
   taskSettings:
     taskDensity: 0.1
-    edgeOnly: 0
-    taskEdgeAvoidance: 0
+    borderOnly: 0
+    topBorderOffset: 0
+    bottomBorderOffset: 0
+    leftBorderOffset: 0
+    rightBorderOffset: 0
   decor:
     density: 1
     decor: []

--- a/Assets/Scripts/MapGeneration/TerrainSettings.cs
+++ b/Assets/Scripts/MapGeneration/TerrainSettings.cs
@@ -17,16 +17,12 @@ namespace TimelessEchoes.MapGeneration
         public class TaskSettings
         {
             [Range(0f,1f)] public float taskDensity = 0.1f;
-            public bool edgeOnly;
-            [ShowIf(nameof(edgeOnly))]
-            [MinValue(0)]
-            [FormerlySerializedAs("edgeOffset")]
-            public int innerEdgeOffset;
-            [ShowIf(nameof(edgeOnly))]
-            [MinValue(0)]
-            public int outerEdgeOffset;
-            [HideIf(nameof(edgeOnly))]
-            public int taskEdgeAvoidance;
+
+            public bool borderOnly;
+            [MinValue(0)] public int topBorderOffset;
+            [MinValue(0)] public int bottomBorderOffset;
+            [MinValue(0)] public int leftBorderOffset;
+            [MinValue(0)] public int rightBorderOffset;
         }
 
         [Serializable]

--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ grass tiles. Decorative tiles can be spawned with weighted probabilities and
 optional rotation.
 
 Each terrain type exposes task settings controlling where procedural tasks may
-appear. The `innerEdgeOffset` pulls the allowed spawn zone inward from the tile
-edge, while `outerEdgeOffset` extends the valid edge region outward. When
-`edgeOnly` is enabled on a terrain, tasks spawn only within this band between the
-two offsets.
+appear. When `borderOnly` is enabled, tasks spawn only along the terrain's
+computed borders. The directional offsets (`topBorderOffset`, `bottomBorderOffset`,
+`leftBorderOffset` and `rightBorderOffset`) shift this border check in each
+direction. If `borderOnly` is disabled these offsets specify how many tiles away
+from the edges tasks must spawn.
 
 ## Building
 Use **File > Build Settings...** to create standalone builds.


### PR DESCRIPTION
## Summary
- remove taskEdgeAvoidance from task settings
- always expose directional border offsets
- enforce new border offset logic in spawn validation
- document how offsets affect spawning
- update ScriptableObject assets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818d52a3c4832e9c4108830c2b88dd