### PR TITLE
Revamp wiki styling and enemy pages

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -6,7 +6,7 @@
     <title>Echoes of Vasteria</title>
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="homepage">
     <header>
         <h1>Echoes of Vasteria</h1>
     </header>
@@ -18,6 +18,10 @@
         <h2>Welcome to Echoes of Vasteria</h2>
         <p>Echoes of Vasteria is an incremental hero management game where your hero automatically ventures through procedurally generated maps. Collect gear, complete tasks and battle enemies as you progress.</p>
         <p>Play the game on Steam: <a href="https://store.steampowered.com/app/2940000" target="_blank" rel="noopener">Echoes of Vasteria on Steam</a></p>
+        <section id="changes">
+            <h2>Changes</h2>
+            <p>No recorded changes.</p>
+        </section>
     </main>
     <footer>
         &copy; 2024 Echoes of Vasteria

--- a/Website/style.css
+++ b/Website/style.css
@@ -1,17 +1,17 @@
 :root {
-  --bg-color: #c0cbdc;
+  --bg-color: #ffffff;
   --text-color: #181425;
-  --header-bg: #63c74d;
-  --nav-bg: #3e8948;
-  --accent-color: #0099db;
+  --header-bg: #c0cbdc;
+  --nav-bg: #8b9bb4;
+  --accent-color: #3a4466;
 }
 @media (prefers-color-scheme: dark) {
   :root {
     --bg-color: #181425;
     --text-color: #c0cbdc;
-    --header-bg: #124e89;
-    --nav-bg: #262b44;
-    --accent-color: #2ce8f5;
+    --header-bg: #265c42;
+    --nav-bg: #193c3e;
+    --accent-color: #63c74d;
   }
 }
 body {
@@ -20,6 +20,20 @@ body {
   padding: 0;
   background-color: var(--bg-color);
   color: var(--text-color);
+}
+
+body.homepage::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url('images/MainPage.png');
+  background-size: cover;
+  background-position: center;
+  opacity: 0.2;
+  z-index: -1;
 }
 header {
   background-color: var(--header-bg);
@@ -113,6 +127,28 @@ section {
 
 .enemy-nav a:hover {
   text-decoration: underline;
+}
+
+.enemy-image {
+  width: 150px;
+  image-rendering: pixelated;
+}
+
+.enemy-stats {
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+.enemy-stats th,
+.enemy-stats td {
+  border: 1px solid var(--nav-bg);
+  padding: 4px 8px;
+}
+
+.enemy-stats th {
+  background-color: var(--header-bg);
+  color: var(--text-color);
+  text-align: left;
 }
 footer {
   background-color: var(--header-bg);

--- a/Website/wiki/green.html
+++ b/Website/wiki/green.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Medium Green Slime</title>
+    <title>Green Slime</title>
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>
     <header>
-        <h1>Medium Green Slime</h1>
+        <h1>Green Slime</h1>
     </header>
     <nav>
         <a href="../index.html">Home</a>
@@ -25,13 +25,26 @@
         <h3>Slimes</h3>
         <ul>
             <li><a href="small.html">Small Green Slime</a></li>
-            <li><a href="medium.html">Medium Green Slime</a></li>
+            <li><a href="green.html">Green Slime</a></li>
             <li><a href="large.html">Large Green Slime</a></li>
         </ul>
     </aside>
     <main class="main-content">
         <p>A sturdier version of the green slime. It has moderate health and can take a few hits.</p>
-        <img src="../images/Slime_Medium_Green.png" alt="Medium Green Slime sprite" />
+        <img class="enemy-image" src="../images/Slime_Medium_Green.png" alt="Green Slime sprite" />
+        <table class="enemy-stats">
+            <tr><th>Experience</th><td>4</td></tr>
+            <tr><th>Max Health</th><td>25</td></tr>
+            <tr><th>Damage</th><td>2</td></tr>
+            <tr><th>Defense</th><td>0.5</td></tr>
+            <tr><th>Attack Speed</th><td>1.3</td></tr>
+            <tr><th>Attack Range</th><td>1</td></tr>
+            <tr><th>Move Speed</th><td>5</td></tr>
+            <tr><th>Vision Range</th><td>7</td></tr>
+            <tr><th>Assist Range</th><td>5</td></tr>
+            <tr><th>Wander Distance</th><td>3</td></tr>
+            <tr><th>Spawn Range X</th><td>150 - 500</td></tr>
+        </table>
         <div class="enemy-nav">
             <h2>Other Enemies</h2>
             <ul>
@@ -39,6 +52,10 @@
                 <li><a href="large.html">Large Green Slime</a></li>
             </ul>
         </div>
+        <section id="changes">
+            <h2>Changes</h2>
+            <p>No recorded changes.</p>
+        </section>
     </main>
     </div>
     <footer>

--- a/Website/wiki/index.html
+++ b/Website/wiki/index.html
@@ -25,7 +25,7 @@
         <h3>Slimes</h3>
         <ul>
             <li><a href="small.html">Small Green Slime</a></li>
-            <li><a href="medium.html">Medium Green Slime</a></li>
+            <li><a href="green.html">Green Slime</a></li>
             <li><a href="large.html">Large Green Slime</a></li>
         </ul>
     </aside>
@@ -42,6 +42,10 @@
             <h2>Other Information</h2>
             <p>Check back for more details on mechanics, gear upgrades, and strategies as the wiki expands.</p>
         </section>
+          <section id="changes">
+              <h2>Changes</h2>
+              <p>No recorded changes.</p>
+          </section>
     </main>
     </div>
     <footer>

--- a/Website/wiki/large.html
+++ b/Website/wiki/large.html
@@ -25,20 +25,37 @@
         <h3>Slimes</h3>
         <ul>
             <li><a href="small.html">Small Green Slime</a></li>
-            <li><a href="medium.html">Medium Green Slime</a></li>
+            <li><a href="green.html">Green Slime</a></li>
             <li><a href="large.html">Large Green Slime</a></li>
         </ul>
     </aside>
     <main class="main-content">
         <p>The largest of the green slimes. It is slow but can deal significant damage.</p>
-        <img src="../images/Slime_Big_Green.png" alt="Large Green Slime sprite" />
+        <img class="enemy-image" src="../images/Slime_Big_Green.png" alt="Large Green Slime sprite" />
+        <table class="enemy-stats">
+            <tr><th>Experience</th><td>15</td></tr>
+            <tr><th>Max Health</th><td>250</td></tr>
+            <tr><th>Damage</th><td>10</td></tr>
+            <tr><th>Defense</th><td>10</td></tr>
+            <tr><th>Attack Speed</th><td>1.3</td></tr>
+            <tr><th>Attack Range</th><td>1</td></tr>
+            <tr><th>Move Speed</th><td>5</td></tr>
+            <tr><th>Vision Range</th><td>7</td></tr>
+            <tr><th>Assist Range</th><td>5</td></tr>
+            <tr><th>Wander Distance</th><td>3</td></tr>
+            <tr><th>Spawn Range X</th><td>500+</td></tr>
+        </table>
         <div class="enemy-nav">
             <h2>Other Enemies</h2>
             <ul>
                 <li><a href="small.html">Small Green Slime</a></li>
-                <li><a href="medium.html">Medium Green Slime</a></li>
+                <li><a href="green.html">Green Slime</a></li>
             </ul>
         </div>
+        <section id="changes">
+            <h2>Changes</h2>
+            <p>No recorded changes.</p>
+        </section>
     </main>
     </div>
     <footer>

--- a/Website/wiki/small.html
+++ b/Website/wiki/small.html
@@ -25,20 +25,37 @@
         <h3>Slimes</h3>
         <ul>
             <li><a href="small.html">Small Green Slime</a></li>
-            <li><a href="medium.html">Medium Green Slime</a></li>
+            <li><a href="green.html">Green Slime</a></li>
             <li><a href="large.html">Large Green Slime</a></li>
         </ul>
     </aside>
     <main class="main-content">
         <p>The smallest variant of green slime. These weak creatures often appear in groups.</p>
-        <img src="../images/Slime_Small_Green.png" alt="Small Green Slime sprite" />
+        <img class="enemy-image" src="../images/Slime_Small_Green.png" alt="Small Green Slime sprite" />
+        <table class="enemy-stats">
+            <tr><th>Experience</th><td>1</td></tr>
+            <tr><th>Max Health</th><td>10</td></tr>
+            <tr><th>Damage</th><td>1</td></tr>
+            <tr><th>Defense</th><td>0</td></tr>
+            <tr><th>Attack Speed</th><td>1</td></tr>
+            <tr><th>Attack Range</th><td>1</td></tr>
+            <tr><th>Move Speed</th><td>3</td></tr>
+            <tr><th>Vision Range</th><td>7</td></tr>
+            <tr><th>Assist Range</th><td>5</td></tr>
+            <tr><th>Wander Distance</th><td>2</td></tr>
+            <tr><th>Spawn Range X</th><td>45 - 150</td></tr>
+        </table>
         <div class="enemy-nav">
             <h2>Other Enemies</h2>
             <ul>
-                <li><a href="medium.html">Medium Green Slime</a></li>
+                <li><a href="green.html">Green Slime</a></li>
                 <li><a href="large.html">Large Green Slime</a></li>
             </ul>
         </div>
+        <section id="changes">
+            <h2>Changes</h2>
+            <p>No recorded changes.</p>
+        </section>
     </main>
     </div>
     <footer>


### PR DESCRIPTION
## Summary
- apply Endesga-64 colours for light/dark themes
- add faded homepage background
- rename medium slime page to `green.html`
- add enemy stats tables and changes sections
- ensure enemy images scale consistently

## Testing
- `apt-get install -y imagemagick`


------
https://chatgpt.com/codex/tasks/task_e_6885cae87438832eae78589428968fda