### PR TITLE
Fix wiki layout with fixed sidebar

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -134,6 +134,21 @@ main > section:last-child {
   box-sizing: border-box;
 }
 
+/* Keep wiki navigation fixed on the left while
+   allowing the main content to remain centered */
+body.wiki-page {
+  padding-left: 240px; /* sidebar width + gap */
+}
+
+body.wiki-page .sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
 .sidebar h2,
 .sidebar h3 {
   margin-top: 0;

--- a/Website/wiki/green.html
+++ b/Website/wiki/green.html
@@ -6,7 +6,7 @@
     <title>Green Slime</title>
     <link rel="stylesheet" href="../style.css">
 </head>
-<body>
+<body class="wiki-page">
     <header>
         <h1>Green Slime</h1>
     </header>

--- a/Website/wiki/index.html
+++ b/Website/wiki/index.html
@@ -6,7 +6,7 @@
     <title>Echoes of Vasteria Wiki</title>
     <link rel="stylesheet" href="../style.css">
 </head>
-<body>
+<body class="wiki-page">
     <header>
         <h1>Echoes of Vasteria Wiki</h1>
     </header>

--- a/Website/wiki/large.html
+++ b/Website/wiki/large.html
@@ -6,7 +6,7 @@
     <title>Large Green Slime</title>
     <link rel="stylesheet" href="../style.css">
 </head>
-<body>
+<body class="wiki-page">
     <header>
         <h1>Large Green Slime</h1>
     </header>

--- a/Website/wiki/small.html
+++ b/Website/wiki/small.html
@@ -6,7 +6,7 @@
     <title>Small Green Slime</title>
     <link rel="stylesheet" href="../style.css">
 </head>
-<body>
+<body class="wiki-page">
     <header>
         <h1>Small Green Slime</h1>
     </header>


### PR DESCRIPTION
## Summary
- keep wiki sidebar fixed to the left side of the screen
- offset wiki pages so the content stays centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885dcc8a6f4832e89dd2ed6a88755c6