### PR TITLE
Remove overall task density

### DIFF
--- a/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
+++ b/Assets/Scripts/MapGeneration/MapGenerationConfig.cs
@@ -42,7 +42,6 @@ namespace TimelessEchoes.MapGeneration
         {
             public float minX;
             public float height = 18f;
-            [FormerlySerializedAs("density")] public float taskDensity = 0.1f;
 
             public float enemyDensity = 0.1f;
 

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -42,9 +42,6 @@ namespace TimelessEchoes.Tasks
         [HideInInspector]
         private int bottomBuffer;
 
-        [TabGroup("Settings", "Area")] [SerializeField]
-        [HideInInspector]
-        private float taskDensity = 0.1f;
 
 
         [TabGroup("Settings", "Area")] [SerializeField]
@@ -133,7 +130,6 @@ namespace TimelessEchoes.Tasks
 
             minX = config.taskGeneratorSettings.minX;
             height = config.taskGeneratorSettings.height;
-            taskDensity = config.taskGeneratorSettings.taskDensity;
             enemyDensity = config.taskGeneratorSettings.enemyDensity;
             topBuffer = config.taskGeneratorSettings.topBuffer;
             bottomBuffer = config.taskGeneratorSettings.bottomBuffer;
@@ -271,12 +267,11 @@ namespace TimelessEchoes.Tasks
                 controller.ClearTaskObjects();
             }
 
-            var baseTaskCount = Mathf.RoundToInt((localMaxX - localMinX) * taskDensity);
             var bottomCount = Mathf.RoundToInt((localMaxX - localMinX) * (bottomTerrain?.taskSettings.taskDensity ?? 0f));
             var middleCount = Mathf.RoundToInt((localMaxX - localMinX) * (middleTerrain?.taskSettings.taskDensity ?? 0f));
             var topCount = Mathf.RoundToInt((localMaxX - localMinX) * (topTerrain?.taskSettings.taskDensity ?? 0f));
             var enemyCount = Mathf.RoundToInt((localMaxX - localMinX) * enemyDensity);
-            if (baseTaskCount + bottomCount + middleCount + topCount <= 0 && enemyCount <= 0)
+            if (bottomCount + middleCount + topCount <= 0 && enemyCount <= 0)
                 return;
 
             var spawnedTasks = new List<(Vector3 pos, MonoBehaviour obj)>();
@@ -306,13 +301,6 @@ namespace TimelessEchoes.Tasks
                         break;
             }
 
-            for (var i = 0; i < baseTaskCount; i++)
-            {
-                for (var a = 0; a < 10; a++)
-                    if (TrySpawnTask(Random.Range(localMinX, localMaxX), parent, clearExisting, false, false, false,
-                            spawnedTasks, taskPositions, taskMap))
-                        break;
-            }
 
             for (var i = 0; i < enemyCount; i++)
             {

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ appear. When `borderOnly` is enabled, tasks spawn only along the terrain's
 computed borders. The directional offsets (`topBorderOffset`, `bottomBorderOffset`,
 `leftBorderOffset` and `rightBorderOffset`) shift this border check in each
 direction. If `borderOnly` is disabled these offsets specify how many tiles away
-from the edges tasks must spawn.
+from the edges tasks must spawn. Task spawn counts now rely solely on each
+terrain's `taskSettings.taskDensity` value; the generator's overall density
+setting has been removed.
 
 ## Building
 Use **File > Build Settings...** to create standalone builds.


### PR DESCRIPTION
## Summary
- remove `taskDensity` from `ProceduralTaskGenerator`
- update `MapGenerationConfig` and README to note terrain density only
- adjust task generation counts accordingly

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 on mise.jdx.dev)*

------
https://chatgpt.com/codex/tasks/task_e_6881abdef9cc832e941a47ea5f496fa8