### PR TITLE
Ensure echoes always reset tasks

### DIFF
--- a/Assets/Scripts/Hero/EchoManager.cs
+++ b/Assets/Scripts/Hero/EchoManager.cs
@@ -49,11 +49,10 @@ namespace TimelessEchoes.Hero
                 {
                     var tc = obj.GetComponent<TaskController>();
                     if (tc != null)
-                    {
                         Object.Destroy(tc);
-                        echoHero.SetTask(null);
-                        echoHero.ClearTaskController();
-                    }
+
+                    echoHero.SetTask(null);
+                    echoHero.ClearTaskController();
                 }
 
                 var echo = obj.AddComponent<EchoController>();


### PR DESCRIPTION
## Summary
- ensure disabling skills always resets tasks for new echoes
- cleanup TaskController reference if it exists

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c63d4aa0832eb7e994c3d6c181dc