### PR TITLE
Introduce EchoType and update Echo behaviors

### DIFF
--- a/Assets/Resources/Buffs/Combat Echo.asset
+++ b/Assets/Resources/Buffs/Combat Echo.asset
@@ -20,8 +20,7 @@ MonoBehaviour:
   echoSpawnConfig:
     echoCount: 1
     capableSkills: []
-    disableSkills: 1
-    combatEnabled: 1
+    echoType: 0
   moveSpeedPercent: 0
   damagePercent: 0
   defensePercent: 0

--- a/Assets/Resources/Buffs/Combat Enhancer.asset
+++ b/Assets/Resources/Buffs/Combat Enhancer.asset
@@ -19,8 +19,7 @@ MonoBehaviour:
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
-    disableSkills: 0
-    combatEnabled: 0
+    echoType: 2
   moveSpeedPercent: 0
   damagePercent: 50
   defensePercent: 50

--- a/Assets/Resources/Buffs/Echo.asset
+++ b/Assets/Resources/Buffs/Echo.asset
@@ -19,8 +19,7 @@ MonoBehaviour:
   echoSpawnConfig:
     echoCount: 1
     capableSkills: []
-    disableSkills: 0
-    combatEnabled: 0
+    echoType: 2
   moveSpeedPercent: 0
   damagePercent: 0
   defensePercent: 0

--- a/Assets/Resources/Buffs/Lerp.asset
+++ b/Assets/Resources/Buffs/Lerp.asset
@@ -19,8 +19,7 @@ MonoBehaviour:
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
-    disableSkills: 0
-    combatEnabled: 1
+    echoType: 1
   moveSpeedPercent: 0
   damagePercent: 0
   defensePercent: 0

--- a/Assets/Resources/Buffs/MoveSpeed.asset
+++ b/Assets/Resources/Buffs/MoveSpeed.asset
@@ -20,8 +20,7 @@ MonoBehaviour:
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
-    disableSkills: 0
-    combatEnabled: 0
+    echoType: 2
   moveSpeedPercent: 40
   damagePercent: 0
   defensePercent: 0

--- a/Assets/Resources/Buffs/Vampiric.asset
+++ b/Assets/Resources/Buffs/Vampiric.asset
@@ -19,8 +19,7 @@ MonoBehaviour:
   echoSpawnConfig:
     echoCount: 0
     capableSkills: []
-    disableSkills: 0
-    combatEnabled: 1
+    echoType: 1
   moveSpeedPercent: 0
   damagePercent: 0
   defensePercent: 0

--- a/Assets/Scriptables/Skills/Combat.asset
+++ b/Assets/Scriptables/Skills/Combat.asset
@@ -34,8 +34,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 11400000, guid: 57a723c0f93b2224f915740d8fba4467, type: 2}
@@ -48,8 +47,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.01
     statUpgrade: {fileID: 0}
@@ -62,8 +60,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.01
     statUpgrade: {fileID: 0}
@@ -76,8 +73,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 11400000, guid: 63665106227b9814ea58f2b77d5a7bb5, type: 2}
@@ -90,8 +86,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 1
-      combatEnabled: 1
+      echoType: 0
     echoDuration: 30
     chance: 0.01
     statUpgrade: {fileID: 0}
@@ -104,8 +99,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.01
     statUpgrade: {fileID: 0}
@@ -118,8 +112,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.01
     statUpgrade: {fileID: 0}
@@ -132,8 +125,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.01
     statUpgrade: {fileID: 0}

--- a/Assets/Scriptables/Skills/Farming.asset
+++ b/Assets/Scriptables/Skills/Farming.asset
@@ -34,8 +34,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.05
     statUpgrade: {fileID: 0}
@@ -49,8 +48,7 @@ MonoBehaviour:
       echoCount: 1
       capableSkills:
       - {fileID: 11400000}
-      disableSkills: 0
-      combatEnabled: 0
+      echoType: 3
     echoDuration: 10
     chance: 0.05
     statUpgrade: {fileID: 0}
@@ -63,8 +61,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 0}
@@ -77,8 +74,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 11400000, guid: 63665106227b9814ea58f2b77d5a7bb5, type: 2}

--- a/Assets/Scriptables/Skills/Fishing.asset
+++ b/Assets/Scriptables/Skills/Fishing.asset
@@ -34,8 +34,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 11400000, guid: 46b4e7a4349a20b4cb76d97fb2d13016, type: 2}
@@ -48,8 +47,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 0}
@@ -62,8 +60,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.12
     statUpgrade: {fileID: 0}
@@ -77,8 +74,7 @@ MonoBehaviour:
       echoCount: 1
       capableSkills:
       - {fileID: 11400000}
-      disableSkills: 0
-      combatEnabled: 0
+      echoType: 3
     echoDuration: 10
     chance: 0.05
     statUpgrade: {fileID: 0}
@@ -91,8 +87,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.38
     statUpgrade: {fileID: 0}

--- a/Assets/Scriptables/Skills/Looting.asset
+++ b/Assets/Scriptables/Skills/Looting.asset
@@ -34,8 +34,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.1
     statUpgrade: {fileID: 0}
@@ -48,8 +47,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.05
     statUpgrade: {fileID: 0}
@@ -62,8 +60,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 1
-      combatEnabled: 1
+      echoType: 0
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 0}
@@ -76,8 +73,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.15
     statUpgrade: {fileID: 0}
@@ -90,8 +86,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.3
     statUpgrade: {fileID: 0}
@@ -104,8 +99,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.5
     statUpgrade: {fileID: 0}

--- a/Assets/Scriptables/Skills/Mining.asset
+++ b/Assets/Scriptables/Skills/Mining.asset
@@ -35,8 +35,7 @@ MonoBehaviour:
       echoCount: 1
       capableSkills:
       - {fileID: 11400000}
-      disableSkills: 0
-      combatEnabled: 0
+      echoType: 3
     echoDuration: 10
     chance: 0.05
     statUpgrade: {fileID: 0}
@@ -49,8 +48,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.25
     statUpgrade: {fileID: 0}
@@ -63,8 +61,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 11400000, guid: 57a723c0f93b2224f915740d8fba4467, type: 2}
@@ -78,8 +75,7 @@ MonoBehaviour:
       echoCount: 1
       capableSkills:
       - {fileID: 11400000}
-      disableSkills: 0
-      combatEnabled: 0
+      echoType: 3
     echoDuration: 10
     chance: 0.05
     statUpgrade: {fileID: 0}

--- a/Assets/Scriptables/Skills/Woodcutting.asset
+++ b/Assets/Scriptables/Skills/Woodcutting.asset
@@ -34,8 +34,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 11400000, guid: 57a723c0f93b2224f915740d8fba4467, type: 2}
@@ -49,8 +48,7 @@ MonoBehaviour:
       echoCount: 1
       capableSkills:
       - {fileID: 11400000}
-      disableSkills: 0
-      combatEnabled: 0
+      echoType: 3
     echoDuration: 10
     chance: 0.05
     statUpgrade: {fileID: 0}
@@ -63,8 +61,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 1
     statUpgrade: {fileID: 11400000, guid: 0769912c1a6980346a1bbc479ddd8034, type: 2}
@@ -78,8 +75,7 @@ MonoBehaviour:
       echoCount: 1
       capableSkills:
       - {fileID: 11400000}
-      disableSkills: 0
-      combatEnabled: 0
+      echoType: 3
     echoDuration: 10
     chance: 0.05
     statUpgrade: {fileID: 0}
@@ -92,8 +88,7 @@ MonoBehaviour:
     echoSpawnConfig:
       echoCount: 1
       capableSkills: []
-      disableSkills: 0
-      combatEnabled: 1
+      echoType: 1
     echoDuration: 10
     chance: 0.25
     statUpgrade: {fileID: 0}

--- a/Assets/Scripts/Hero/EchoActivator.cs
+++ b/Assets/Scripts/Hero/EchoActivator.cs
@@ -40,7 +40,7 @@ namespace TimelessEchoes.Hero
                 if (echoHero == null || echoHero == hero)
                     continue;
 
-                if (!echo.combatEnabled)
+                if (echo.Type != EchoType.Combat && echo.Type != EchoType.All)
                     continue;
 
                 var dist = Vector2.Distance(pos, echo.transform.position);

--- a/Assets/Scripts/Hero/EchoController.cs
+++ b/Assets/Scripts/Hero/EchoController.cs
@@ -18,6 +18,7 @@ namespace TimelessEchoes.Hero
         public float lifetime = 10f;
         public bool disableSkills;
         public bool combatEnabled;
+        public EchoType Type { get; private set; } = EchoType.All;
 
         // Skill indicator references are stored on the hero controller
         // so they can be configured on the main hero prefab.
@@ -51,12 +52,12 @@ namespace TimelessEchoes.Hero
             if (!AllEchoes.Contains(this))
                 AllEchoes.Add(this);
 
-            if (combatEnabled && !CombatEchoes.Contains(this))
+            if ((Type == EchoType.Combat || Type == EchoType.All) && !CombatEchoes.Contains(this))
                 CombatEchoes.Add(this);
 
             UpdateIndicators();
 
-            if (hero != null && taskController != null && !disableSkills)
+            if (hero != null && taskController != null && Type != EchoType.Combat)
                 AssignTask();
         }
 
@@ -74,13 +75,14 @@ namespace TimelessEchoes.Hero
         /// <summary>
         ///     Configure the echo after it is spawned.
         /// </summary>
-        public void Init(IEnumerable<Skill> skills, float duration, bool disable, bool combat)
+        public void Init(IEnumerable<Skill> skills, float duration, EchoType type)
         {
             capableSkills = skills != null ? new List<Skill>(skills) : new List<Skill>();
             lifetime = duration;
             remaining = duration;
-            disableSkills = disable;
-            combatEnabled = combat;
+            Type = type;
+            disableSkills = type == EchoType.Combat;
+            combatEnabled = type == EchoType.Combat || type == EchoType.All;
 
             if (hero != null)
             {
@@ -166,7 +168,7 @@ namespace TimelessEchoes.Hero
                     obj.SetActive(state);
             }
 
-            SetActive(hero.CombatIndicator, combatEnabled);
+            SetActive(hero.CombatIndicator, Type == EchoType.Combat || Type == EchoType.All);
             SetActive(hero.MiningIndicator, false);
             SetActive(hero.WoodcuttingIndicator, false);
             SetActive(hero.FishingIndicator, false);
@@ -175,7 +177,7 @@ namespace TimelessEchoes.Hero
 
             var hasSkills = capableSkills != null && capableSkills.Count > 0;
 
-            if (!hasSkills && !disableSkills)
+            if (!hasSkills && Type != EchoType.Combat && Type != EchoType.Selective)
             {
                 SetActive(hero.MiningIndicator, true);
                 SetActive(hero.WoodcuttingIndicator, true);
@@ -217,7 +219,7 @@ namespace TimelessEchoes.Hero
             if (hero == null || taskController == null)
                 return;
 
-            if (disableSkills)
+            if (Type == EchoType.Combat)
                 return;
 
             if (capableSkills == null || capableSkills.Count == 0)

--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -11,8 +11,8 @@ namespace TimelessEchoes.Hero
     /// </summary>
     public static class EchoManager
     {
-        public static HeroController SpawnEcho(IEnumerable<Skill> skills, float duration, bool combat,
-            bool disableSkills = false)
+        public static HeroController SpawnEcho(IEnumerable<Skill> skills, float duration,
+            EchoType type = EchoType.All)
         {
             var hero = HeroController.Instance;
             if (hero == null)
@@ -39,6 +39,9 @@ namespace TimelessEchoes.Hero
                 if (hp != null)
                     hp.Immortal = false; // ensure damage can be forwarded
 
+                bool combat = type == EchoType.Combat || type == EchoType.All;
+                bool disableSkills = type == EchoType.Combat;
+
                 echoHero.AllowAttacks = combat;
 
                 if (disableSkills)
@@ -53,15 +56,15 @@ namespace TimelessEchoes.Hero
                 }
 
                 var echo = obj.AddComponent<EchoController>();
-                echo.Init(skills, duration, disableSkills, combat);
+                echo.Init(skills, duration, type);
             }
 
             return echoHero;
         }
 
-        public static HeroController SpawnEcho(Skill skill, float duration, bool combat, bool disableSkills = false)
+        public static HeroController SpawnEcho(Skill skill, float duration, EchoType type = EchoType.All)
         {
-            return SpawnEcho(new List<Skill> { skill }, duration, combat, disableSkills);
+            return SpawnEcho(new List<Skill> { skill }, duration, type);
         }
 
         /// <summary>
@@ -86,16 +89,14 @@ namespace TimelessEchoes.Hero
 
             int count = 1;
             IEnumerable<Skill> skills = fallbackSkills;
-            bool disable = false;
-            bool combat = false;
+            EchoType type = EchoType.All;
 
             if (config != null)
             {
                 count = countOverride > 0 ? countOverride : Mathf.Max(1, config.echoCount);
                 if (config.capableSkills != null && config.capableSkills.Count > 0)
                     skills = config.capableSkills;
-                combat = config.combatEnabled;
-                disable = config.disableSkills;
+                type = config.echoType;
             }
             else if (countOverride > 0)
             {
@@ -105,7 +106,7 @@ namespace TimelessEchoes.Hero
             var spawned = new List<HeroController>();
             for (int i = 0; i < count; i++)
             {
-                var h = SpawnEcho(skills, duration, combat, disable);
+                var h = SpawnEcho(skills, duration, type);
                 if (h != null)
                     spawned.Add(h);
             }

--- a/Assets/Scripts/Hero/EchoSpawnConfig.cs
+++ b/Assets/Scripts/Hero/EchoSpawnConfig.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using Sirenix.OdinInspector;
 using TimelessEchoes.Skills;
 
 namespace TimelessEchoes
@@ -11,24 +10,10 @@ namespace TimelessEchoes
     {
         [Min(1)]
         public int echoCount = 1;
-        [HideIf(nameof(disableSkills))]
         [Tooltip("Skills this Echo can perform. Leave empty to allow all skills.")]
         public List<Skill> capableSkills = new();
 
-        /// <summary>
-        /// When true, spawned Echoes ignore all task related behaviour.
-        /// </summary>
-        [OnValueChanged(nameof(OnDisableSkillsChanged))]
-        public bool disableSkills;
-        /// <summary>
-        /// When true, spawned Echoes can perform combat actions.
-        /// </summary>
-        public bool combatEnabled = true;
-
-        private void OnDisableSkillsChanged()
-        {
-            if (disableSkills)
-                combatEnabled = true;
-        }
+        [Tooltip("Overall behaviour for spawned Echoes.")]
+        public TimelessEchoes.Hero.EchoType echoType = TimelessEchoes.Hero.EchoType.All;
     }
 }

--- a/Assets/Scripts/Hero/EchoType.cs
+++ b/Assets/Scripts/Hero/EchoType.cs
@@ -1,0 +1,13 @@
+namespace TimelessEchoes.Hero
+{
+    /// <summary>
+    /// Defines behaviour presets for Echo helpers.
+    /// </summary>
+    public enum EchoType
+    {
+        Combat,
+        All,
+        TaskOnly,
+        Selective
+    }
+}

--- a/Assets/Scripts/Hero/EchoType.cs.meta
+++ b/Assets/Scripts/Hero/EchoType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93ab7383960147cf979b23f58e1bf847

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -260,7 +260,13 @@ namespace TimelessEchoes.Hero
         private void OnEnable()
         {
             if (taskController == null)
-                taskController = GetComponent<TaskController>() ?? GetComponentInParent<TaskController>();
+            {
+                var echo = GetComponent<EchoController>();
+                bool skip = IsEcho && echo != null &&
+                            (echo.Type == EchoType.Combat || echo.Type == EchoType.TaskOnly);
+                if (!skip)
+                    taskController = GetComponent<TaskController>() ?? GetComponentInParent<TaskController>();
+            }
 
             if (buffController == null)
             {
@@ -820,7 +826,7 @@ namespace TimelessEchoes.Hero
 
                 if (enemy == null)
                 {
-                    if (echo != null && echo.disableSkills)
+                    if (echo != null && echo.Type == EchoType.Combat)
                     {
                         if (setter.target != mainHero)
                             setter.target = mainHero;


### PR DESCRIPTION
## Summary
- add `EchoType` enum to unify echo behavior settings
- replace boolean flags in `EchoSpawnConfig` with `echoType`
- adjust `EchoManager`, `EchoController`, `HeroController`, and `EchoActivator` to use `EchoType`
- update task-following logic for echoes
- migrate scriptable assets to new enum

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6882bf241060832ea8799ad6139cfeab