### PR TITLE
Fix combat echoes idle tasking

### DIFF
--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -45,7 +45,11 @@ namespace TimelessEchoes.Hero
                 {
                     var tc = obj.GetComponent<TaskController>();
                     if (tc != null)
+                    {
                         Object.Destroy(tc);
+                        echoHero.SetTask(null);
+                        echoHero.ClearTaskController();
+                    }
                 }
 
                 var echo = obj.AddComponent<EchoController>();

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -489,6 +489,15 @@ namespace TimelessEchoes.Hero
                 newBase.Claim(this);
         }
 
+        /// <summary>
+        ///     Clear the reference to the active <see cref="TaskController" /> so
+        ///     this hero no longer receives task assignments.
+        /// </summary>
+        public void ClearTaskController()
+        {
+            taskController = null;
+        }
+
         private void UpdateBehavior()
         {
             if (stats == null) return;


### PR DESCRIPTION
## Summary
- add `ClearTaskController` method on `HeroController`
- reset tasks and null out task controller when disabling skills in `SpawnEcho`

Combat-only echoes no longer keep performing tasks after the first one completes.

------
https://chatgpt.com/codex/tasks/task_e_68820de7e584832ebfabf63f7fe78f48