### PR TITLE
Add ManualTaskProgress script

### DIFF
--- a/Assets/Scripts/Tasks/ManualTaskProgress.cs
+++ b/Assets/Scripts/Tasks/ManualTaskProgress.cs
@@ -1,0 +1,67 @@
+using TimelessEchoes.Hero;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace TimelessEchoes.Tasks
+{
+    /// <summary>
+    /// Allows the player to click and hold on a task to manually advance
+    /// its progress.
+    /// </summary>
+    public class ManualTaskProgress : MonoBehaviour,
+        IPointerDownHandler, IPointerUpHandler, IPointerExitHandler
+    {
+        [SerializeField] private MonoBehaviour taskObject;
+
+        private ITask task;
+        private bool held;
+        private bool arrived;
+
+        private void Awake()
+        {
+            if (taskObject == null)
+                taskObject = GetComponent<MonoBehaviour>();
+            task = taskObject as ITask ?? taskObject?.GetComponent<ITask>();
+        }
+
+        private void OnDisable()
+        {
+            held = false;
+            arrived = false;
+        }
+
+        private void Update()
+        {
+            if (!held || task == null)
+                return;
+
+            var hero = HeroController.Instance ?? FindFirstObjectByType<HeroController>();
+            if (hero == null)
+                return;
+
+            if (!arrived)
+            {
+                task.OnArrival(hero);
+                arrived = true;
+            }
+
+            task.Tick(hero);
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            held = true;
+            arrived = false;
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            held = false;
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            held = false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ManualTaskProgress` to allow holding on a task UI element to advance the task

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885e3e4d6dc832eb08a0f44338588ff