### PR TITLE
Enhance wiki layout with grid and crisp sprites

### DIFF
--- a/Website/wiki/green.html
+++ b/Website/wiki/green.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Green Slime</title>
     <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="wiki.css">
 </head>
 <body class="wiki-page">
     <header>
@@ -44,9 +45,9 @@
     </aside>
     <main class="main-content">
         <p>A sturdier version of the green slime. It has moderate health and can take a few hits.</p>
-        <aside class="monster-infobox">
-            <img src="../images/Slime_Medium_Green.png" alt="Green Slime" class="monster-img" />
-            <table class="monster-stats">
+        <aside class="monster-infobox infobox">
+            <img src="../images/Slime_Medium_Green.png" alt="Green Slime" class="monster-img pixel-art" />
+            <table class="monster-stats stats">
                 <tbody>
                 <tr><th>Experience</th><td>4</td></tr>
                 <tr><th>Max Health</th><td>25</td></tr>

--- a/Website/wiki/index.html
+++ b/Website/wiki/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Echoes of Vasteria Wiki</title>
     <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="wiki.css">
 </head>
 <body class="wiki-page">
     <header>

--- a/Website/wiki/large.html
+++ b/Website/wiki/large.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Large Green Slime</title>
     <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="wiki.css">
 </head>
 <body class="wiki-page">
     <header>
@@ -44,9 +45,9 @@
     </aside>
     <main class="main-content">
         <p>The largest of the green slimes. It is slow but can deal significant damage.</p>
-        <aside class="monster-infobox">
-            <img src="../images/Slime_Big_Green.png" alt="Large Green Slime" class="monster-img" />
-            <table class="monster-stats">
+        <aside class="monster-infobox infobox">
+            <img src="../images/Slime_Big_Green.png" alt="Large Green Slime" class="monster-img pixel-art" />
+            <table class="monster-stats stats">
                 <tbody>
                 <tr><th>Experience</th><td>15</td></tr>
                 <tr><th>Max Health</th><td>250</td></tr>

--- a/Website/wiki/small.html
+++ b/Website/wiki/small.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Small Green Slime</title>
     <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="wiki.css">
 </head>
 <body class="wiki-page">
     <header>
@@ -44,9 +45,9 @@
     </aside>
     <main class="main-content">
         <p>The smallest variant of green slime. These weak creatures often appear in groups.</p>
-        <aside class="monster-infobox">
-            <img src="../images/Slime_Small_Green.png" alt="Small Green Slime" class="monster-img" />
-            <table class="monster-stats">
+        <aside class="monster-infobox infobox">
+            <img src="../images/Slime_Small_Green.png" alt="Small Green Slime" class="monster-img pixel-art" />
+            <table class="monster-stats stats">
                 <tbody>
                 <tr><th>Experience</th><td>1</td></tr>
                 <tr><th>Max Health</th><td>10</td></tr>

--- a/Website/wiki/wiki.css
+++ b/Website/wiki/wiki.css
@@ -1,0 +1,26 @@
+/* ---------------------------------------------------------- */
+/*  WIKI IMPROVEMENTS                                         */
+/* ---------------------------------------------------------- */
+
+body.wiki-page{margin:0;min-height:100vh;display:grid;
+     grid-template-columns:220px 1fr;
+     grid-template-rows:auto 1fr auto;
+     grid-template-areas:"header header"
+                         "nav    main"
+                         "footer footer";}
+
+body.wiki-page header{grid-area:header;}
+body.wiki-page nav{grid-area:nav;background:#083b3b;color:#e6fff2;padding:1.2rem 1rem;
+       position:sticky;top:0;}
+body.wiki-page main{grid-area:main;margin:0 auto;max-width:60rem;}
+body.wiki-page footer{grid-area:footer;}
+
+.pixel-art{image-rendering:pixelated;image-rendering:crisp-edges;max-width:100%;}
+.infobox{float:right;width:180px;margin:0 1rem 1rem 2rem;}
+h2{clear:right;}
+
+.stats{width:100%;border-collapse:collapse;}
+.stats th,.stats td{padding:2px 6px;white-space:nowrap;font-weight:400;}
+.stats th::after{content:" |";color:#c0d1c0;}
+.stats td{text-align:right;}
+/* ---------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- add wiki.css with new grid-based layout, crisp pixel-art images and stat table styling
- include wiki.css in all wiki pages
- mark infobox images with `pixel-art` class and tables with `stats`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885e310a920832e91850fa0616883bf