### PR TITLE
Fix save load and screenshot script issues

### DIFF
--- a/Assets/Scripts/Blindsided/Oracle.cs
+++ b/Assets/Scripts/Blindsided/Oracle.cs
@@ -200,13 +200,18 @@ namespace Blindsided
             loaded = false;
             saveData = new GameData();
 
+            var backupPath = _fileName + ".bac";
+
+            if (!ES3.FileExists(_fileName) && ES3.FileExists(backupPath))
+                ES3.RestoreBackup(_fileName);
+
             try
             {
                 saveData = ES3.Load<GameData>(_dataName, _settings);
             }
             catch
             {
-                if (ES3.RestoreBackup(_fileName))
+                if (ES3.FileExists(backupPath) && ES3.RestoreBackup(_fileName))
                 {
                     Debug.LogWarning("Backup restored; re-loading.");
                     saveData = ES3.Load<GameData>(_dataName, _settings);

--- a/Assets/Scripts/Tools/EditorScreenshot.cs
+++ b/Assets/Scripts/Tools/EditorScreenshot.cs
@@ -1,16 +1,19 @@
 using System;
 using System.IO;
+using UnityEngine;
+#if UNITY_EDITOR
 using Sirenix.OdinInspector;
 using UnityEditor;
-using UnityEngine;
-
-#if UNITY_EDITOR
+#endif
 
 namespace TimelessEchoes
 {
+#if UNITY_EDITOR
     [ExecuteInEditMode]
+#endif
     public class EditorScreenshot : MonoBehaviour
     {
+#if UNITY_EDITOR
         [Title("Screenshot Settings")] public Camera targetCamera;
 
         public int width = 1920;
@@ -57,7 +60,6 @@ namespace TimelessEchoes
 
             AssetDatabase.Refresh();
         }
+#endif
     }
 }
-
-#endif


### PR DESCRIPTION
## Summary
- ensure backup save is restored when main save file missing
- keep EditorScreenshot component as stub in builds to avoid missing script

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ba2cbbd0832e8472a3452bed8a20