### PR TITLE
Fix wiki layout navigation

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -68,6 +68,28 @@ header {
 header h1 {
   margin: 0;
 }
+
+header .top-nav {
+  background-color: var(--nav-bg);
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+header .top-nav .nav-left a {
+  margin-right: 10px;
+}
+
+header .top-nav .nav-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+header .top-nav input[type="search"] {
+  padding: 4px;
+}
 nav {
   background-color: var(--nav-bg);
   padding: 10px;

--- a/Website/wiki/green.html
+++ b/Website/wiki/green.html
@@ -9,27 +9,20 @@
 </head>
 <body class="wiki-page">
     <header>
+        <div class="top-nav">
+            <div class="nav-left">
+                <a href="../index.html">Home</a>
+                <a href="index.html">Wiki Home</a>
+            </div>
+            <div class="nav-right">
+                <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
+                <button id="light-btn">Light</button>
+                <button id="dark-btn">Dark</button>
+            </div>
+        </div>
         <h1>Green Slime</h1>
     </header>
-    <nav>
-        <div class="nav-left">
-            <a href="../index.html">Home</a>
-            <a href="index.html">Wiki Home</a>
-        </div>
-        <div class="nav-right">
-            <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
-            <button id="light-btn">Light</button>
-            <button id="dark-btn">Dark</button>
-        </div>
-    </nav>
-    <datalist id="search-options">
-        <option value="Wiki Home">
-        <option value="Small Green Slime">
-        <option value="Green Slime">
-        <option value="Large Green Slime">
-    </datalist>
-    <div class="wiki-container">
-    <aside class="sidebar">
+    <nav class="sidebar">
         <h2>Navigation</h2>
         <ul>
             <li><a href="index.html">Wiki Home</a></li>
@@ -42,7 +35,14 @@
             <li><a href="green.html">Green Slime</a></li>
             <li><a href="large.html">Large Green Slime</a></li>
         </ul>
-    </aside>
+    </nav>
+    <datalist id="search-options">
+        <option value="Wiki Home">
+        <option value="Small Green Slime">
+        <option value="Green Slime">
+        <option value="Large Green Slime">
+    </datalist>
+    <div class="wiki-container">
     <main class="main-content">
         <p>A sturdier version of the green slime. It has moderate health and can take a few hits.</p>
         <aside class="monster-infobox infobox">

--- a/Website/wiki/index.html
+++ b/Website/wiki/index.html
@@ -9,27 +9,20 @@
 </head>
 <body class="wiki-page">
     <header>
+        <div class="top-nav">
+            <div class="nav-left">
+                <a href="../index.html">Home</a>
+                <a href="index.html">Wiki Home</a>
+            </div>
+            <div class="nav-right">
+                <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
+                <button id="light-btn">Light</button>
+                <button id="dark-btn">Dark</button>
+            </div>
+        </div>
         <h1>Echoes of Vasteria Wiki</h1>
     </header>
-    <nav>
-        <div class="nav-left">
-            <a href="../index.html">Home</a>
-            <a href="index.html">Wiki Home</a>
-        </div>
-        <div class="nav-right">
-            <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
-            <button id="light-btn">Light</button>
-            <button id="dark-btn">Dark</button>
-        </div>
-    </nav>
-    <datalist id="search-options">
-        <option value="Wiki Home">
-        <option value="Small Green Slime">
-        <option value="Green Slime">
-        <option value="Large Green Slime">
-    </datalist>
-    <div class="wiki-container">
-    <aside class="sidebar">
+    <nav class="sidebar">
         <h2>Navigation</h2>
         <ul>
             <li><a href="index.html">Wiki Home</a></li>
@@ -42,7 +35,14 @@
             <li><a href="green.html">Green Slime</a></li>
             <li><a href="large.html">Large Green Slime</a></li>
         </ul>
-    </aside>
+    </nav>
+    <datalist id="search-options">
+        <option value="Wiki Home">
+        <option value="Small Green Slime">
+        <option value="Green Slime">
+        <option value="Large Green Slime">
+    </datalist>
+    <div class="wiki-container">
     <main class="main-content">
         <section id="tasks">
             <h2>Tasks</h2>

--- a/Website/wiki/large.html
+++ b/Website/wiki/large.html
@@ -9,27 +9,20 @@
 </head>
 <body class="wiki-page">
     <header>
+        <div class="top-nav">
+            <div class="nav-left">
+                <a href="../index.html">Home</a>
+                <a href="index.html">Wiki Home</a>
+            </div>
+            <div class="nav-right">
+                <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
+                <button id="light-btn">Light</button>
+                <button id="dark-btn">Dark</button>
+            </div>
+        </div>
         <h1>Large Green Slime</h1>
     </header>
-    <nav>
-        <div class="nav-left">
-            <a href="../index.html">Home</a>
-            <a href="index.html">Wiki Home</a>
-        </div>
-        <div class="nav-right">
-            <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
-            <button id="light-btn">Light</button>
-            <button id="dark-btn">Dark</button>
-        </div>
-    </nav>
-    <datalist id="search-options">
-        <option value="Wiki Home">
-        <option value="Small Green Slime">
-        <option value="Green Slime">
-        <option value="Large Green Slime">
-    </datalist>
-    <div class="wiki-container">
-    <aside class="sidebar">
+    <nav class="sidebar">
         <h2>Navigation</h2>
         <ul>
             <li><a href="index.html">Wiki Home</a></li>
@@ -42,7 +35,14 @@
             <li><a href="green.html">Green Slime</a></li>
             <li><a href="large.html">Large Green Slime</a></li>
         </ul>
-    </aside>
+    </nav>
+    <datalist id="search-options">
+        <option value="Wiki Home">
+        <option value="Small Green Slime">
+        <option value="Green Slime">
+        <option value="Large Green Slime">
+    </datalist>
+    <div class="wiki-container">
     <main class="main-content">
         <p>The largest of the green slimes. It is slow but can deal significant damage.</p>
         <aside class="monster-infobox infobox">

--- a/Website/wiki/small.html
+++ b/Website/wiki/small.html
@@ -9,27 +9,20 @@
 </head>
 <body class="wiki-page">
     <header>
+        <div class="top-nav">
+            <div class="nav-left">
+                <a href="../index.html">Home</a>
+                <a href="index.html">Wiki Home</a>
+            </div>
+            <div class="nav-right">
+                <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
+                <button id="light-btn">Light</button>
+                <button id="dark-btn">Dark</button>
+            </div>
+        </div>
         <h1>Small Green Slime</h1>
     </header>
-    <nav>
-        <div class="nav-left">
-            <a href="../index.html">Home</a>
-            <a href="index.html">Wiki Home</a>
-        </div>
-        <div class="nav-right">
-            <input type="search" id="search-input" list="search-options" placeholder="Search wiki...">
-            <button id="light-btn">Light</button>
-            <button id="dark-btn">Dark</button>
-        </div>
-    </nav>
-    <datalist id="search-options">
-        <option value="Wiki Home">
-        <option value="Small Green Slime">
-        <option value="Green Slime">
-        <option value="Large Green Slime">
-    </datalist>
-    <div class="wiki-container">
-    <aside class="sidebar">
+    <nav class="sidebar">
         <h2>Navigation</h2>
         <ul>
             <li><a href="index.html">Wiki Home</a></li>
@@ -42,7 +35,14 @@
             <li><a href="green.html">Green Slime</a></li>
             <li><a href="large.html">Large Green Slime</a></li>
         </ul>
-    </aside>
+    </nav>
+    <datalist id="search-options">
+        <option value="Wiki Home">
+        <option value="Small Green Slime">
+        <option value="Green Slime">
+        <option value="Large Green Slime">
+    </datalist>
+    <div class="wiki-container">
     <main class="main-content">
         <p>The smallest variant of green slime. These weak creatures often appear in groups.</p>
         <aside class="monster-infobox infobox">

--- a/Website/wiki/wiki.css
+++ b/Website/wiki/wiki.css
@@ -10,8 +10,8 @@ body.wiki-page{margin:0;min-height:100vh;display:grid;
                          "footer footer";}
 
 body.wiki-page header{grid-area:header;}
-body.wiki-page nav{grid-area:nav;background:#083b3b;color:#e6fff2;padding:1.2rem 1rem;
-       position:sticky;top:0;}
+body.wiki-page nav.sidebar{grid-area:nav;background:#083b3b;color:#e6fff2;padding:1.2rem 1rem;
+       position:sticky;top:0;display:block;}
 body.wiki-page main{grid-area:main;margin:0 auto;max-width:60rem;}
 body.wiki-page footer{grid-area:footer;}
 


### PR DESCRIPTION
## Summary
- move wiki navigation links (Home, Wiki Home, search and theme buttons) back into page header
- place the sidebar navigation where the old top bar used to be
- style new top navigation bar
- adjust wiki navigation css rules

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885e590630c832e8ea753fb519865cb