### PR TITLE
Fix double reaper spawn at max distance

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -63,6 +63,7 @@ namespace TimelessEchoes
         [SerializeField] public string mildredQuestId;
 
         public GameObject ReaperPrefab => reaperPrefab;
+        public GameObject GravestonePrefab => gravestonePrefab;
         public Vector3 ReaperSpawnOffset => reaperSpawnOffset;
         public Transform MeetingParent => meetingParent;
         public GameObject CurrentMap => currentMap;
@@ -362,8 +363,13 @@ namespace TimelessEchoes
         private void OnHeroDeath()
         {
             DestroyAllEchoes();
+            bool distanceReaper = false;
             if (hero != null)
             {
+                var controller = hero.GetComponent<Hero.HeroController>();
+                if (controller != null)
+                    distanceReaper = controller.ReaperSpawnedByDistance;
+
                 var hp = hero.GetComponent<HeroHealth>();
                 if (hp != null)
                     hp.OnDeath -= OnHeroDeath;
@@ -372,7 +378,7 @@ namespace TimelessEchoes
                 if (ai != null)
                     ai.enabled = false;
 
-                if (reaperPrefab != null && currentMap != null)
+                if (!distanceReaper && reaperPrefab != null && currentMap != null)
                 {
                     ReaperManager.Spawn(reaperPrefab, hero.gameObject, currentMap.transform, false,
                         () =>
@@ -383,7 +389,7 @@ namespace TimelessEchoes
                                     currentMap.transform);
                         }, reaperSpawnOffset);
                 }
-                else
+                else if (!distanceReaper)
                 {
                     hero.gameObject.SetActive(false);
                     if (gravestonePrefab != null && currentMap != null)

--- a/Assets/Scripts/Hero/HeroController.cs
+++ b/Assets/Scripts/Hero/HeroController.cs
@@ -109,6 +109,8 @@ namespace TimelessEchoes.Hero
 
         private bool reaperSpawnedByDistance;
 
+        public bool ReaperSpawnedByDistance => reaperSpawnedByDistance;
+
         private float damageBonus;
         private float defenseBonus;
 
@@ -262,7 +264,14 @@ namespace TimelessEchoes.Hero
                     var hp = health != null ? health : GetComponent<HeroHealth>();
                     if (gm != null && hp != null && hp.CurrentHealth > 0f && gm.ReaperPrefab != null && gm.CurrentMap != null)
                     {
-                        ReaperManager.Spawn(gm.ReaperPrefab, gameObject, gm.CurrentMap.transform, false, null, gm.ReaperSpawnOffset);
+                        ReaperManager.Spawn(gm.ReaperPrefab, gameObject, gm.CurrentMap.transform, false,
+                            () =>
+                            {
+                                gameObject.SetActive(false);
+                                if (gm.GravestonePrefab != null)
+                                    Instantiate(gm.GravestonePrefab, transform.position, Quaternion.identity,
+                                        gm.CurrentMap.transform);
+                            }, gm.ReaperSpawnOffset);
                         reaperSpawnedByDistance = true;
                     }
                 }


### PR DESCRIPTION
## Summary
- expose `GravestonePrefab` from `GameManager`
- mark when the hero was reaped for distance and check it in `OnHeroDeath`
- use the same gravestone callback when spawning the distance reaper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885dbaca5ec832ebc74a82fcbe209a2