### PR TITLE
fix: Prevent combat echoes from being destroyed when out of range

### DIFF
--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -18,6 +18,7 @@ namespace TimelessEchoes.Hero
         public float lifetime = 10f;
         public bool disableSkills;
         public bool combatEnabled;
+        public float maxRange = 20f;
 
         // Skill indicator references are stored on the hero controller
         // so they can be configured on the main hero prefab.
@@ -101,6 +102,11 @@ namespace TimelessEchoes.Hero
             {
                 Destroy(gameObject);
                 return;
+            }
+
+            if (Vector3.Distance(transform.position, HeroController.Instance.transform.position) > maxRange)
+            {
+                transform.position = HeroController.Instance.transform.position;
             }
 
             if (!disableSkills && taskController != null)

--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -12,7 +12,7 @@ namespace TimelessEchoes.Hero
     public static class EchoManager
     {
         public static HeroController SpawnEcho(IEnumerable<Skill> skills, float duration, bool combat,
-            bool disableSkills = false)
+            bool disableSkills = false, float maxRange = 20f)
         {
             var hero = HeroController.Instance;
             if (hero == null)
@@ -50,14 +50,15 @@ namespace TimelessEchoes.Hero
 
                 var echo = obj.AddComponent<EchoController>();
                 echo.Init(skills, duration, disableSkills, combat);
+                echo.maxRange = maxRange;
             }
 
             return echoHero;
         }
 
-        public static HeroController SpawnEcho(Skill skill, float duration, bool combat, bool disableSkills = false)
+        public static HeroController SpawnEcho(Skill skill, float duration, bool combat, bool disableSkills = false, float maxRange = 20f)
         {
-            return SpawnEcho(new List<Skill> { skill }, duration, combat, disableSkills);
+            return SpawnEcho(new List<Skill> { skill }, duration, combat, disableSkills, maxRange);
         }
     }
 }

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -518,6 +518,12 @@ namespace TimelessEchoes.Hero
                 return;
             }
 
+            if (IsEcho)
+            {
+                setter.target = Instance.transform;
+                return;
+            }
+
             if (state == State.Combat)
             {
                 Log("Hero exiting combat", TELogCategory.Combat, this);
@@ -582,6 +588,11 @@ namespace TimelessEchoes.Hero
             {
                 var hp = enemy.GetComponent<Health>();
                 if (hp == null || hp.CurrentHealth <= 0f) continue;
+
+                var screenPoint = Camera.main.WorldToViewportPoint(enemy.transform.position);
+                var onScreen = screenPoint.z > 0 && screenPoint.x > 0 && screenPoint.x < 1 && screenPoint.y > 0 && screenPoint.y < 1;
+                if (!onScreen && !UnlimitedAggroRange) continue;
+
                 var d = Vector2.Distance(pos, enemy.transform.position);
                 if (d <= range && d < best)
                 {


### PR DESCRIPTION
This commit corrects the behavior of combat echoes when they are outside of their maximum range. Instead of being destroyed, they are now moved to your hero's position.