### PR TITLE
Add RuneScape-style enemy infobox

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -242,3 +242,54 @@ footer {
     margin-top: 10px;
   }
 }
+
+/* Monster infobox styling */
+.monster-infobox {
+  --border: var(--nav-bg);
+  --bg: var(--header-bg);
+  float: right;
+  margin: 0 0 20px 20px;
+  font: 14px/1.4 "Segoe UI", sans-serif;
+  color: var(--text-color);
+  max-width: 320px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.monster-infobox .monster-img {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: #000;
+}
+
+.monster-infobox .monster-stats {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.monster-infobox th,
+.monster-infobox td {
+  padding: 6px 8px;
+}
+
+.monster-infobox th {
+  width: 40%;
+  text-align: right;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.monster-infobox td {
+  text-align: left;
+}
+
+.monster-infobox .header-row th {
+  background: var(--nav-bg);
+  text-align: center;
+  font-weight: 700;
+  color: var(--text-color);
+}
+

--- a/Website/wiki/green.html
+++ b/Website/wiki/green.html
@@ -44,20 +44,24 @@
     </aside>
     <main class="main-content">
         <p>A sturdier version of the green slime. It has moderate health and can take a few hits.</p>
-        <img class="enemy-image" src="../images/Slime_Medium_Green.png" alt="Green Slime sprite" />
-        <table class="enemy-stats">
-            <tr><th>Experience</th><td>4</td></tr>
-            <tr><th>Max Health</th><td>25</td></tr>
-            <tr><th>Damage</th><td>2</td></tr>
-            <tr><th>Defense</th><td>0.5</td></tr>
-            <tr><th>Attack Speed</th><td>1.3</td></tr>
-            <tr><th>Attack Range</th><td>1</td></tr>
-            <tr><th>Move Speed</th><td>5</td></tr>
-            <tr><th>Vision Range</th><td>7</td></tr>
-            <tr><th>Assist Range</th><td>5</td></tr>
-            <tr><th>Wander Distance</th><td>3</td></tr>
-            <tr><th>Spawn Range X</th><td>150 - 500</td></tr>
-        </table>
+        <aside class="monster-infobox">
+            <img src="../images/Slime_Medium_Green.png" alt="Green Slime" class="monster-img" />
+            <table class="monster-stats">
+                <tbody>
+                <tr><th>Experience</th><td>4</td></tr>
+                <tr><th>Max Health</th><td>25</td></tr>
+                <tr><th>Damage</th><td>2</td></tr>
+                <tr><th>Defense</th><td>0.5</td></tr>
+                <tr><th>Attack Speed</th><td>1.3</td></tr>
+                <tr><th>Attack Range</th><td>1</td></tr>
+                <tr><th>Move Speed</th><td>5</td></tr>
+                <tr><th>Vision Range</th><td>7</td></tr>
+                <tr><th>Assist Range</th><td>5</td></tr>
+                <tr><th>Wander Distance</th><td>3</td></tr>
+                <tr><th>Spawn Range X</th><td>150 - 500</td></tr>
+                </tbody>
+            </table>
+        </aside>
         <div class="enemy-nav">
             <h2>Other Enemies</h2>
             <ul>

--- a/Website/wiki/large.html
+++ b/Website/wiki/large.html
@@ -44,20 +44,24 @@
     </aside>
     <main class="main-content">
         <p>The largest of the green slimes. It is slow but can deal significant damage.</p>
-        <img class="enemy-image" src="../images/Slime_Big_Green.png" alt="Large Green Slime sprite" />
-        <table class="enemy-stats">
-            <tr><th>Experience</th><td>15</td></tr>
-            <tr><th>Max Health</th><td>250</td></tr>
-            <tr><th>Damage</th><td>10</td></tr>
-            <tr><th>Defense</th><td>10</td></tr>
-            <tr><th>Attack Speed</th><td>1.3</td></tr>
-            <tr><th>Attack Range</th><td>1</td></tr>
-            <tr><th>Move Speed</th><td>5</td></tr>
-            <tr><th>Vision Range</th><td>7</td></tr>
-            <tr><th>Assist Range</th><td>5</td></tr>
-            <tr><th>Wander Distance</th><td>3</td></tr>
-            <tr><th>Spawn Range X</th><td>500+</td></tr>
-        </table>
+        <aside class="monster-infobox">
+            <img src="../images/Slime_Big_Green.png" alt="Large Green Slime" class="monster-img" />
+            <table class="monster-stats">
+                <tbody>
+                <tr><th>Experience</th><td>15</td></tr>
+                <tr><th>Max Health</th><td>250</td></tr>
+                <tr><th>Damage</th><td>10</td></tr>
+                <tr><th>Defense</th><td>10</td></tr>
+                <tr><th>Attack Speed</th><td>1.3</td></tr>
+                <tr><th>Attack Range</th><td>1</td></tr>
+                <tr><th>Move Speed</th><td>5</td></tr>
+                <tr><th>Vision Range</th><td>7</td></tr>
+                <tr><th>Assist Range</th><td>5</td></tr>
+                <tr><th>Wander Distance</th><td>3</td></tr>
+                <tr><th>Spawn Range X</th><td>500+</td></tr>
+                </tbody>
+            </table>
+        </aside>
         <div class="enemy-nav">
             <h2>Other Enemies</h2>
             <ul>

--- a/Website/wiki/small.html
+++ b/Website/wiki/small.html
@@ -44,20 +44,24 @@
     </aside>
     <main class="main-content">
         <p>The smallest variant of green slime. These weak creatures often appear in groups.</p>
-        <img class="enemy-image" src="../images/Slime_Small_Green.png" alt="Small Green Slime sprite" />
-        <table class="enemy-stats">
-            <tr><th>Experience</th><td>1</td></tr>
-            <tr><th>Max Health</th><td>10</td></tr>
-            <tr><th>Damage</th><td>1</td></tr>
-            <tr><th>Defense</th><td>0</td></tr>
-            <tr><th>Attack Speed</th><td>1</td></tr>
-            <tr><th>Attack Range</th><td>1</td></tr>
-            <tr><th>Move Speed</th><td>3</td></tr>
-            <tr><th>Vision Range</th><td>7</td></tr>
-            <tr><th>Assist Range</th><td>5</td></tr>
-            <tr><th>Wander Distance</th><td>2</td></tr>
-            <tr><th>Spawn Range X</th><td>45 - 150</td></tr>
-        </table>
+        <aside class="monster-infobox">
+            <img src="../images/Slime_Small_Green.png" alt="Small Green Slime" class="monster-img" />
+            <table class="monster-stats">
+                <tbody>
+                <tr><th>Experience</th><td>1</td></tr>
+                <tr><th>Max Health</th><td>10</td></tr>
+                <tr><th>Damage</th><td>1</td></tr>
+                <tr><th>Defense</th><td>0</td></tr>
+                <tr><th>Attack Speed</th><td>1</td></tr>
+                <tr><th>Attack Range</th><td>1</td></tr>
+                <tr><th>Move Speed</th><td>3</td></tr>
+                <tr><th>Vision Range</th><td>7</td></tr>
+                <tr><th>Assist Range</th><td>5</td></tr>
+                <tr><th>Wander Distance</th><td>2</td></tr>
+                <tr><th>Spawn Range X</th><td>45 - 150</td></tr>
+                </tbody>
+            </table>
+        </aside>
         <div class="enemy-nav">
             <h2>Other Enemies</h2>
             <ul>


### PR DESCRIPTION
## Summary
- style enemy infobox with green background, image on top and stats below
- update slime pages to use the new infobox layout

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6885dfa83fb8832e89bfa06ebbe139d7