### PR TITLE
Add wiki search and theme toggle

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -11,8 +11,24 @@
     --text-color: #c0cbdc;
     --header-bg: #265c42;
     --nav-bg: #193c3e;
-    --accent-color: #63c74d;
+  --accent-color: #63c74d;
   }
+}
+
+:root.light-mode {
+  --bg-color: #ffffff;
+  --text-color: #181425;
+  --header-bg: #c0cbdc;
+  --nav-bg: #8b9bb4;
+  --accent-color: #3a4466;
+}
+
+:root.dark-mode {
+  --bg-color: #181425;
+  --text-color: #c0cbdc;
+  --header-bg: #265c42;
+  --nav-bg: #193c3e;
+  --accent-color: #63c74d;
 }
 html,
 body {
@@ -52,7 +68,17 @@ header {
 nav {
   background-color: var(--nav-bg);
   padding: 10px;
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+nav .nav-left a {
+  margin-right: 10px;
+}
+nav .nav-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 nav a {
   color: var(--accent-color);
@@ -62,11 +88,14 @@ nav a {
 nav a:hover {
   color: #fee761;
 }
+nav input[type="search"] {
+  padding: 4px;
+}
 main {
   flex: 1;
   padding: 20px;
   max-width: 800px;
-  margin: auto;
+  margin: 0 auto;
 }
 
 section {
@@ -166,8 +195,15 @@ footer {
   padding: 10px;
 }
 @media (max-width: 600px) {
+  nav {
+    flex-direction: column;
+    align-items: flex-start;
+  }
   nav a {
     display: block;
     margin: 5px 0;
+  }
+  nav .nav-right {
+    margin-top: 10px;
   }
 }

--- a/Website/wiki/green.html
+++ b/Website/wiki/green.html
@@ -11,9 +11,22 @@
         <h1>Green Slime</h1>
     </header>
     <nav>
-        <a href="../index.html">Home</a>
-        <a href="index.html">Wiki Home</a>
+        <div class="nav-left">
+            <a href="../index.html">Home</a>
+            <a href="index.html">Wiki Home</a>
+        </div>
+        <div class="nav-right">
+            <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
+            <button id="light-btn">Light</button>
+            <button id="dark-btn">Dark</button>
+        </div>
     </nav>
+    <datalist id="search-options">
+        <option value="Wiki Home">
+        <option value="Small Green Slime">
+        <option value="Green Slime">
+        <option value="Large Green Slime">
+    </datalist>
     <div class="wiki-container">
     <aside class="sidebar">
         <h2>Navigation</h2>
@@ -61,5 +74,6 @@
     <footer>
         &copy; 2025 Echoes of Vasteria
     </footer>
+    <script src="wiki.js"></script>
 </body>
 </html>

--- a/Website/wiki/index.html
+++ b/Website/wiki/index.html
@@ -11,9 +11,22 @@
         <h1>Echoes of Vasteria Wiki</h1>
     </header>
     <nav>
-        <a href="../index.html">Home</a>
-        <a href="index.html">Wiki Home</a>
+        <div class="nav-left">
+            <a href="../index.html">Home</a>
+            <a href="index.html">Wiki Home</a>
+        </div>
+        <div class="nav-right">
+            <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
+            <button id="light-btn">Light</button>
+            <button id="dark-btn">Dark</button>
+        </div>
     </nav>
+    <datalist id="search-options">
+        <option value="Wiki Home">
+        <option value="Small Green Slime">
+        <option value="Green Slime">
+        <option value="Large Green Slime">
+    </datalist>
     <div class="wiki-container">
     <aside class="sidebar">
         <h2>Navigation</h2>
@@ -51,5 +64,6 @@
     <footer>
         &copy; 2025 Echoes of Vasteria
     </footer>
+    <script src="wiki.js"></script>
 </body>
 </html>

--- a/Website/wiki/large.html
+++ b/Website/wiki/large.html
@@ -11,9 +11,22 @@
         <h1>Large Green Slime</h1>
     </header>
     <nav>
-        <a href="../index.html">Home</a>
-        <a href="index.html">Wiki Home</a>
+        <div class="nav-left">
+            <a href="../index.html">Home</a>
+            <a href="index.html">Wiki Home</a>
+        </div>
+        <div class="nav-right">
+            <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
+            <button id="light-btn">Light</button>
+            <button id="dark-btn">Dark</button>
+        </div>
     </nav>
+    <datalist id="search-options">
+        <option value="Wiki Home">
+        <option value="Small Green Slime">
+        <option value="Green Slime">
+        <option value="Large Green Slime">
+    </datalist>
     <div class="wiki-container">
     <aside class="sidebar">
         <h2>Navigation</h2>
@@ -61,5 +74,6 @@
     <footer>
         &copy; 2025 Echoes of Vasteria
     </footer>
+    <script src="wiki.js"></script>
 </body>
 </html>

--- a/Website/wiki/small.html
+++ b/Website/wiki/small.html
@@ -11,9 +11,22 @@
         <h1>Small Green Slime</h1>
     </header>
     <nav>
-        <a href="../index.html">Home</a>
-        <a href="index.html">Wiki Home</a>
+        <div class="nav-left">
+            <a href="../index.html">Home</a>
+            <a href="index.html">Wiki Home</a>
+        </div>
+        <div class="nav-right">
+            <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
+            <button id="light-btn">Light</button>
+            <button id="dark-btn">Dark</button>
+        </div>
     </nav>
+    <datalist id="search-options">
+        <option value="Wiki Home">
+        <option value="Small Green Slime">
+        <option value="Green Slime">
+        <option value="Large Green Slime">
+    </datalist>
     <div class="wiki-container">
     <aside class="sidebar">
         <h2>Navigation</h2>
@@ -61,5 +74,6 @@
     <footer>
         &copy; 2025 Echoes of Vasteria
     </footer>
+    <script src="wiki.js"></script>
 </body>
 </html>

--- a/Website/wiki/wiki.js
+++ b/Website/wiki/wiki.js
@@ -1,0 +1,44 @@
+const pages = [
+  { title: 'Wiki Home', url: 'index.html' },
+  { title: 'Small Green Slime', url: 'small.html' },
+  { title: 'Green Slime', url: 'green.html' },
+  { title: 'Large Green Slime', url: 'large.html' }
+];
+
+function setTheme(theme) {
+  document.documentElement.classList.remove('light-mode', 'dark-mode');
+  if (theme) {
+    document.documentElement.classList.add(theme + '-mode');
+  }
+  localStorage.setItem('theme', theme);
+}
+
+function initTheme() {
+  const saved = localStorage.getItem('theme');
+  if (saved) {
+    setTheme(saved);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initTheme();
+  const lightBtn = document.getElementById('light-btn');
+  const darkBtn = document.getElementById('dark-btn');
+  const searchInput = document.getElementById('search-input');
+
+  if (lightBtn) {
+    lightBtn.addEventListener('click', () => setTheme('light'));
+  }
+  if (darkBtn) {
+    darkBtn.addEventListener('click', () => setTheme('dark'));
+  }
+  if (searchInput) {
+    searchInput.addEventListener('change', () => {
+      const query = searchInput.value.toLowerCase();
+      const page = pages.find(p => p.title.toLowerCase() === query);
+      if (page) {
+        window.location.href = page.url;
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- adjust layout to keep wiki content top aligned
- create dark/light mode CSS classes and responsive nav layout
- add dark/light mode toggle buttons and search bar to wiki pages
- implement search and theme toggle logic in `wiki.js`

## Testing
- `html5validator --root Website/wiki --show-warnings` *(fails: empty output due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6885d1fb61ec832ea8979581b8c3af22