### PR TITLE
Fix missing UI group

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -42,6 +42,7 @@ namespace TimelessEchoes
         [TitleGroup("Prefabs")]
         [SerializeField] private Vector3 reaperSpawnOffset = Vector3.zero;
 
+        [TitleGroup("UI")]
         [TitleGroup("UI/General")]
         [SerializeField] private Button returnToTavernButton;
         [TitleGroup("UI/General")]


### PR DESCRIPTION
## Summary
- fix Odin group error by defining the root UI group before sub-groups

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885e06e59e0832e98ebd6e0f86bca8d