### PR TITLE
Limit echo aggro range and follow hero

### DIFF
--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -25,6 +25,7 @@ namespace TimelessEchoes.Hero
         private HeroController hero;
         private TaskController taskController;
         private float remaining;
+        private float defaultAggroRange;
 
         /// <summary>
         ///     Returns true once <see cref="Init" /> has completed.
@@ -38,6 +39,8 @@ namespace TimelessEchoes.Hero
             remaining = lifetime;
             if (!AllEchoes.Contains(this))
                 AllEchoes.Add(this);
+            if (hero != null)
+                defaultAggroRange = hero.CombatAggroRange;
         }
 
         private void OnEnable()
@@ -61,6 +64,11 @@ namespace TimelessEchoes.Hero
         {
             CombatEchoes.Remove(this);
             AllEchoes.Remove(this);
+            if (hero != null)
+            {
+                hero.UnlimitedAggroRange = false;
+                hero.CombatAggroRange = defaultAggroRange;
+            }
         }
 
         /// <summary>
@@ -81,6 +89,8 @@ namespace TimelessEchoes.Hero
                 // skill list as "all skills" instead of "combat only".
                 var combatOnly = combatEnabled && disableSkills;
                 hero.UnlimitedAggroRange = combatOnly;
+                if (combatOnly)
+                    hero.CombatAggroRange = defaultAggroRange;
             }
 
             Initialized = true;
@@ -139,7 +149,10 @@ namespace TimelessEchoes.Hero
             CombatEchoes.Remove(this);
             AllEchoes.Remove(this);
             if (hero != null)
+            {
                 hero.UnlimitedAggroRange = false;
+                hero.CombatAggroRange = defaultAggroRange;
+            }
         }
 
         private void UpdateIndicators()

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -79,6 +79,19 @@ namespace TimelessEchoes.Hero
 
         public bool UnlimitedAggroRange { get; set; }
 
+        /// <summary>
+        /// Maximum distance echoes will search for combat targets when
+        /// <see cref="UnlimitedAggroRange"/> is enabled.
+        /// </summary>
+        [SerializeField]
+        private float combatAggroRange = 20f;
+
+        public float CombatAggroRange
+        {
+            get => combatAggroRange;
+            set => combatAggroRange = value;
+        }
+
         private Transform currentEnemy;
         private Health currentEnemyHealth;
 
@@ -494,7 +507,7 @@ namespace TimelessEchoes.Hero
             var nearest = allowAttacks && currentEnemy != null ? currentEnemy : null;
             if (allowAttacks && nearest == null)
             {
-                var range = UnlimitedAggroRange ? float.PositiveInfinity : stats.visionRange;
+                var range = UnlimitedAggroRange ? combatAggroRange : stats.visionRange;
                 nearest = FindNearestEnemy(range);
             }
 
@@ -578,8 +591,30 @@ namespace TimelessEchoes.Hero
             var enemies = Object.FindObjectsOfType<Enemy>();
 #endif
             Vector2 pos = transform.position;
+
+            Camera cam = EnemyActivator.Instance != null
+                ? EnemyActivator.Instance.GetComponent<Camera>()
+                : null;
+            Vector3 min = Vector3.zero, max = Vector3.zero;
+            bool checkBounds = false;
+            if (cam != null)
+            {
+                const float padding = 2f;
+                min = cam.ViewportToWorldPoint(Vector3.zero) - Vector3.one * padding;
+                max = cam.ViewportToWorldPoint(Vector3.one) + Vector3.one * padding;
+                checkBounds = true;
+            }
+
             foreach (var enemy in enemies)
             {
+                if (enemy == null) continue;
+                if (checkBounds)
+                {
+                    Vector3 p = enemy.transform.position;
+                    if (p.x < min.x || p.x > max.x || p.y < min.y || p.y > max.y)
+                        continue;
+                }
+
                 var hp = enemy.GetComponent<Health>();
                 if (hp == null || hp.CurrentHealth <= 0f) continue;
                 var d = Vector2.Distance(pos, enemy.transform.position);
@@ -768,6 +803,33 @@ namespace TimelessEchoes.Hero
 
         private void AutoAdvance()
         {
+            if (IsEcho && HeroController.Instance != null && HeroController.Instance != this)
+            {
+                var mainHero = HeroController.Instance.transform;
+                var echo = GetComponent<EchoController>();
+                var enemy = FindNearestEnemy(combatAggroRange);
+
+                if (enemy == null)
+                {
+                    if (echo != null && echo.disableSkills)
+                    {
+                        if (setter.target != mainHero)
+                            setter.target = mainHero;
+                        ai.canMove = true;
+                        return;
+                    }
+
+                    var dist = Vector2.Distance(transform.position, mainHero.position);
+                    if (dist > combatAggroRange)
+                    {
+                        if (setter.target != mainHero)
+                            setter.target = mainHero;
+                        ai.canMove = true;
+                        return;
+                    }
+                }
+            }
+
             if (idleWalkTarget == null)
             {
                 idleWalkTarget = new GameObject("IdleWalkTarget").transform;

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ automatically cast as soon as you have enough resources.
 ## Echoes
 Clones spawned by milestones are referred to as **Echoes**. An Echo performs
 tasks of a specified skill for a limited time when summoned.
+Combat oriented echoes ignore tasks and only engage in combat. When no enemy is
+within their combat aggro range they automatically follow the main hero instead
+of wandering off. The aggro range defaults to 20 units and can be configured on
+the hero prefab.
 
 ## Tasks
 Task scripts can be found under `Assets/Scripts/Tasks`. A `TaskController`


### PR DESCRIPTION
## Summary
- follow the hero whenever combat-only echoes have no enemy
- mention combat echo behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882069697d8832eb8e334c2ee1902fa