### PR TITLE
Fix wiki layout and enemy image spacing

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -120,9 +120,7 @@ main > section:last-child {
   display: flex;
   gap: 20px;
   max-width: 1200px;
-  /* Align sidebar with the left edge of the viewport */
-  margin-left: 0;
-  margin-right: auto;
+  margin: auto;
   flex: 1;
 }
 
@@ -191,11 +189,12 @@ main > section:last-child {
   background-color: var(--header-bg);
   padding: 4px;
   border: 1px solid var(--nav-bg);
+  display: block;
 }
 
 .enemy-stats {
   border-collapse: collapse;
-  margin-top: 10px;
+  margin-top: 0;
 }
 
 .enemy-stats th,


### PR DESCRIPTION
## Summary
- center wiki container so content no longer sticks to the left
- remove gap between enemy images and stats tables

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885d9fa1b68832e89ff31cb0c3509ae