### PR TITLE
Centralize map generation configs

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -31,6 +31,7 @@ namespace TimelessEchoes
     public class GameManager : MonoBehaviour
     {
         public static GameManager Instance { get; private set; }
+        public static MapGenerationConfig CurrentGenerationConfig { get; private set; }
         [Header("Prefabs")] [SerializeField] private GameObject mapPrefab;
         [SerializeField] private GameObject gravestonePrefab;
         [SerializeField] private GameObject reaperPrefab;
@@ -63,6 +64,10 @@ namespace TimelessEchoes
         public GameObject ReaperPrefab => reaperPrefab;
         public Vector3 ReaperSpawnOffset => reaperSpawnOffset;
         public Transform MeetingParent => meetingParent;
+
+        [Header("Map Generation")]
+        [SerializeField] private List<MapGenerationConfig> generationConfigs = new();
+        [SerializeField] private int currentConfigIndex;
 
         [Header("Cameras")] [SerializeField] private CinemachineCamera tavernCamera;
 
@@ -274,6 +279,15 @@ namespace TimelessEchoes
         private IEnumerator StartRunRoutine()
         {
             yield return StartCoroutine(CleanupMapRoutine());
+            if (generationConfigs != null && generationConfigs.Count > 0)
+            {
+                var index = Mathf.Clamp(currentConfigIndex, 0, generationConfigs.Count - 1);
+                CurrentGenerationConfig = generationConfigs[index];
+            }
+            else
+            {
+                CurrentGenerationConfig = null;
+            }
             if (statTracker == null)
             {
                 statTracker = GameplayStatTracker.Instance;

--- a/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
+++ b/Assets/Scripts/MapGeneration/SegmentedMapGenerator.cs
@@ -14,8 +14,6 @@ namespace TimelessEchoes.MapGeneration
     [RequireComponent(typeof(TaskController))]
     public class SegmentedMapGenerator : MonoBehaviour
     {
-        [SerializeField]
-        private MapGenerationConfig config;
 
         [SerializeField] private Vector2Int segmentSize = new(64, 18);
         [SerializeField] private Transform segmentParent;
@@ -40,16 +38,16 @@ namespace TimelessEchoes.MapGeneration
             chunkGenerator = GetComponent<TilemapChunkGenerator>();
             taskGenerator = GetComponent<ProceduralTaskGenerator>();
             controller = GetComponent<TaskController>();
-            ApplyConfig();
+            ApplyConfig(GameManager.CurrentGenerationConfig);
             if (segmentParent == null)
                 segmentParent = transform;
         }
 
-        private void ApplyConfig()
+        private void ApplyConfig(MapGenerationConfig cfg)
         {
-            if (config == null) return;
+            if (cfg == null) return;
 
-            segmentSize = config.segmentedMapSettings.segmentSize;
+            segmentSize = cfg.segmentedMapSettings.segmentSize;
         }
 
         private IEnumerator Start()

--- a/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
+++ b/Assets/Scripts/MapGeneration/TilemapChunkGenerator.cs
@@ -12,7 +12,6 @@ namespace TimelessEchoes.MapGeneration
 {
     public class TilemapChunkGenerator : MonoBehaviour
     {
-        [SerializeField] private MapGenerationConfig config;
 
         [Header("Tilemaps")] [TabGroup("References")] [SerializeField]
         private Tilemap terrainMap;
@@ -68,7 +67,7 @@ namespace TimelessEchoes.MapGeneration
 
         private void Awake()
         {
-            ApplyConfig();
+            ApplyConfig(GameManager.CurrentGenerationConfig);
             var taskGen = GetComponent<ProceduralTaskGenerator>();
             AssignTilemaps(taskGen);
             rng = randomizeSeed ? new Random() : new Random(seed);
@@ -76,23 +75,23 @@ namespace TimelessEchoes.MapGeneration
             prevGrassDepth = -1;
         }
 
-        private void ApplyConfig()
+        private void ApplyConfig(MapGenerationConfig cfg)
         {
-            if (config == null) return;
+            if (cfg == null) return;
 
             if (terrainMap == null)
-                terrainMap = config.tilemapChunkSettings.terrainMap;
+                terrainMap = cfg.tilemapChunkSettings.terrainMap;
             if (decorMap == null)
-                decorMap = config.tilemapChunkSettings.decorMap;
-            bottomTerrain = config.tilemapChunkSettings.bottomTerrain;
-            middleTerrain = config.tilemapChunkSettings.middleTerrain;
-            topTerrain = config.tilemapChunkSettings.topTerrain;
-            minAreaWidth = config.tilemapChunkSettings.minAreaWidth;
-            edgeWaviness = config.tilemapChunkSettings.edgeWaviness;
-            sandDepthRange = config.tilemapChunkSettings.middleDepthRange;
-            grassDepthRange = config.tilemapChunkSettings.topDepthRange;
-            seed = config.tilemapChunkSettings.seed;
-            randomizeSeed = config.tilemapChunkSettings.randomizeSeed;
+                decorMap = cfg.tilemapChunkSettings.decorMap;
+            bottomTerrain = cfg.tilemapChunkSettings.bottomTerrain;
+            middleTerrain = cfg.tilemapChunkSettings.middleTerrain;
+            topTerrain = cfg.tilemapChunkSettings.topTerrain;
+            minAreaWidth = cfg.tilemapChunkSettings.minAreaWidth;
+            edgeWaviness = cfg.tilemapChunkSettings.edgeWaviness;
+            sandDepthRange = cfg.tilemapChunkSettings.middleDepthRange;
+            grassDepthRange = cfg.tilemapChunkSettings.topDepthRange;
+            seed = cfg.tilemapChunkSettings.seed;
+            randomizeSeed = cfg.tilemapChunkSettings.randomizeSeed;
         }
 
         public void AssignTilemaps(ProceduralTaskGenerator generator)

--- a/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
+++ b/Assets/Scripts/Tasks/ProceduralTaskGenerator.cs
@@ -20,8 +20,6 @@ namespace TimelessEchoes.Tasks
     [RequireComponent(typeof(TaskController))]
     public class ProceduralTaskGenerator : MonoBehaviour
     {
-        [SerializeField]
-        private MapGenerationConfig config;
         [TabGroup("Settings", "Area")] [SerializeField]
         [HideInInspector]
         private float minX;
@@ -116,7 +114,7 @@ namespace TimelessEchoes.Tasks
         {
             if (controller == null)
                 controller = GetComponent<TaskController>();
-            ApplyConfig();
+            ApplyConfig(GameManager.CurrentGenerationConfig);
 
             var chunk = GetComponent<TilemapChunkGenerator>();
             chunk?.AssignTilemaps(this);
@@ -124,30 +122,29 @@ namespace TimelessEchoes.Tasks
             EnsureTilemaps();
         }
 
-        private void ApplyConfig()
+        private void ApplyConfig(MapGenerationConfig cfg)
         {
-            if (config == null) return;
-
-            minX = config.taskGeneratorSettings.minX;
-            height = config.taskGeneratorSettings.height;
-            enemyDensity = config.taskGeneratorSettings.enemyDensity;
-            topBuffer = config.taskGeneratorSettings.topBuffer;
-            bottomBuffer = config.taskGeneratorSettings.bottomBuffer;
-            blockingMask = config.taskGeneratorSettings.blockingMask;
-            otherTaskEdgeOffset = config.taskGeneratorSettings.otherTaskEdgeOffset;
-            enemies = config.taskGeneratorSettings.enemies;
+            if (cfg == null) return;
+            minX = cfg.taskGeneratorSettings.minX;
+            height = cfg.taskGeneratorSettings.height;
+            enemyDensity = cfg.taskGeneratorSettings.enemyDensity;
+            topBuffer = cfg.taskGeneratorSettings.topBuffer;
+            bottomBuffer = cfg.taskGeneratorSettings.bottomBuffer;
+            blockingMask = cfg.taskGeneratorSettings.blockingMask;
+            otherTaskEdgeOffset = cfg.taskGeneratorSettings.otherTaskEdgeOffset;
+            enemies = cfg.taskGeneratorSettings.enemies;
 
             taskCategories = new List<WeightedTaskCategory>
             {
-                config.taskGeneratorSettings.woodcutting,
-                config.taskGeneratorSettings.mining,
-                config.taskGeneratorSettings.farming,
-                config.taskGeneratorSettings.fishing,
-                config.taskGeneratorSettings.looting
+                cfg.taskGeneratorSettings.woodcutting,
+                cfg.taskGeneratorSettings.mining,
+                cfg.taskGeneratorSettings.farming,
+                cfg.taskGeneratorSettings.fishing,
+                cfg.taskGeneratorSettings.looting
             };
 
-            npcTasks = config.taskGeneratorSettings.npcTasks;
-            minTaskDistance = config.taskGeneratorSettings.minTaskDistance;
+            npcTasks = cfg.taskGeneratorSettings.npcTasks;
+            minTaskDistance = cfg.taskGeneratorSettings.minTaskDistance;
         }
 
         private void OnDrawGizmos()


### PR DESCRIPTION
## Summary
- add `CurrentGenerationConfig` static property in `GameManager`
- keep a list of map generation configs in `GameManager`
- set `CurrentGenerationConfig` before creating a map during run start
- make generation components use the static config instead of serialized fields

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68832ffdfa20832e8b9d8fce5a9f9841